### PR TITLE
Fix three security quick wins (2FA PRNG, display_errors, Permissions-Policy)

### DIFF
--- a/public_html/backend/pages/login.inc.php
+++ b/public_html/backend/pages/login.inc.php
@@ -188,7 +188,7 @@
 					if (!empty($administrator['two_factor_auth']) && !empty($administrator['email'])) {
 
 						session::$data['security_verification'] = [
-							'code' => mt_rand(100000, 999999),
+							'code' => random_int(100000, 999999),
 							'expires' => strtotime('+15 minutes'),
 							'attempts' => 0,
 						];

--- a/public_html/includes/nodes/nod_administrator.inc.php
+++ b/public_html/includes/nodes/nod_administrator.inc.php
@@ -97,7 +97,7 @@
 					die('Your account is disabled');
 				}
 
-				ini_set('display_errors', 'On');
+				//ini_set('display_errors', 'On'); // Disabled: exposes SQL queries, paths and stack traces
 
 				database::query(
 					"update ". DB_TABLE_PREFIX ."administrators

--- a/public_html/includes/nodes/nod_document.inc.php
+++ b/public_html/includes/nodes/nod_document.inc.php
@@ -51,7 +51,7 @@
 				'report-uri '. self::ilink('f:csp_report'),
 			]));
 
-			header('Permissions-Policy: ', implode(',', [
+			header('Permissions-Policy: ' . implode(',', [
 					'camera=()',
 					'clipboard-read=()',
 					'clipboard-write=()',


### PR DESCRIPTION
> You asked an autist to have a peek. Now you're getting pull requests. You were warned. 😉

## Summary

Three low-effort, high-impact security fixes identified during a code audit of `dev-major`:

- **`mt_rand()` → `random_int()` for 2FA codes** (`login.inc.php:191`)
  `mt_rand()` uses the Mersenne Twister PRNG, whose internal state can be reconstructed after observing a few outputs (e.g. via CAPTCHA values generated in the same process). `random_int()` uses the OS CSPRNG and is not predictable.

- **Disable `display_errors` for authenticated administrators** (`nod_administrator.inc.php:100`)
  With `display_errors = On`, any PHP error leaks full SQL queries, file paths, and stack traces in the HTTP response — even in production. If an admin session is compromised (or via XSS), this hands an attacker a complete map of the internals.

- **Fix `Permissions-Policy` header bug** (`nod_document.inc.php:54`)
  `header('Permissions-Policy: ', implode(...))` passes `implode()` as the boolean `replace` parameter of `header()` instead of concatenating it into the header value. The header is never actually sent. One-character fix: `, ` → `. `.

More incoming. 🐾

## Test plan

- [ ] Verify 2FA code is still generated and delivered correctly
- [ ] Verify admin backend still works without `display_errors`
- [ ] Verify `Permissions-Policy` header is present in HTTP response