### PR TITLE
`date_login` can be NULL

### DIFF
--- a/public_html/install/structure.sql
+++ b/public_html/install/structure.sql
@@ -173,7 +173,7 @@ CREATE TABLE `lc_customers` (
   `last_ip` VARCHAR(39) NOT NULL,
   `last_host` VARCHAR(128) NOT NULL,
   `last_agent` VARCHAR(256) NOT NULL,
-  `date_login` DATETIME NOT NULL,
+  `date_login` DATETIME NULL,
   `date_updated` DATETIME NOT NULL,
   `date_created` DATETIME NOT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
"NOT NULL" for `date_login` is too strict. 
Importing customers from another/accounting/CRM system and so on... = problem.