### PR TITLE
Fix issue where email multipart header is incomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,13 @@ ehthumbs.db
 Thumbs.db
 error_log
 .ftpquota
+
+######################
+# VisualStudio Files #
+######################
+.vs/
+
+######################
+# Vim Files          #
+######################
+*.sw[op]

--- a/public_html/includes/entities/ent_email.inc.php
+++ b/public_html/includes/entities/ent_email.inc.php
@@ -319,6 +319,9 @@
       if (empty($body)) {
         trigger_error('Cannot send email with an empty body', E_USER_WARNING);
         return false;
+      } else {
+        // end multipart with expected boundary
+        $body .= '--'. $multipart_boundary_string . "--"
       }
 
     // Deliver via SMTP


### PR DESCRIPTION
Whenever the `[Error Report]` or `[Not Found Report]` emails run I get an additional email from my self hosted mail server (dovecot/postfix):
```
Bad header:
  MIME error: error: part did not end with expected boundary; ; error:
    unexpected end of parts before epilogue
Content type: BadHdrMime
Internal reference code for the message is 1038650-01/2ZhVJIbzk1Da

First upstream SMTP client IP address: [127.0.0.1] 
```

Essentially the multipart boundary declared in the `Content-Type: multipart/mixed; boundary` header is missing at the end of the body's content:
```
Content-Type: multipart/mixed; boundary="==Multipart_Boundary_xxxxxx
```

This change inserts an appropriate ending using the declared multipart boundary if the body is not empty.