### PR TITLE
Show total product option price when = is selected

### DIFF
--- a/public_html/includes/references/ref_product.inc.php
+++ b/public_html/includes/references/ref_product.inc.php
@@ -322,9 +322,9 @@
 
                   case '=':
                     if ((float)$value[$this->_currency_code] != 0) {
-                      $value['price_adjust'] = currency::convert($value[$this->_currency_code], $this->_currency_code, settings::get('store_currency_code')) - $this->price;
+                      $value['price_adjust'] = currency::convert($value[$this->_currency_code], $this->_currency_code, settings::get('store_currency_code'));
                     } else {
-                      $value['price_adjust'] = $value[settings::get('store_currency_code')] - $this->price;
+                      $value['price_adjust'] = $value[settings::get('store_currency_code')];
                     }
                     break;
 


### PR DESCRIPTION
When setting product options with various prices, and the `=` sign is selected, show the total price of the product having that option rather than the difference between it and the base price. If someone prefers to show the difference they can select `+` or `-`.