### PR TITLE
Update structure.sql

### DIFF
--- a/public_html/install/structure.sql
+++ b/public_html/install/structure.sql
@@ -663,7 +663,7 @@ CREATE TABLE `lc_products_prices` (
   `USD` FLOAT(11,4) NOT NULL DEFAULT '0',
   `EUR` FLOAT(11,4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `product_id` (`product_id`)
+  UNIQUE KEY `uniq_product_id` (`product_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET={DB_DATABASE_CHARSET} COLLATE {DB_DATABASE_COLLATION};
 -- -----
 CREATE TABLE `lc_products_to_categories` (


### PR DESCRIPTION
After doing an update to all my lc_products_xxx tables, I ended up with multiple copies of the products showing in the cart with the exact same information, including the product_id.

There was only a single entry for each item in lc_products, lc_products_info, and lc_lc_products_to_categories.  However, it turned out that there were multiple prices for the same `product_id` in lc_products_prices.

Changing the product_id key to be unique should prevent that problem from happening.