### PR TITLE
inconsistent product categories save

### DIFF
--- a/public_html/includes/entities/ent_product.inc.php
+++ b/public_html/includes/entities/ent_product.inc.php
@@ -249,8 +249,8 @@
     // Categories
       database::query(
         "delete from " . DB_TABLE_PRODUCTS_TO_CATEGORIES . "
-        where product_id = ". (int)$this->data['id'] ."
-        and category_id not in ('". implode(", ", database::input($this->data['categories'])) ."');"
+        where product_id = '". (int)$this->data['id'] ."'
+        and category_id not in ('". @implode("', '", database::input($this->data['categories'])) ."');"
       );
 
       foreach ($this->data['categories'] as $category_id) {


### PR DESCRIPTION
product categories would not consistently save via admin 'edit product' app - only primary category would stay set, and could only 'add' cats, not remove from product without problems.  Follows convention of other similar checks to suppress error with implode.