### PR TITLE
Replace mt_rand/str_shuffle with CSPRNG in security-critical locations

### DIFF
--- a/public_html/frontend/pages/account/reset_password.inc.php
+++ b/public_html/frontend/pages/account/reset_password.inc.php
@@ -76,7 +76,7 @@
 			if (empty($_REQUEST['reset_token'])) {
 
 				$reset_token = [
-					'token' => substr(str_shuffle(str_repeat('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', 10)), 0, 8),
+					'token' => bin2hex(random_bytes(24)),
 					'expires' => date('Y-m-d H:i:s', strtotime('+15 minutes')),
 				];
 

--- a/public_html/includes/entities/ent_order.inc.php
+++ b/public_html/includes/entities/ent_order.inc.php
@@ -204,7 +204,7 @@
 			}
 
 			if (!$this->data['public_key']) {
-				$this->data['public_key'] = substr(str_shuffle(str_repeat('0123456789abcdefghijklmnopqrstuvwxyz', mt_rand(5, 10))), 0, 32);
+				$this->data['public_key'] = bin2hex(random_bytes(16));
 			}
 
 			if (!$this->data['date_dispatched']) {

--- a/public_html/includes/functions/func_captcha.inc.php
+++ b/public_html/includes/functions/func_captcha.inc.php
@@ -27,7 +27,7 @@
 
 		$code = '';
 		for ($i=0; $i<$config['length']; $i++) {
-			$code .= substr($possible, mt_rand(0, strlen($possible) -1), 1);
+			$code .= substr($possible, random_int(0, strlen($possible) -1), 1);
 		}
 
 		if (!$image = imagecreate($config['width'], $config['height'])) {


### PR DESCRIPTION
## Summary

Replaces all remaining `mt_rand()` / `str_shuffle()` calls in security-critical code paths with cryptographically secure alternatives. Companion to #397 which already fixed the 2FA code generation.

**Why this matters:** Mersenne Twister (`mt_rand`) is a deterministic PRNG whose internal state can be reconstructed after observing a few outputs. CAPTCHA values generated via `mt_rand()` are observable — an attacker who solves a few CAPTCHAs can predict future reset tokens and order keys generated in the same process.

### Changes

| Location | Before | After |
|---|---|---|
| CAPTCHA generation (`func_captcha.inc.php:30`) | `mt_rand(0, strlen-1)` | `random_int(0, strlen-1)` |
| Password reset token (`reset_password.inc.php:79`) | `str_shuffle()` → 8 alphanumeric chars (~47 bit) | `bin2hex(random_bytes(24))` → 48 hex chars (192 bit) |
| Order public_key (`ent_order.inc.php:207`) | `str_shuffle()` + `mt_rand()` → 32 chars | `bin2hex(random_bytes(16))` → 32 hex chars (128 bit) |

**Note on reset token length:** Changed from 8 to 48 characters. The token is stored as JSON in `password_reset_token VARCHAR(128)` — total JSON payload is 92 bytes, well within the column limit.

## Test plan

- [ ] Generate CAPTCHA — verify it still renders correctly
- [ ] Request password reset — verify token is received and works
- [ ] Create order — verify `public_key` is generated and order is accessible via public link