### PR TITLE
set_time_limit()  causes a warning on shared hosting

### DIFF
--- a/public_html/admin/modules.app/run_job.inc.php
+++ b/public_html/admin/modules.app/run_job.inc.php
@@ -1,5 +1,5 @@
 <?php
-  set_time_limit(60*5);
+  @set_time_limit(60*5);
   ob_end_clean();
 
   $jobs = new mod_jobs();


### PR DESCRIPTION
set_time_limit() has been disabled for security reasons
mostly on shared hosting