### PR TITLE
Add unique key for product_id and filename

### DIFF
--- a/public_html/install/structure.sql
+++ b/public_html/install/structure.sql
@@ -585,6 +585,7 @@ CREATE TABLE `lc_products_images` (
   `checksum` VARCHAR(32) NULL,
   `priority` INT(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_product_id_filename` (`product_id`,`filename`),
   KEY `product_id` (`product_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET={DB_DATABASE_CHARSET} COLLATE {DB_DATABASE_COLLATION};
 -- -----


### PR DESCRIPTION
I had a similar problem to my previous lc_products_prices pull request.

Currently, it's possible to upload the same image multiple times via SQL, which causes LC to display that image multiple times on the product pages as "extra images".

Creating a unique compound key based on product_id and filename will prevent that from happening:

ALTER TABLE `lc_products_images`
ADD CONSTRAINT uq_product_id_filename UNIQUE (`product_id`, `filename`);