### PR TITLE
Implement module hook system for extensibility

### DIFF
--- a/public_html/includes/app_header.inc.php
+++ b/public_html/includes/app_header.inc.php
@@ -44,3 +44,12 @@
   stats::$data['before_content'] = microtime(true) - SCRIPT_TIMESTAMP_START;
 
   stats::start_watch('content_capture');
+
+  $modules_hooks_dirs = glob(FS_DIR_APP . 'includes/modules/*/hooks', GLOB_ONLYDIR);
+
+  foreach ($modules_hooks_dirs as $hook_dir) {
+    foreach (glob($hook_dir . '/*.php') as $hook_file) {
+      require_once vmod::check($hook_file);
+    }
+  }
+

--- a/public_html/includes/library/lib_hook.inc.php
+++ b/public_html/includes/library/lib_hook.inc.php
@@ -1,0 +1,71 @@
+<?php
+
+class Hooks {
+
+  private static array $actions = [];
+  private static array $filters = [];
+
+  // Add an action callback
+  public static function add_action(string $hook, callable $callback, int $priority = 10): void {
+    self::$actions[$hook][$priority][] = $callback;
+  }
+
+  // Run all action callbacks
+  public static function do_action(string $hook, ...$args): void {
+    if (empty(self::$actions[$hook])) return;
+
+    ksort(self::$actions[$hook]);
+    foreach (self::$actions[$hook] as $priority => $callbacks) {
+      foreach ($callbacks as $callback) {
+        call_user_func_array($callback, $args);
+      }
+    }
+  }
+
+  // Add a filter callback
+  public static function add_filter(string $hook, callable $callback, int $priority = 10): void {
+    self::$filters[$hook][$priority][] = $callback;
+  }
+
+  // Apply all filters to a value
+  public static function apply_filters(string $hook, mixed $value, ...$args): mixed {
+    if (empty(self::$filters[$hook])) return $value;
+
+    ksort(self::$filters[$hook]);
+    foreach (self::$filters[$hook] as $priority => $callbacks) {
+      foreach ($callbacks as $callback) {
+        $value = call_user_func_array($callback, array_merge([$value], $args));
+      }
+    }
+    return $value;
+  }
+
+  // Remove a specific action
+  public static function remove_action(string $hook, callable $callback, int $priority = 10): void {
+    self::remove_callback(self::$actions, $hook, $callback, $priority);
+  }
+
+  // Remove a specific filter
+  public static function remove_filter(string $hook, callable $callback, int $priority = 10): void {
+    self::remove_callback(self::$filters, $hook, $callback, $priority);
+  }
+
+  // Utility to remove callback from action/filter array
+  private static function remove_callback(array &$store, string $hook, callable $callback, int $priority): void {
+    if (!isset($store[$hook][$priority])) return;
+
+    foreach ($store[$hook][$priority] as $i => $existing_callback) {
+      if ($existing_callback === $callback) {
+        unset($store[$hook][$priority][$i]);
+      }
+    }
+
+    // Clean up if empty
+    if (empty($store[$hook][$priority])) {
+      unset($store[$hook][$priority]);
+    }
+    if (empty($store[$hook])) {
+      unset($store[$hook]);
+    }
+  }
+}

--- a/public_html/includes/modules/hook-test/hooks/hook-test.php
+++ b/public_html/includes/modules/hook-test/hooks/hook-test.php
@@ -1,0 +1,6 @@
+<?php
+
+
+Hooks::add_action('render_head', function() {
+  echo '<meta name="custom-hook" content="LiteCart Custom Head">';
+});

--- a/public_html/includes/modules/hook-test/hooks/hook-test.php
+++ b/public_html/includes/modules/hook-test/hooks/hook-test.php
@@ -1,6 +1,0 @@
-<?php
-
-
-Hooks::add_action('render_head', function() {
-  echo '<meta name="custom-hook" content="LiteCart Custom Head">';
-});

--- a/public_html/includes/templates/default.catalog/layouts/default.inc.php
+++ b/public_html/includes/templates/default.catalog/layouts/default.inc.php
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="<?php echo document::href_rlink(FS_DIR_TEMPLATE . 'css/app.min.css'); ?>">
 {snippet:head_tags}
 {snippet:style}
+<?php Hooks::do_action('render_header'); ?>
 </head>
 <body>
 
@@ -44,5 +45,6 @@
 {snippet:foot_tags}
 <script src="<?php echo document::href_rlink(FS_DIR_TEMPLATE . 'js/app.min.js'); ?>"></script>
 {snippet:javascript}
+<?php Hooks::do_action('render_footer'); ?>
 </body>
 </html>


### PR DESCRIPTION
Modules can use the `Hooks` class to extend or modify LiteCart functionality without changing core files.

To add a hook in your module:

1. Create a hook file in your module:

`modules/your_module/hooks/my_hook.php`

2. Add your custom logic using `Hooks::add_action()` or `Hooks::add_filter():`

```Hooks::add_action('before_render_head', function() {
  echo '<meta name="my-hook" content="custom">';
});

Hooks::add_filter('product_price_display', function($price) {
  return $price * 0.9; // Apply 10% discount
});
```


3. Ensure hook files are autoloaded by scanning all:
`modules/*/hooks/*.php`