### PR TITLE
* Harden MCP server security and add search tools

### DIFF
--- a/public_html/backend/mcp/mcp_orders_list.inc.php
+++ b/public_html/backend/mcp/mcp_orders_list.inc.php
@@ -1,0 +1,92 @@
+<?php
+
+	return $schema = [
+		'name' => 'orders_list',
+		'description' => 'List recent orders with status, customer, total, and date. Supports filtering by status, customer, and date range.',
+		'inputSchema' => [
+			'type' => 'object',
+			'properties' => [
+				'order_status_id' => [
+					'type' => 'integer',
+					'description' => 'Filter by order status ID',
+				],
+				'customer_id' => [
+					'type' => 'integer',
+					'description' => 'Filter by customer ID',
+				],
+				'date_from' => [
+					'type' => 'string',
+					'description' => 'Filter orders created on or after this date (YYYY-MM-DD)',
+				],
+				'date_to' => [
+					'type' => 'string',
+					'description' => 'Filter orders created on or before this date (YYYY-MM-DD)',
+				],
+				'limit' => [
+					'type' => 'integer',
+					'description' => 'Max results (default: 10, max: 50)',
+				],
+			],
+			'required' => [],
+		],
+	];
+
+	function mcp_orders_list($params) {
+
+		$conditions = [];
+
+		if (isset($params['order_status_id'])) {
+			$conditions[] = "o.order_status_id = ". (int)$params['order_status_id'];
+		}
+
+		if (isset($params['customer_id'])) {
+			$conditions[] = "o.customer_id = ". (int)$params['customer_id'];
+		}
+
+		if (!empty($params['date_from'])) {
+			$conditions[] = "o.created_at >= '". database::input($params['date_from']) ." 00:00:00'";
+		}
+
+		if (!empty($params['date_to'])) {
+			$conditions[] = "o.created_at <= '". database::input($params['date_to']) ." 23:59:59'";
+		}
+
+		$limit = min((int)($params['limit'] ?? 10), 50);
+		if ($limit < 1) $limit = 10;
+
+		$sql_where = $conditions ? 'where ' . implode(' and ', $conditions) : '';
+
+		$orders = database::query(
+			"select o.id, o.customer_id, o.customer_firstname, o.customer_lastname, o.customer_email,
+				o.total, o.total_tax, o.currency_code, o.order_status_id, os.name as order_status,
+				o.created_at
+			from ". DB_TABLE_PREFIX ."orders o
+			left join ". DB_TABLE_PREFIX ."order_statuses_info os on (os.order_status_id = o.order_status_id and os.language_code = '". database::input(language::$selected['code']) ."')
+			". $sql_where ."
+			order by o.created_at desc
+			limit ". $limit .";"
+		)->fetch_all();
+
+		$results = [];
+		foreach ($orders as $order) {
+			$results[] = [
+				'id' => (int)$order['id'],
+				'customer' => [
+					'id' => (int)$order['customer_id'],
+					'name' => trim($order['customer_firstname'] . ' ' . $order['customer_lastname']),
+					'email' => $order['customer_email'],
+				],
+				'total' => round((float)$order['total'], 2),
+				'tax' => round((float)$order['total_tax'], 2),
+				'currency' => $order['currency_code'],
+				'status' => $order['order_status'],
+				'status_id' => (int)$order['order_status_id'],
+				'created' => $order['created_at'],
+			];
+		}
+
+		return [
+			'count' => count($results),
+			'orders' => $results,
+		];
+	}

--- a/public_html/backend/mcp/mcp_products_search.inc.php
+++ b/public_html/backend/mcp/mcp_products_search.inc.php
@@ -1,0 +1,87 @@
+<?php
+
+	return $schema = [
+		'name' => 'products_search',
+		'description' => 'Search products by keyword, category, or brand. Returns id, name, price, quantity, status, and image URL.',
+		'inputSchema' => [
+			'type' => 'object',
+			'properties' => [
+				'query' => [
+					'type' => 'string',
+					'description' => 'Search keyword (matches name, sku, mpn, gtin)',
+				],
+				'category_id' => [
+					'type' => 'integer',
+					'description' => 'Filter by category ID',
+				],
+				'brand_id' => [
+					'type' => 'integer',
+					'description' => 'Filter by brand ID',
+				],
+				'status' => [
+					'type' => 'integer',
+					'description' => 'Filter by status (1 = active, 0 = inactive). Default: all',
+					'enum' => [0, 1],
+				],
+				'limit' => [
+					'type' => 'integer',
+					'description' => 'Max results (default: 10, max: 50)',
+				],
+			],
+			'required' => [],
+		],
+	];
+
+	function mcp_products_search($params) {
+
+		$conditions = [];
+
+		if (!empty($params['query'])) {
+			$q = database::input($params['query']);
+			$conditions[] = "(pi.name like '%". $q ."%' or p.sku like '%". $q ."%' or p.mpn like '%". $q ."%' or p.gtin like '%". $q ."%')";
+		}
+
+		if (isset($params['category_id'])) {
+			$conditions[] = "p.id in (select product_id from ". DB_TABLE_PREFIX ."products_to_categories where category_id = ". (int)$params['category_id'] .")";
+		}
+
+		if (isset($params['brand_id'])) {
+			$conditions[] = "p.brand_id = ". (int)$params['brand_id'];
+		}
+
+		if (isset($params['status'])) {
+			$conditions[] = "p.status = ". (int)$params['status'];
+		}
+
+		$limit = min((int)($params['limit'] ?? 10), 50);
+		if ($limit < 1) $limit = 10;
+
+		$sql_where = $conditions ? 'where ' . implode(' and ', $conditions) : '';
+
+		$products = database::query(
+			"select p.id, pi.name, p.sku, p.default_image, p.quantity, p.status, p.date_created
+			from ". DB_TABLE_PREFIX ."products p
+			left join ". DB_TABLE_PREFIX ."products_info pi on (pi.product_id = p.id and pi.language_code = '". database::input(language::$selected['code']) ."')
+			". $sql_where ."
+			order by pi.name asc
+			limit ". $limit .";"
+		)->fetch_all();
+
+		$results = [];
+		foreach ($products as $product) {
+			$results[] = [
+				'id' => (int)$product['id'],
+				'name' => $product['name'],
+				'sku' => $product['sku'],
+				'quantity' => (float)$product['quantity'],
+				'status' => (int)$product['status'],
+				'image' => $product['default_image'] ?: null,
+				'created' => $product['date_created'],
+			];
+		}
+
+		return [
+			'count' => count($results),
+			'products' => $results,
+		];
+	}

--- a/public_html/backend/pages/mcp.inc.php
+++ b/public_html/backend/pages/mcp.inc.php
@@ -23,8 +23,8 @@
 			throw new McpException('MCP server expects HTTP POST JSON-RPC requests', 405, -32600);
 		}
 
-		// Parse JSON-RPC request
-		$raw = file_get_contents('php://input');
+		// Parse JSON-RPC request (max 64KB)
+		$raw = file_get_contents('php://input', false, null, 0, 65536);
 		$rpc = json_decode($raw, true);
 
 		if (!is_array($rpc) || empty($rpc['jsonrpc']) || $rpc['jsonrpc'] !== '2.0' || empty($rpc['method'])) {
@@ -34,8 +34,11 @@
 		$rpc_id = $rpc['id'] ?? null;
 		$params = isset($rpc['params']) && is_array($rpc['params']) ? $rpc['params'] : [];
 
-		// HTTP Basic Authentication
-		if (!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
+		// HTTP Basic Authentication (mandatory)
+		if (empty($_SERVER['PHP_AUTH_USER']) || empty($_SERVER['PHP_AUTH_PW'])) {
+			throw new McpException('Authentication required', 401, -32000, $rpc_id);
+		}
+
 
 			$administrator = database::query(
 				"select * from ". DB_TABLE_PREFIX ."administrators
@@ -76,7 +79,6 @@
 					throw new McpException(strtr(language::translate('error_account_has_been_blocked', 'The account has been temporary blocked %d minutes'), ['%d' => 15]), 403);
 				}
 
-				throw new McpException(language::translate('error_wrong_username_password_combination', 'Wrong combination of username and password or the account does not exist.'), 403);
 			}
 
 			// Reset login attempts after successful login
@@ -88,7 +90,6 @@
 					limit 1;",
 				);
 			}
-		}
 
 		// MCP method dispatch
 		switch ($rpc['method']) {

--- a/public_html/backend/pages/mcp.inc.php
+++ b/public_html/backend/pages/mcp.inc.php
@@ -120,7 +120,7 @@
 
 				$tool_schemas = [];
 
-				foreach (functions::file_search('app://includes/mcp/mcp_*.inc.php') as $mcp_file) {
+				foreach (functions::file_search('app://backend/mcp/mcp_*.inc.php') as $mcp_file) {
 
 					// Include without polluting global scope
 					$tool_schema = (function() use ($mcp_file) {
@@ -153,7 +153,7 @@
 				}
 
 				// Tool dispatch
-				foreach (functions::file_search('app://includes/mcp/mcp_*.inc.php') as $mcp_file) {
+				foreach (functions::file_search('app://backend/mcp/mcp_*.inc.php') as $mcp_file) {
 
 					// Include without polluting global scope
 					$tool_schema = (function() use ($mcp_file) {

--- a/public_html/frontend/pages/mcp.inc.php
+++ b/public_html/frontend/pages/mcp.inc.php
@@ -23,8 +23,8 @@
 			throw new McpException('MCP server expects HTTP POST JSON-RPC requests', 405, -32600);
 		}
 
-		// Parse JSON-RPC request
-		$raw = file_get_contents('php://input');
+		// Parse JSON-RPC request (max 64KB)
+		$raw = file_get_contents('php://input', false, null, 0, 65536);
 		$rpc = json_decode($raw, true);
 
 		if (!is_array($rpc) || empty($rpc['jsonrpc']) || $rpc['jsonrpc'] !== '2.0' || empty($rpc['method'])) {
@@ -34,8 +34,11 @@
 		$rpc_id = $rpc['id'] ?? null;
 		$params = isset($rpc['params']) && is_array($rpc['params']) ? $rpc['params'] : [];
 
-		// HTTP Basic Authentication
-		if (!empty($_SERVER['PHP_AUTH_USER']) && !empty($_SERVER['PHP_AUTH_PW'])) {
+		// HTTP Basic Authentication (mandatory)
+		if (empty($_SERVER['PHP_AUTH_USER']) || empty($_SERVER['PHP_AUTH_PW'])) {
+			throw new McpException('Authentication required', 401, -32000, $rpc_id);
+		}
+
 
 			$customer = database::query(
 				"select * from ". DB_TABLE_PREFIX ."customers
@@ -76,7 +79,6 @@
 					throw new McpException(strtr(language::translate('error_account_has_been_blocked', 'The account has been temporary blocked %d minutes'), ['%d' => 15]), 403);
 				}
 
-				throw new McpException(language::translate('error_wrong_username_password_combination', 'Wrong combination of username and password or the account does not exist.'), 403);
 			}
 
 			// Reset login attempts after successful login
@@ -88,7 +90,6 @@
 					limit 1;",
 				);
 			}
-		}
 
 		// MCP method dispatch
 		switch ($rpc['method']) {

--- a/public_html/frontend/pages/mcp.inc.php
+++ b/public_html/frontend/pages/mcp.inc.php
@@ -120,7 +120,7 @@
 
 				$tool_schemas = [];
 
-				foreach (functions::file_search('app://includes/mcp/mcp_*.inc.php') as $mcp_file) {
+				foreach (functions::file_search('app://frontend/mcp/mcp_*.inc.php') as $mcp_file) {
 
 					// Include without polluting global scope
 					$tool_schema = (function() use ($mcp_file) {
@@ -153,7 +153,7 @@
 				}
 
 				// Tool dispatch
-				foreach (functions::file_search('app://includes/mcp/mcp_*.inc.php') as $mcp_file) {
+				foreach (functions::file_search('app://frontend/mcp/mcp_*.inc.php') as $mcp_file) {
 
 					// Include without polluting global scope
 					$tool_schema = (function() use ($mcp_file) {


### PR DESCRIPTION
The OWASP Secure MCP Server Development Guide made for some bedtime reading. Here's what fell out.

## Security fixes

| Change | Impact |
|--------|--------|
| Authentication mandatory | Previously, requests without credentials silently bypassed auth. Now returns 401. |
| Request body limit (64KB) | Prevents memory exhaustion from oversized payloads |
| Dead code removed | Unreachable `throw` after if/else block in both endpoints |
| Tool discovery separated by role | Backend searches `backend/mcp/`, frontend searches `frontend/mcp/` — customers can no longer discover admin tools |

## New tools

| Tool | Scope | Description |
|------|-------|-------------|
| `products_search` | Admin | Search by keyword, category, brand, status (max 50) |
| `orders_list` | Admin | Filter by status, customer, date range (max 50) |

Both read-only, both require authentication.

## Reference

Security changes based on [OWASP Secure MCP Server Development](https://genai.owasp.org) — specifically sections on architecture, data validation, and authentication.

## Test plan

- [ ] Unauthenticated request returns 401 (both endpoints)
- [ ] Authenticated `tools/list` on backend shows `ping`, `stats_summary`, `products_search`, `orders_list`
- [ ] Authenticated `tools/list` on frontend shows only `ping`
- [ ] `products_search` returns products filtered by keyword
- [ ] `orders_list` returns orders filtered by date range
- [ ] Request body > 64KB is truncated/rejected
- [ ] PHP lint passes