### PR TITLE
add attribute_groups to display them in settings pages

### DIFF
--- a/public_html/includes/functions/func_form.inc.php
+++ b/public_html/includes/functions/func_form.inc.php
@@ -566,6 +566,8 @@
 
     switch ($matches[1]) {
 
+      case 'attribute_groups':
+        return form_draw_attribute_groups_list($name, $input, true, $parameters);
       case 'date':
         return form_draw_date_field($name, $input, $parameters);
 


### PR DESCRIPTION
I have a module for which I'd like to disable certain options (`attribute_group`).

I need these lines of code so I can add them to the payment module's settings.