### PR TITLE
Fix 5 stock items integration bugs (closes #398)

### DIFF
--- a/public_html/frontend/pages/shopping_cart.inc.php
+++ b/public_html/frontend/pages/shopping_cart.inc.php
@@ -183,7 +183,6 @@
 
 		if ($cheapest_shipping) {
 			$_page->snippets['cheapest_shipping'] = $cheapest_shipping;
-			var_dump($_page->snippets['cheapest_shipping']);
 		}
 	}
 

--- a/public_html/includes/entities/ent_order.inc.php
+++ b/public_html/includes/entities/ent_order.inc.php
@@ -290,7 +290,7 @@
 					discount_tax = ". (float)$this->data['discount_tax'] .",
 					total = ". (float)$this->data['total'] .",
 					total_tax = ". (float)$this->data['total_tax'] .",
-					notes = '". database::input($this->data['ip_address']) ."',
+					notes = '". database::input($this->data['notes']) ."',
 					conversions = '". database::input(f::format_json($this->data['conversions'])) ."',
 					ip_address = '". database::input($this->data['ip_address']) ."',
 					hostname = '". database::input($this->data['hostname']) ."',
@@ -311,13 +311,6 @@
 					if (empty($previous_order_item['product_id'])) continue;
 					$this->adjust_stock_quantity($previous_order_item['product_id'], $previous_order_item['option_stock_combination'], (float)$previous_order_item['quantity']);
 				}
-
-				database::query(
-					"update ". DB_TABLE_PREFIX ."products
-					set quantity = quantity + ". (float)$previous_order_item['quantity'] ."
-					where product_id = ". (int)$previous_order_item['product_id'] ."
-					limit 1;"
-				);
 			}
 
 			// Delete order lines

--- a/public_html/includes/entities/ent_stock_item.inc.php
+++ b/public_html/includes/entities/ent_stock_item.inc.php
@@ -220,7 +220,7 @@
 					$products_query = database::query(
 						"select id from ". DB_TABLE_PREFIX ."products
 						where id in (
-							select product_id from ". DB_TABLE_PREFIX ."products_to_stock_items
+							select product_id from ". DB_TABLE_PREFIX ."products_stock_options
 							where stock_item_id = ". (int)$this->data['id'] ."
 						);"
 					);

--- a/public_html/includes/nodes/nod_cart.inc.php
+++ b/public_html/includes/nodes/nod_cart.inc.php
@@ -238,7 +238,7 @@
 				foreach ($product->stock_options as $option) {
 					if ($option['id'] == $stock_option_id) {
 						$item['stock_items'][] = [
-							'stock_item_id' => $option['id'],
+							'stock_item_id' => $option['stock_item_id'],
 							'name' => $option['name'],
 							'quantity' => 1,
 						];


### PR DESCRIPTION
## Summary

Five bugs in the stock items integration that cause cart, checkout, and product breakage on `dev-major`:

- **Non-existent table reference** (`ent_stock_item.inc.php:223`): `products_to_stock_items` → `products_stock_options`
- **Wrong ID in cart** (`nod_cart.inc.php:241`): Stored `stock_option.id` (PSO primary key) instead of `stock_option.stock_item_id` — wrong reference propagated to orders
- **Notes/IP swap** (`ent_order.inc.php:293`): `notes` field was populated with `ip_address` value
- **Orphaned restock query** (`ent_order.inc.php:315-320`): Query outside the foreach loop targeted wrong table (`products` instead of `stock_items`) with wrong column (`product_id` instead of `id`). Cross-checked with `dev` branch — [v2 only has the foreach loop](https://github.com/litecart/litecart/blob/dev/public_html/includes/entities/ent_order.inc.php#L291-L297), no extra query. This was introduced during the v3 refactor.
- **Debug var_dump** (`shopping_cart.inc.php:186`): Left in production code

## Test plan

- [ ] Add product with stock options to cart — verify correct `stock_item_id` is stored
- [ ] Complete checkout — verify order notes contain actual notes, not IP address
- [ ] Change order status with `stock_action = 'commit'` — verify stock is restocked correctly
- [ ] Verify no `var_dump` output on shopping cart page