### PR TITLE
+ Auto-install LiteCart on first Docker start via CLI installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@ RUN sed -ri -e 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.c
 # Copy application files
 COPY public_html/ /var/www/html/public_html/
 
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Set correct permissions
 RUN chown -R www-data:www-data /var/www/html/public_html \
     && chmod -R 755 /var/www/html/public_html \
@@ -55,4 +59,4 @@ RUN chown -R www-data:www-data /var/www/html/public_html \
 
 EXPOSE 80
 
-CMD ["apache2-foreground"]
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,14 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      - APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+      DB_SERVER: mysql
+      DB_USERNAME: litecart
+      DB_PASSWORD: litecart
+      DB_DATABASE: litecart
+      DB_COLLATION: utf8mb4_general_ci
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin
+      TZ: UTC
     restart: unless-stopped
 
   mysql:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+CONFIG_FILE="/var/www/html/public_html/includes/config.inc.php"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "No config found — running LiteCart installer..."
+
+  # Wait for MySQL to accept connections
+  until php -r "new PDO('mysql:host=${DB_SERVER:-mysql};port=3306', '${DB_USERNAME:-litecart}', '${DB_PASSWORD:-litecart}');" 2>/dev/null; do
+    echo "Waiting for MySQL..."
+    sleep 2
+  done
+
+  php /var/www/html/public_html/install/install.php \
+    --document_root="/var/www/html/public_html" \
+    --db_server="${DB_SERVER:-mysql}" \
+    --db_username="${DB_USERNAME:-litecart}" \
+    --db_password="${DB_PASSWORD:-litecart}" \
+    --db_database="${DB_DATABASE:-litecart}" \
+    --db_collation="${DB_COLLATION:-utf8mb4_general_ci}" \
+    --db_table_prefix="${DB_TABLE_PREFIX:-lc_}" \
+    --timezone="${TZ:-UTC}" \
+    --username="${ADMIN_USERNAME:-admin}" \
+    --password="${ADMIN_PASSWORD:-admin}"
+
+  echo ""
+  echo "============================================"
+  echo " LiteCart installed successfully!"
+  echo " Admin: http://localhost:9080/admin/"
+  echo " User:  ${ADMIN_USERNAME:-admin}"
+  echo " Pass:  ${ADMIN_PASSWORD:-admin}"
+  echo "============================================"
+  echo ""
+else
+  echo "Config found — skipping installation."
+fi
+
+exec apache2-foreground


### PR DESCRIPTION
One command to rule them all. No browser needed.

Following up on your [comment in #401](https://github.com/litecart/litecart/pull/401#issuecomment-4085684997) about using the CLI installer — now that #403 fixed the CLI detection, we can put it to work. The Docker environment now auto-installs on first boot using the CLI installer you built.

## Before vs after

| Before | After |
|--------|-------|
| `docker-compose up -d --build` | `docker-compose up -d --build` |
| Open `http://localhost:9080/install/` | Done. |
| Fill in DB credentials manually | |
| Click install | |
| **4 steps** | **1 step** |

## How it works

1. `docker-entrypoint.sh` checks if `config.inc.php` exists
2. If not → waits for MySQL to be ready, then runs `php install/install.php` with environment variables
3. If yes → skips straight to `apache2-foreground`
4. On subsequent `docker-compose up`, installation is skipped (config already exists)

## Environment variables

All configurable via `docker-compose.yml`:

| Variable | Default | Purpose |
|----------|---------|---------|
| `DB_SERVER` | `mysql` | Database host |
| `DB_USERNAME` | `litecart` | Database user |
| `DB_PASSWORD` | `litecart` | Database password |
| `DB_DATABASE` | `litecart` | Database name |
| `DB_COLLATION` | `utf8mb4_general_ci` | Database collation |
| `ADMIN_USERNAME` | `admin` | Admin login |
| `ADMIN_PASSWORD` | `admin` | Admin password |
| `TZ` | `UTC` | Timezone |

## Quick start

```bash
docker-compose up -d --build
# That's it. Visit http://localhost:9080/ when ready.
# Admin: http://localhost:9080/admin/ (admin/admin)
```

## Test plan

- [ ] Fresh `docker-compose up -d --build` — auto-installs without visiting browser
- [ ] `docker-compose down && docker-compose up -d` — skips installation (config exists)
- [ ] `docker-compose down -v && docker-compose up -d --build` — reinstalls from scratch
- [ ] Custom env vars (e.g. different admin password) — applied correctly
- [ ] Manual install via `http://localhost:9080/install/` still works if entrypoint is bypassed