### PR TITLE
Fix CLI installer: move CLI detection before DOCUMENT_ROOT check

### DIFF
--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -4,6 +4,18 @@
 	mb_internal_encoding('UTF-8');
 	mb_http_output('UTF-8');
 
+	// CLI detection (polyfill from compatibility.inc.php, needed before DOCUMENT_ROOT check)
+	if (!isset($_SERVER['REQUEST_METHOD'])) {
+		$_SERVER['SERVER_SOFTWARE'] = 'CLI';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+		$_REQUEST = getopt('', [
+			'db_server::', 'db_username:', 'db_password::', 'db_database:', 'db_table_prefix::', 'db_collation::',
+			'document_root:', 'timezone::', 'admin_folder::', 'username::', 'password::', 'development_type::', 'cleanup::',
+		]);
+		$_REQUEST['install'] = true;
+	}
+
 	if (!empty($_SERVER['DOCUMENT_ROOT'])) {
 		define('DOCUMENT_ROOT', rtrim(str_replace('\\', '/', realpath($_SERVER['DOCUMENT_ROOT'])), '/') . '/');
 
@@ -69,12 +81,7 @@
 			exit;
 		}
 
-		$_REQUEST = getopt('', [
-			'db_server::', 'db_username:', 'db_password::', 'db_database:', 'db_table_prefix::', 'db_collation::',
-			'document_root:', 'timezone::', 'admin_folder::', 'username::', 'password::', 'development_type:: cleanup::',
-		]);
-
-		$_REQUEST['install'] = true;
+		// getopt() and $_REQUEST['install'] already set in CLI detection block above
 	}
 
 	if (empty($_REQUEST['install'])) {


### PR DESCRIPTION
Turns out telling the installer who it is *before* asking it where it lives makes a difference.

## Problem

`install.php` checks `$_REQUEST['document_root']` at line 10, but `getopt()` only populates `$_REQUEST` at line 84. In CLI mode, `$_REQUEST` is empty at that point, so the DOCUMENT_ROOT detection always fails. Similarly, `$_SERVER['SERVER_SOFTWARE']` isn't set in PHP CLI — the polyfill from `compatibility.inc.php` is loaded too late (line 37).

## Fix

Moves CLI detection to the top of `install.php`:
- Sets `$_SERVER['SERVER_SOFTWARE'] = 'CLI'` and other polyfills
- Runs `getopt()` to populate `$_REQUEST` with CLI arguments
- Removes the now-duplicate `getopt()` block at the original location

This enables automated installation via:
```bash
php install.php --document_root="/var/www/html" --db_server="localhost" --db_username="user" --db_password="pass" --db_database="litecart"
```

Useful for CI/CD pipelines and automated deployments. As discussed in #401.

## Test plan

- [ ] `php install.php --help` still shows usage info
- [ ] `php install.php --document_root=... --db_server=...` completes installation
- [ ] Web-based installation still works (browser)