### PR TITLE
Fixed quantity step validator caption

### DIFF
--- a/public_html/includes/library/lib_cart.inc.php
+++ b/public_html/includes/library/lib_cart.inc.php
@@ -214,7 +214,7 @@
         }
 
         if ($product->quantity_step > 0 && ($quantity % $product->quantity_step) != 0) {
-          throw new Exception(strtr(language::translate('error_can_only_purchase_sets_for_item', 'You can only purchase sets by %num for this item'), ['%num' => (float)$product->quantity_max]));
+          throw new Exception(strtr(language::translate('error_can_only_purchase_sets_for_item', 'You can only purchase sets by %num for this item'), ['%num' => (float)$product->quantity_step]));
         }
 
         //if (($product->quantity - $quantity) < 0 && empty($product->sold_out_status['orderable'])) {


### PR DESCRIPTION
Fixed quantity step validator caption. When adding to cart an item with a defined quantity step, but the added quantity is not a multiple of that step, an error popup appeared with validator caption saying "You can only purchase sets by %num for this item", but the number was erroneously showing maximum allowed purchase quantity. Now it's the step.