### PR TITLE
Allow trailing slash on Contact Us URL

### DIFF
--- a/public_html/includes/routes/url_customer_service.inc.php
+++ b/public_html/includes/routes/url_customer_service.inc.php
@@ -11,7 +11,7 @@
 
       return [
         [
-          'pattern' => '#^('. implode('|', array_filter($titles)) .')$#',
+          'pattern' => '#^('. implode('|', array_filter($titles)) .')/?$#',
           'page' => 'customer_service',
           'params' => '',
           'options' => [


### PR DESCRIPTION
All pages except the Customer Services contact page allowed an optional trailing slash on the URLs. Two chars in the route regex seems to make it consistent.