### PR TITLE
+ Add MCP stats_summary tool, fix ENUM schema builder and syntax errors

### DIFF
--- a/public_html/backend/mcp/mcp_stats_summary.inc.php
+++ b/public_html/backend/mcp/mcp_stats_summary.inc.php
@@ -1,0 +1,112 @@
+<?php
+
+	return $schema = [
+		'name' => 'stats_summary',
+		'description' => 'Returns shop statistics: sales totals (month/year/all-time), order counts, averages, top 5 products by quantity, and customer/product/category counts. All monetary values in the store\'s base currency.',
+		'inputSchema' => [
+			'type' => 'object',
+			'properties' => [
+				'period' => [
+					'type' => 'string',
+					'description' => 'Filter period: "month", "year", or "all" (default: "all")',
+					'enum' => ['month', 'year', 'all'],
+				],
+			],
+			'required' => [],
+		],
+	];
+
+	function mcp_stats_summary($params) {
+
+		$period = $params['period'] ?? 'all';
+		$currency_code = settings::get('store_currency_code');
+
+		// Get order statuses that count as a sale
+		$order_statuses = database::query(
+			"select id from ". DB_TABLE_PREFIX ."order_statuses where is_sale;"
+		)->fetch_all('id');
+
+		if (empty($order_statuses)) {
+			return [
+				'period' => $period,
+				'currency' => $currency_code,
+				'message' => 'No sale order statuses configured',
+			];
+		}
+
+		$status_list = "'" . implode("', '", $order_statuses) . "'";
+
+		$stats = [
+			'period' => $period,
+			'currency' => $currency_code,
+		];
+
+		// Period filter
+		$date_filter = '';
+		switch ($period) {
+			case 'month':
+				$date_filter = "and created_at >= '" . date('Y-m-d H:i:s', mktime(0, 0, 0, date('m'), 1, date('Y'))) . "'";
+				break;
+			case 'year':
+				$date_filter = "and created_at >= '" . date('Y-m-d H:i:s', mktime(0, 0, 0, 1, 1, date('Y'))) . "'";
+				break;
+		}
+
+		// Sales summary
+		$orders = database::query(
+			"select count(id) as num_orders,
+				sum(total - total_tax) as total_sales,
+				sum(total_tax) as total_tax,
+				max(total) as max_order_amount,
+				min(total) as min_order_amount
+			from ". DB_TABLE_PREFIX ."orders
+			where order_status_id in (". $status_list .")
+			". $date_filter .";"
+		)->fetch();
+
+		$stats['sales'] = [
+			'total' => round((float)$orders['total_sales'], 2),
+			'tax' => round((float)$orders['total_tax'], 2),
+			'orders' => (int)$orders['num_orders'],
+			'average_order' => $orders['num_orders'] > 0 ? round($orders['total_sales'] / $orders['num_orders'], 2) : 0,
+			'max_order' => round((float)$orders['max_order_amount'], 2),
+			'min_order' => round((float)$orders['min_order_amount'], 2),
+		];
+
+		// Top products (by quantity sold)
+		$top_products = database::query(
+			"select oi.product_id, oi.name, sum(oi.quantity) as total_quantity, sum(oi.price * oi.quantity) as total_revenue
+			from ". DB_TABLE_PREFIX ."orders_items oi
+			left join ". DB_TABLE_PREFIX ."orders o on (o.id = oi.order_id)
+			where o.order_status_id in (". $status_list .")
+			". str_replace('created_at', 'o.created_at', $date_filter) ."
+			group by oi.product_id, oi.name
+			order by total_quantity desc
+			limit 5;"
+		)->fetch_all();
+
+		$stats['top_products'] = [];
+		foreach ($top_products as $product) {
+			$stats['top_products'][] = [
+				'id' => (int)$product['product_id'],
+				'name' => $product['name'],
+				'quantity_sold' => (int)$product['total_quantity'],
+				'revenue' => round((float)$product['total_revenue'], 2),
+			];
+		}
+
+		// Counts
+		$stats['counts'] = [
+			'customers' => (int)database::query(
+				"select count(id) as n from ". DB_TABLE_PREFIX ."customers;"
+			)->fetch('n'),
+			'products' => (int)database::query(
+				"select count(id) as n from ". DB_TABLE_PREFIX ."products where status;"
+			)->fetch('n'),
+			'categories' => (int)database::query(
+				"select count(id) as n from ". DB_TABLE_PREFIX ."categories where status;"
+			)->fetch('n'),
+		];
+
+		return $stats;
+	}

--- a/public_html/frontend/pages/product.inc.php
+++ b/public_html/frontend/pages/product.inc.php
@@ -388,7 +388,6 @@
 	} else {
 		$_page->snippets['stock_status'] = settings::get('display_stock_count') ? f::format_number($product->quantity_available) : t('title_in_stock', 'In Stock');
 	}
-f::format_number
 	// Cheapest shipping
 	if (settings::get('display_cheapest_shipping')) {
 

--- a/public_html/includes/functions/func_catalog.inc.php
+++ b/public_html/includes/functions/func_catalog.inc.php
@@ -202,13 +202,13 @@
 		if (!empty($filter['attributes']) && is_array($filter['attributes'])) {
 		$sql_where_attributes = [];
 			foreach ($filter['attributes'] as $group_id => $values) {
-				$sql_where_attributes[] = (
+				$sql_where_attributes[] =
 					"p.id in (
 						select distinct product_id from ". DB_TABLE_PREFIX ."products_attributes
 						where (group_id = ". (int)$group_id ." and (value_id in ('". implode("', '", database::input($values)) ."') or custom_value in ('". implode("', '", database::input($values)) ."')))
 					)";
 			}
-			$sql_inner_where['attributes'] = implode(PHP . "and ", $sql_where_attributes);
+			$sql_inner_where['attributes'] = implode(PHP_EOL . "and ", $sql_where_attributes);
 		}
 
 		if (!empty($filter['products'])) {

--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -531,7 +531,7 @@
 
 				$sql .= '  `' . $column_name . '` ' . $column['type'];
 
-				if (isset($column['length'])) {
+				if (isset($column['length']) && strpos($column['type'], '(') === false) {
 					$sql .= '(' . $column['length'] . ')';
 				}
 

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -511,7 +511,7 @@
 				"locale": { "type": "VARCHAR", "length": 64, "default": "''" },
 				"locale_intl": { "type": "VARCHAR", "length": 16, "default": "''" },
 				"mysql_collation": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"url_type": { "type": "ENUM('','none','root','path','domain')", "length": 16, "default": "''" },
+				"url_type": { "type": "ENUM('','none','root','path','domain')", "default": "''" },
 				"domain_name": { "type": "VARCHAR", "length": 64, "default": "''" },
 				"raw_date": { "type": "VARCHAR", "length": 32, "default": "''" },
 				"raw_time": { "type": "VARCHAR", "length": 32, "default": "''" },

--- a/public_html/install/upgrade.php
+++ b/public_html/install/upgrade.php
@@ -633,7 +633,7 @@
 						$sql .= '  `'. database::input($column_name) .'` '. database::input($column['type']);
 					}
 
-					if (isset($column['length'])) {
+					if (isset($column['length']) && strpos($column['type'], '(') === false) {
 						$sql .= '('. $column['length'] .')';
 					}
 


### PR DESCRIPTION
First tool beyond `ping` for the MCP server. Because a ping that returns `[]` is a bit lonely.

## What it does

A `stats_summary` tool that returns shop statistics via JSON-RPC — the same data the dashboard widget shows, but machine-readable for AI assistants.

**Parameters:**

| Name | Type | Required | Description |
|------|------|----------|-------------|
| `period` | string | No | `"month"`, `"year"`, or `"all"` (default) |

**Returns:**

| Field | Content |
|-------|---------|
| `sales` | Net total, tax, order count, average/min/max order amount |
| `top_products` | Top 5 by quantity sold (with revenue) |
| `counts` | Active customers, products, categories |

Follows the existing `mcp_ping` pattern — single file, schema + function, auto-discovered by the dispatcher. Lives in `backend/mcp/` (admin-only, requires authentication).

## Bonus fixes (pre-existing issues caught by CI)

| File | Issue |
|------|-------|
| `func_catalog.inc.php` | Stray parenthesis + `PHP` → `PHP_EOL` typo |
| `product.inc.php` | Orphaned `f::format_number` line |
| `install.php` + `upgrade.php` | Double parentheses on ENUM columns (`ENUM(...)(16)`) — added `strpos` guard |
| `structure.json` | Removed stray `length: 16` from `url_type` ENUM definition |

## Test plan

- [ ] `tools/list` includes `stats_summary` with correct schema
- [ ] `tools/call` with `{"name": "stats_summary"}` returns valid stats
- [ ] `tools/call` with `{"name": "stats_summary", "arguments": {"period": "month"}}` filters correctly
- [ ] Unauthenticated request returns 401
- [ ] PHP lint passes on all files
- [ ] Schema import succeeds without ENUM double-parentheses error