### PR TITLE
* Fix header warning when accessing install.php after installation

### DIFF
--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -39,12 +39,13 @@
     }
 
   } else {
-    require __DIR__ . '/includes/header.inc.php';
-  }
 
-  if (empty($_REQUEST['install'])) {
-    header('Location: index.php');
-    exit;
+    if (empty($_REQUEST['install'])) {
+      header('Location: index.php');
+      exit;
+    }
+
+    require __DIR__ . '/includes/header.inc.php';
   }
 
   ob_start();


### PR DESCRIPTION
## Summary

Fixes a PHP warning when accessing `install.php` after the installation is complete:

```
Warning: Cannot modify header information - headers already sent
(output started at includes/header.inc.php:1)
in install/install.php on line 46
```

## Cause

When `install.php` is accessed without the `install` POST parameter, it redirects to `index.php` via `header('Location: ...')`. However, the HTML header template (`includes/header.inc.php`) is included *before* the redirect check, so output has already been sent when `header()` is called.

## Fix

Move the redirect check (`if (empty($_REQUEST['install']))`) before the `require header.inc.php` include, so the `Location` header is sent before any HTML output.

## Test Plan

- [ ] Access `install.php` directly after installation — should redirect cleanly to `index.php` without warnings
- [ ] Run the installer normally — installation process works unchanged
- [ ] CLI installation (`php install.php --install ...`) still works