### PR TITLE
* Replace SHA1 remember-me with HMAC-SHA256 tokens

### DIFF
--- a/public_html/admin/login.php
+++ b/public_html/admin/login.php
@@ -172,9 +172,10 @@
 
       user::load($user['id']);
 
-      if (!empty($_POST['remember_me'])) {
-        $checksum = sha1($user['username'] . $user['password_hash'] . $_SERVER['REMOTE_ADDR'] . ($_SERVER['HTTP_USER_AGENT'] ? $_SERVER['HTTP_USER_AGENT'] : ''));
-        header('Set-Cookie: remember_me='. $user['username'] .':'. $checksum .'; Path='. WS_DIR_APP .'; Expires='. gmdate('r', strtotime('+3 months')) .'; HttpOnly; SameSite=Lax', false);
+      if (!empty($_POST['remember_me']) && defined('DB_SERVER_SECRET')) {
+        $expiry_days = (int)(settings::get('remember_me_days') ?: 30);
+        $token = functions::token_create_remember($user['id'], $user['password_hash'], $expiry_days);
+        header('Set-Cookie: remember_me='. $token .'; Path='. WS_DIR_APP .'; Expires='. gmdate('r', strtotime('+'. $expiry_days .' days')) .'; HttpOnly; SameSite=Lax' . (!empty($_SERVER['HTTPS']) ? '; Secure' : ''), false);
       } else if (!empty($_COOKIE['remember_me'])) {
         header('Set-Cookie: remember_me=; Path='. WS_DIR_APP .'; Max-Age=-1; HttpOnly; SameSite=Lax', false);
       }

--- a/public_html/includes/functions/func_token.inc.php
+++ b/public_html/includes/functions/func_token.inc.php
@@ -1,0 +1,38 @@
+<?php
+
+  function token_create_remember($id, $password_hash, $expiry_days=30) {
+
+    if (!defined('DB_SERVER_SECRET')) return '';
+
+    $exp = time() + (int)$expiry_days * 86400;
+    $payload = $id . ':' . $exp . ':' . substr($password_hash, 0, 16);
+    $sig = hash_hmac('sha256', $payload, DB_SERVER_SECRET);
+
+    return base64_encode(json_encode([
+      'id' => (int)$id,
+      'exp' => $exp,
+      'sig' => $sig,
+    ]));
+  }
+
+  function token_verify_remember($cookie_value, $password_hash) {
+
+    if (!defined('DB_SERVER_SECRET')) return false;
+
+    $decoded = base64_decode($cookie_value, true);
+    if ($decoded === false) return false;
+
+    $token = json_decode($decoded, true);
+    if (!is_array($token) || empty($token['id']) || empty($token['exp']) || empty($token['sig'])) {
+      return false;
+    }
+
+    if ($token['exp'] < time()) return false;
+
+    $payload = $token['id'] . ':' . $token['exp'] . ':' . substr($password_hash, 0, 16);
+    $expected_sig = hash_hmac('sha256', $payload, DB_SERVER_SECRET);
+
+    if (!hash_equals($expected_sig, $token['sig'])) return false;
+
+    return (int)$token['id'];
+  }

--- a/public_html/includes/library/lib_customer.inc.php
+++ b/public_html/includes/library/lib_customer.inc.php
@@ -12,26 +12,33 @@
     // Bind customer to session
       self::$data = &session::$data['customer'];
 
-    // Login remembered customer automatically
-      if (empty(self::$data['id']) && !empty($_COOKIE['customer_remember_me']) && empty($_POST)) {
+    // Login remembered customer automatically (HMAC-based token)
+      if (empty(self::$data['id']) && !empty($_COOKIE['customer_remember_me']) && empty($_POST) && defined('DB_SERVER_SECRET')) {
 
         try {
 
-          list($email, $key) = explode(':', $_COOKIE['customer_remember_me']);
+        // Decode token to get customer ID (verify signature after DB lookup)
+          $decoded = base64_decode($_COOKIE['customer_remember_me'], true);
+          $token = $decoded ? json_decode($decoded, true) : null;
+          if (!is_array($token) || empty($token['id'])) {
+            throw new Exception('Invalid or legacy cookie format');
+          }
 
           $customer_query = database::query(
             "select * from ". DB_TABLE_PREFIX ."customers
-            where email = '". database::input($email) ."'
+            where id = ". (int)$token['id'] ."
+            and status
+            and (date_blocked_until is null or date_blocked_until < '". date('Y-m-d H:i:s') ."')
             limit 1;"
           );
 
           if (!$customer = database::fetch($customer_query)) {
-            throw new Exception('Invalid email or the account has been removed');
+            throw new Exception('Invalid customer or account removed');
           }
 
-          $checksum = sha1($customer['email'] . $customer['password_hash'] . $_SERVER['REMOTE_ADDR'] . ($_SERVER['HTTP_USER_AGENT'] ? $_SERVER['HTTP_USER_AGENT'] : ''));
-
-          if ($checksum != $key) {
+        // Verify HMAC with actual password hash
+          $verified_id = functions::token_verify_remember($_COOKIE['customer_remember_me'], $customer['password_hash']);
+          if ($verified_id === false) {
             if (++$customer['login_attempts'] < 3) {
               database::query(
                 "update ". DB_TABLE_PREFIX ."customers
@@ -49,7 +56,7 @@
               );
             }
 
-            throw new Exception('Invalid checksum for cookie');
+            throw new Exception('Invalid token signature');
           }
 
           self::load($customer['id']);

--- a/public_html/includes/library/lib_user.inc.php
+++ b/public_html/includes/library/lib_user.inc.php
@@ -13,16 +13,21 @@
     // Bind user to session
       self::$data = &session::$data['user'];
 
-    // Login remembered user automatically
-      if (empty(self::$data['id']) && !empty($_COOKIE['remember_me']) && empty($_POST)) {
+    // Login remembered user automatically (HMAC-based token)
+      if (empty(self::$data['id']) && !empty($_COOKIE['remember_me']) && empty($_POST) && defined('DB_SERVER_SECRET')) {
 
         try {
 
-          list($username, $key) = explode(':', $_COOKIE['remember_me']);
+        // Decode token to get user ID (verify signature after DB lookup)
+          $decoded = base64_decode($_COOKIE['remember_me'], true);
+          $token = $decoded ? json_decode($decoded, true) : null;
+          if (!is_array($token) || empty($token['id'])) {
+            throw new Exception('Invalid or legacy cookie format');
+          }
 
           $user_query = database::query(
             "select * from ". DB_TABLE_PREFIX ."users
-            where lower(username) = lower('". database::input($username) ."')
+            where id = ". (int)$token['id'] ."
             and status
             and (date_valid_from is null or date_valid_from < '". date('Y-m-d H:i:s') ."')
             and (date_valid_to is null or year(date_valid_to) < '1971' or date_valid_to > '". date('Y-m-d H:i:s') ."')
@@ -30,12 +35,12 @@
           );
 
           if (!$user = database::fetch($user_query)) {
-            throw new Exception('Invalid email or the account has been removed');
+            throw new Exception('Invalid user or account removed');
           }
 
-          $checksum = sha1($user['username'] . $user['password_hash'] . $_SERVER['REMOTE_ADDR'] . ($_SERVER['HTTP_USER_AGENT'] ? $_SERVER['HTTP_USER_AGENT'] : ''));
-
-          if ($checksum != $key) {
+        // Verify HMAC with actual password hash
+          $verified_id = functions::token_verify_remember($_COOKIE['remember_me'], $user['password_hash']);
+          if ($verified_id === false) {
 
             if (++$user['login_attempts'] < 3) {
               database::query(
@@ -54,7 +59,7 @@
               );
             }
 
-            throw new Exception('Invalid checksum for cookie');
+            throw new Exception('Invalid token signature');
           }
 
           self::load($user['id']);

--- a/public_html/pages/login.inc.php
+++ b/public_html/pages/login.inc.php
@@ -99,9 +99,10 @@
 
       customer::load($customer['id']);
 
-      if (!empty($_POST['remember_me'])) {
-        $checksum = sha1($customer['email'] . $customer['password_hash'] . $_SERVER['REMOTE_ADDR'] . ($_SERVER['HTTP_USER_AGENT'] ? $_SERVER['HTTP_USER_AGENT'] : ''));
-        header('Set-Cookie: customer_remember_me='. $customer['email'] .':'. $checksum .'; Path='. WS_DIR_APP .'; Expires='. gmdate('r', strtotime('+3 months')) .'; HttpOnly; SameSite=Lax', false);
+      if (!empty($_POST['remember_me']) && defined('DB_SERVER_SECRET')) {
+        $expiry_days = (int)(settings::get('remember_me_days') ?: 30);
+        $token = functions::token_create_remember($customer['id'], $customer['password_hash'], $expiry_days);
+        header('Set-Cookie: customer_remember_me='. $token .'; Path='. WS_DIR_APP .'; Expires='. gmdate('r', strtotime('+'. $expiry_days .' days')) .'; HttpOnly; SameSite=Lax' . (!empty($_SERVER['HTTPS']) ? '; Secure' : ''), false);
       }
 
       notices::add('success', strtr(language::translate('success_logged_in_as_user', 'You are now logged in as %firstname %lastname.'), [


### PR DESCRIPTION
SHA1 walked into a bar. The bouncer said "I know you, you're weak." So we replaced him with HMAC-SHA256 — same door, better bouncer.

## What's changed

The remember-me cookie for both admin users and customers now uses HMAC-SHA256 instead of plain SHA1 checksums.

| Before | After |
|--------|-------|
| `username:sha1(username + password_hash + IP + UA)` | Base64-encoded JSON with HMAC-SHA256 signature |
| Breaks when IP or User-Agent changes | Stable across networks and browser updates |
| No expiration in token | Built-in expiry timestamp, verified server-side |
| Uses `!=` comparison | Uses `hash_equals()` (constant-time) |
| Works without config | Requires `DB_SERVER_SECRET` in config (graceful skip if missing) |

## How it works

1. On login with "remember me", `token_create_remember()` builds a payload: `{id}:{expiry}:{password_hash_prefix}` and signs it with `hash_hmac('sha256', payload, DB_SERVER_SECRET)`
2. Cookie contains base64-encoded JSON: `{"id": 1, "exp": 1745337600, "sig": "abc..."}`
3. On next visit, `token_verify_remember()` decodes the cookie, checks expiry, rebuilds the expected signature from the DB password hash, and compares with `hash_equals()`
4. Old-format cookies (`email:sha1...`) fail JSON decode and are silently cleared — no user-facing errors during migration

## Additional improvements

- Customer remember-me now checks `status` and `date_blocked_until` before auto-login
- Remember-me cookies get `Secure` flag on HTTPS connections
- Expiry configurable via `remember_me_days` setting (default: 30 days, was hardcoded 3 months)

## Test plan

- [ ] Login with "remember me" checked — verify cookie is set (base64 JSON, not `email:sha1`)
- [ ] Close browser, reopen — auto-login should work
- [ ] Change password — old remember-me cookie should fail (password hash changed)
- [ ] Wait for token to expire (or manually set short expiry) — should not auto-login
- [ ] Test with `DB_SERVER_SECRET` undefined — remember-me should be silently disabled
- [ ] Test with old-format cookie still in browser — should clear it and show login page
- [ ] Admin and customer login/remember-me both covered