### PR TITLE
fix for 'Array--m--#' links in manufacturer pages

### DIFF
--- a/public_html/includes/routes/url_product.inc.php
+++ b/public_html/includes/routes/url_product.inc.php
@@ -37,10 +37,10 @@
 
       } else if (!empty($link->query['manufacturer_id'])) {
 
-        $manufacturer = reference::manufacturer($link->query['manufacturer_id']);
+        $manufacturer = reference::manufacturer($link->query['manufacturer_id'], $language_code);
 
         if (!empty($manufacturer->id)) {
-          $new_path .= functions::catalog_category_trail($manufacturer->name, $language_code) .'-m-'. $manufacturer->id .'/';
+          $new_path .= functions::general_path_friendly($manufacturer->name, $language_code) .'-m-'. $manufacturer->id .'/';
         }
 
         $link->path = $new_path;


### PR DESCRIPTION
product links on manufacturer pages would show as 'Array--m--#' and a Notice would also appear: Array to String

The url conditional was using some code bits from category url routines.
As well, the ref fetching call did not pass the language code, per all the other similar calls in this file.  Added to follow suit.