### PR TITLE
Replace all mt_rand/str_shuffle with CSPRNG

### DIFF
--- a/public_html/frontend/pages/account/reset_password.inc.php
+++ b/public_html/frontend/pages/account/reset_password.inc.php
@@ -76,7 +76,7 @@
 			if (empty($_REQUEST['reset_token'])) {
 
 				$reset_token = [
-					'token' => substr(str_shuffle(str_repeat('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789', 10)), 0, 8),
+					'token' => bin2hex(random_bytes(24)),
 					'expires' => date('Y-m-d H:i:s', strtotime('+15 minutes')),
 				];
 

--- a/public_html/includes/entities/ent_order.inc.php
+++ b/public_html/includes/entities/ent_order.inc.php
@@ -204,7 +204,7 @@
 			}
 
 			if (!$this->data['public_key']) {
-				$this->data['public_key'] = substr(str_shuffle(str_repeat('0123456789abcdefghijklmnopqrstuvwxyz', mt_rand(5, 10))), 0, 32);
+				$this->data['public_key'] = bin2hex(random_bytes(16));
 			}
 
 			if (!$this->data['date_dispatched']) {

--- a/public_html/includes/functions/func_captcha.inc.php
+++ b/public_html/includes/functions/func_captcha.inc.php
@@ -27,7 +27,7 @@
 
 		$code = '';
 		for ($i=0; $i<$config['length']; $i++) {
-			$code .= substr($possible, mt_rand(0, strlen($possible) -1), 1);
+			$code .= substr($possible, random_int(0, strlen($possible) -1), 1);
 		}
 
 		if (!$image = imagecreate($config['width'], $config['height'])) {

--- a/public_html/includes/functions/func_password.inc.php
+++ b/public_html/includes/functions/func_password.inc.php
@@ -7,23 +7,40 @@
 		$numbers = '0123456789';
 		$specials = '!#%&/(){}[]+-';
 
+		// Pick $count random characters from $charset using CSPRNG
+		$pick = function($charset, $count) {
+			$result = '';
+			$max = strlen($charset) - 1;
+			for ($i = 0; $i < $count; $i++) {
+				$result .= $charset[random_int(0, $max)];
+			}
+			return $result;
+		};
+
 		$absolutes = '';
-		if ($min_lowercases && !is_bool($min_lowercases)) $absolutes .= substr(str_shuffle(str_repeat($lowercases, $min_lowercases)), 0, $min_lowercases);
-		if ($min_uppercases && !is_bool($min_uppercases)) $absolutes .= substr(str_shuffle(str_repeat($uppercases, $min_uppercases)), 0, $min_uppercases);
-		if ($min_numbers && !is_bool($min_numbers)) $absolutes .= substr(str_shuffle(str_repeat($numbers, $min_numbers)), 0, $min_numbers);
-		if ($min_specials && !is_bool($min_specials)) $absolutes .= substr(str_shuffle(str_repeat($specials, $min_specials)), 0, $min_specials);
+		if ($min_lowercases && !is_bool($min_lowercases)) $absolutes .= $pick($lowercases, $min_lowercases);
+		if ($min_uppercases && !is_bool($min_uppercases)) $absolutes .= $pick($uppercases, $min_uppercases);
+		if ($min_numbers && !is_bool($min_numbers)) $absolutes .= $pick($numbers, $min_numbers);
+		if ($min_specials && !is_bool($min_specials)) $absolutes .= $pick($specials, $min_specials);
 
 		$remaining = $length - strlen($absolutes);
 
-		$characters = '';
-		if ($min_lowercases !== false) $characters .= substr(str_shuffle(str_repeat($lowercases, $remaining)), 0, $remaining);
-		if ($min_uppercases !== false) $characters .= substr(str_shuffle(str_repeat($uppercases, $remaining)), 0, $remaining);
-		if ($min_numbers !== false) $characters .= substr(str_shuffle(str_repeat($numbers, $remaining)), 0, $remaining);
-		if ($min_specials !== false) $characters .= substr(str_shuffle(str_repeat($specials, $remaining)), 0, $remaining);
+		$pool = '';
+		if ($min_lowercases !== false) $pool .= $lowercases;
+		if ($min_uppercases !== false) $pool .= $uppercases;
+		if ($min_numbers !== false) $pool .= $numbers;
+		if ($min_specials !== false) $pool .= $specials;
 
-		$password = str_shuffle($absolutes . substr($characters, 0, $remaining));
+		$password = $absolutes . $pick($pool, $remaining);
 
-		return $password;
+		// Fisher-Yates shuffle with CSPRNG
+		$chars = str_split($password);
+		for ($i = count($chars) - 1; $i > 0; $i--) {
+			$j = random_int(0, $i);
+			[$chars[$i], $chars[$j]] = [$chars[$j], $chars[$i]];
+		}
+
+		return implode('', $chars);
 	}
 
 	function password_check_strength($password) {


### PR DESCRIPTION
Follow-up to #397 as promised. Eliminates all remaining security-critical `mt_rand`/`str_shuffle` usage.

## Changes

| Location | Before | After |
|---|---|---|
| CAPTCHA code (`func_captcha.inc.php:30`) | `mt_rand(0, strlen-1)` | `random_int(0, strlen-1)` |
| Password reset token (`reset_password.inc.php:79`) | `str_shuffle()` → 8 alphanumeric chars | `bin2hex(random_bytes(24))` → 48 hex chars (192 bit) |
| Order public_key (`ent_order.inc.php:207`) | `str_shuffle()` + `mt_rand()` | `bin2hex(random_bytes(16))` → 32 hex chars (128 bit) |
| Password generation (`func_password.inc.php`) | 8× `str_shuffle()` | CSPRNG-based character picker + Fisher-Yates shuffle with `random_int()` |

**Note on reset token length:** Changed from 8 to 48 characters. Stored as JSON in `password_reset_token VARCHAR(128)` — total payload is 92 bytes, within the column limit.

**Cosmetic `mt_rand` calls left as-is:** CAPTCHA noise dots/lines (`func_captcha.inc.php:44,49`) use `mt_rand` for visual decoration only — not security-critical.

## Test plan

- [ ] Generate CAPTCHA — verify it still renders correctly
- [ ] Request password reset — verify token is received and works
- [ ] Create order — verify `public_key` is generated and accessible
- [ ] Generate password (e.g. admin password reset) — verify output meets requirements