### PR TITLE
* Fix checkout session serialization for ent_order

### DIFF
--- a/public_html/includes/entities/ent_order.inc.php
+++ b/public_html/includes/entities/ent_order.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-	class ent_order {
+	class ent_order implements JsonSerializable {
 		public $data;
 		public $previous;
 
@@ -1022,5 +1022,17 @@
 			cache::clear_cache('category');
 			cache::clear_cache('brand');
 			cache::clear_cache('products');
+		}
+
+	// Serialize only $data for session storage (json_encode compatibility)
+		public function jsonSerialize(): mixed {
+			return $this->data;
+		}
+
+	// Restore from session data
+		public static function from_data(array $data): self {
+			$order = new self();
+			$order->data = $data;
+			return $order;
 		}
 	}

--- a/public_html/includes/nodes/nod_session.inc.php
+++ b/public_html/includes/nodes/nod_session.inc.php
@@ -179,6 +179,11 @@
 
 			self::$data = $session['data'];
 
+		// Restore ent_order from serialized data
+			if (!empty(self::$data['checkout']['order']) && is_array(self::$data['checkout']['order'])) {
+				self::$data['checkout']['order'] = ent_order::from_data(self::$data['checkout']['order']);
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Following up on the conversation in #399 — this should fix the checkout breakage caused by `ent_order` not surviving session serialization.

## Problem

`session::save()` serializes session data via `json_encode()`. The checkout stores a full `ent_order` object in `session::$data['checkout']['order']`. This object carries `$shipping` and `$payment` properties containing module instances with closures and DB connections — none of which survive `json_encode()`.

## Fix

| File | Change |
|------|--------|
| `ent_order.inc.php` | `implements JsonSerializable` — `jsonSerialize()` returns only `$data`, skipping `$shipping`, `$payment`, `$previous` |
| `ent_order.inc.php` | `from_data(array $data)` — static factory to rebuild an `ent_order` from a plain array |
| `nod_session.inc.php` | `load()` checks if `checkout.order` is an array (from JSON) and restores it via `ent_order::from_data()` |

The cycle: `ent_order` → `jsonSerialize()` → only `$data` → JSON in DB → `json_decode()` → array → `from_data()` → `ent_order` with `$data` restored. Shipping and payment modules are re-attached during checkout processing, not during session restore.

## Test plan

- [ ] Add products to cart, proceed to checkout — order persists across page loads
- [ ] Close browser, reopen — checkout session is restored
- [ ] Complete checkout flow (customer details → shipping → payment → confirm)
- [ ] `json_encode(session::$data)` no longer throws on order objects
- [ ] PHP lint passes