### PR TITLE
+ Add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.git-hooks
+.github
+node_modules
+art
+*.md
+gruntfile.js
+package.json
+package-lock.json
+.editorconfig
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:8.3-apache
+
+# Install PHP extensions required by LiteCart
+RUN apt-get update && apt-get install -y \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libzip-dev \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        gd \
+        mysqli \
+        pdo_mysql \
+        zip \
+        intl \
+        curl \
+        opcache \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Enable Apache modules
+RUN a2enmod rewrite headers expires
+
+# Set recommended PHP settings for LiteCart
+RUN { \
+    echo 'upload_max_filesize = 50M'; \
+    echo 'post_max_size = 50M'; \
+    echo 'memory_limit = 256M'; \
+    echo 'max_execution_time = 300'; \
+    echo 'session.save_path = /tmp'; \
+    echo 'date.timezone = UTC'; \
+    echo 'expose_php = Off'; \
+} > /usr/local/etc/php/conf.d/litecart.ini
+
+# Set Apache document root to public_html
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Allow .htaccess overrides
+RUN sed -ri -e 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf
+
+# Copy application files
+COPY public_html/ /var/www/html/public_html/
+
+# Set correct permissions
+RUN chown -R www-data:www-data /var/www/html/public_html \
+    && chmod -R 755 /var/www/html/public_html \
+    && chmod -R 775 /var/www/html/public_html/cache \
+    && chmod -R 775 /var/www/html/public_html/data \
+    && chmod -R 775 /var/www/html/public_html/images \
+    && chmod -R 775 /var/www/html/public_html/logs \
+    && chmod -R 755 /var/www/html/public_html/vmods
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  litecart:
+    build: .
+    ports:
+      - "9080:80"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      - APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: litecart_root
+      MYSQL_DATABASE: litecart
+      MYSQL_USER: litecart
+      MYSQL_PASSWORD: litecart
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  mysql_data:

--- a/public_html/install/index.php
+++ b/public_html/install/index.php
@@ -427,6 +427,7 @@ input[name="development_type"]:checked + div {
     <div class="form-group col-md-6">
       <label>Collation</label>
       <select class="form-control" name="db_collation" required>
+        <option selected="selected">utf8mb4_general_ci</option>
         <option>utf8_bin</option>
         <option>utf8_general_ci</option>
         <option>utf8_unicode_ci</option>
@@ -437,7 +438,7 @@ input[name="development_type"]:checked + div {
         <option>utf8_polish_ci</option>
         <option>utf8_estonian_ci</option>
         <option>utf8_spanish_ci</option>
-        <option selected="selected">utf8_swedish_ci</option>
+        <option>utf8_swedish_ci</option>
         <option>utf8_turkish_ci</option>
         <option>utf8_czech_ci</option>
         <option>utf8_danish_ci</option>


### PR DESCRIPTION
One command to rule them all. No more manual Apache/PHP/MySQL setup for local development.

## What's included

| File | Purpose |
|------|---------|
| `Dockerfile` | PHP 8.3-Apache with all LiteCart-required extensions |
| `docker-compose.yml` | Apache + MySQL 8.0 stack on `localhost:9080` |
| `.dockerignore` | Excludes build tooling, docs, and git artifacts from image |

## Quick start

```bash
docker-compose up -d --build
# Visit http://localhost:9080/install/
# DB host: mysql, database: litecart, user: litecart, password: litecart
```

## Why PHP 8.3?

PHP 8.2 enters security-only support and reaches EOL on 31.12.2026. PHP 8.3 has security support until 31.12.2027. For a dev environment image, using a version with at least one year of security support ahead makes sense. The application itself remains compatible with PHP 5.6+ — the Docker image just provides a modern, secure runtime for development.

## Also included

- MySQL configured with `utf8mb4_general_ci` as default collation (avoids the installer warning about `utf8mb4_0900_ai_ci`)
- Installer default collation changed from `utf8_swedish_ci` to `utf8mb4_general_ci` (better Unicode support, added at top of list, Swedish still available)
- Container is fully isolated (no bind mount) — code changes require `docker-compose up -d --build`
- `expose_php = Off` in PHP config
- `vmods/` set to 755 (not writable by web process)

## Note on database driver

I personally prefer PDO over MySQLi (prepared statements, cleaner API) and have been running a PDO-based fork locally. However, swapping the database driver is a significant change that should be discussed before submitting. This PR uses MySQLi to stay consistent with the current codebase. Happy to discuss a PDO migration separately if there's interest.

## Test plan

- [ ] `docker-compose up -d --build` starts both containers
- [ ] `http://localhost:9080/install/` shows installer with all checks green
- [ ] Installation completes successfully with provided DB credentials
- [ ] Admin and storefront work after installation
- [ ] Default collation shows `utf8mb4_general_ci` in installer dropdown