### PR TITLE
* Fix 4 security and correctness bugs

### DIFF
--- a/public_html/backend/pages/mcp.inc.php
+++ b/public_html/backend/pages/mcp.inc.php
@@ -46,6 +46,7 @@
 				and lower(username) = lower('". database::input($_SERVER['PHP_AUTH_USER']) ."')
 				and (valid_from is null or valid_from < '". database::input(date('Y-m-d H:i:s')) ."')
 				and (valid_to is null or valid_to > '". database::input(date('Y-m-d H:i:s')) ."')
+				and (blocked_until is null or blocked_until < '". database::input(date('Y-m-d H:i:s')) ."')
 				limit 1;",
 			)->fetch();
 

--- a/public_html/frontend/init.inc.php
+++ b/public_html/frontend/init.inc.php
@@ -96,11 +96,11 @@
 		switch ($site_tag['position']) {
 
 			case 'head':
-				self::$head_tags[] = $site_tag['content'];
+				document::$head_tags[] = $site_tag['content'];
 				break;
 
 			case 'body':
-				self::$foot_tags[] = $site_tag['content'];
+				document::$foot_tags[] = $site_tag['content'];
 				break;
 		}
 	});

--- a/public_html/frontend/pages/mcp.inc.php
+++ b/public_html/frontend/pages/mcp.inc.php
@@ -46,6 +46,7 @@
 				and lower(username) = lower('". database::input($_SERVER['PHP_AUTH_USER']) ."')
 				and (valid_from is null or valid_from < '". database::input(date('Y-m-d H:i:s')) ."')
 				and (valid_to is null or valid_to > '". database::input(date('Y-m-d H:i:s')) ."')
+				and (blocked_until is null or blocked_until < '". database::input(date('Y-m-d H:i:s')) ."')
 				limit 1;",
 			)->fetch();
 

--- a/public_html/includes/abstracts/abs_reference_entity.inc.php
+++ b/public_html/includes/abstracts/abs_reference_entity.inc.php
@@ -34,26 +34,25 @@
 
     // ArrayAccess implementation
     public function offsetExists($offset): bool {
-			return isset($this->data[$offset]);
+			return isset($this->_data[$offset]);
     }
 
     public function offsetGet($offset): mixed {
-			return fallback($this->data[$offset]);
+			return fallback($this->_data[$offset]);
     }
 
     public function offsetSet($offset, $value): void {
-			if (isset($this->_data[$name])) {
-				trigger_error('Overwriting data is prohibited ('.$name.')', E_USER_WARNING);
+			if (isset($this->_data[$offset])) {
+				trigger_error('Overwriting data is prohibited ('.$offset.')', E_USER_WARNING);
 				return;
 			}
-			$this->data[$offset] = $value;
+			$this->_data[$offset] = $value;
     }
 
     public function offsetUnset($offset): void {
-			if (isset($this->_data[$name])) {
-				trigger_error('Unsetting data is prohibited ('.$name.')', E_USER_WARNING);
+			if (isset($this->_data[$offset])) {
+				trigger_error('Unsetting data is prohibited ('.$offset.')', E_USER_WARNING);
 				return;
 			}
-			//unset($this->data[$offset]);
     }
 	}

--- a/public_html/includes/nodes/nod_database.inc.php
+++ b/public_html/includes/nodes/nod_database.inc.php
@@ -274,7 +274,11 @@
 			}
 
 			if (($result = mysqli_query(self::$_links[$link], $sql)) === false) {
-				throw new Error('MySQL Error: ' . mysqli_errno(self::$_links[$link]) .' - '. preg_replace('#\s+#', ' ', mysqli_error(self::$_links[$link])) . PHP_EOL . $sql);
+				$ref = uniqid('db_');
+				if (in_array('storage', stream_get_wrappers())) {
+					error_log('['. date('Y-m-d H:i:s e') .']['. $ref .'] MySQL Error: '. mysqli_errno(self::$_links[$link]) .' - '. mysqli_error(self::$_links[$link]) .' | Query: '. $sql . PHP_EOL, 3, 'storage://logs/errors.log');
+				}
+				throw new Error('MySQL Error: ' . mysqli_errno(self::$_links[$link]) .' - '. preg_replace('#\s+#', ' ', mysqli_error(self::$_links[$link])) .' (ref: '. $ref .')');
 			}
 
 			if (($duration = microtime(true) - $timestamp) > 5 && in_array('storage', stream_get_wrappers())) {
@@ -300,7 +304,11 @@
 			$timestamp = microtime(true);
 
 			if (mysqli_multi_query(self::$_links[$link], $sql) === false) {
-				throw new Error('MySQL Error: ' . mysqli_errno(self::$_links[$link]) .' - '. preg_replace('#\r#', ' ', mysqli_error(self::$_links[$link])) . PHP_EOL . preg_replace('#^\s+#m', '', $sql));
+				$ref = uniqid('db_');
+				if (in_array('storage', stream_get_wrappers())) {
+					error_log('['. date('Y-m-d H:i:s e') .']['. $ref .'] MySQL Error: '. mysqli_errno(self::$_links[$link]) .' - '. mysqli_error(self::$_links[$link]) .' | Query: '. $sql . PHP_EOL, 3, 'storage://logs/errors.log');
+				}
+				throw new Error('MySQL Error: ' . mysqli_errno(self::$_links[$link]) .' - '. preg_replace('#\r#', ' ', mysqli_error(self::$_links[$link])) .' (ref: '. $ref .')');
 			}
 
 			$results = [];


### PR DESCRIPTION
Found these while taking a deep dive into the v3 code. Four unrelated bugs, all small fixes.

## Fixes

| Fix | File | Bug | Impact |
|-----|------|-----|--------|
| MCP blocked_until | `frontend/pages/mcp.inc.php` | Missing `blocked_until` check in login query | Brute-force account lock bypassable via MCP API |
| MCP blocked_until | `backend/pages/mcp.inc.php` | Same as above for admin MCP endpoint | Same — admin accounts affected too |
| SQL disclosure | `includes/nodes/nod_database.inc.php` | SQL query appended to exception message | Full query text (table names, column names, user input) visible when errors are displayed |
| ArrayAccess | `includes/abstracts/abs_reference_entity.inc.php` | ArrayAccess uses `$this->data` instead of `$this->_data`, and `$name` instead of `$offset` | `isset($ref['field'])` always returns false, set/unset trigger undefined variable warnings |
| Site tags | `frontend/init.inc.php` | `self::$head_tags` used outside class context | Fatal error when site tags with head/body position are loaded |

## Details

**MCP blocked_until:** Both MCP endpoints set `blocked_until` on failed login attempts (line 74) but never check it when loading the account. An attacker blocked at the normal login can continue brute-forcing via the MCP endpoint. Fix: add `and (blocked_until is null or blocked_until < NOW())` to the WHERE clause.

**SQL in exceptions:** `nod_database.inc.php` line 277 and 307 append `$sql` to the error message. Now the query is logged to `storage://logs/errors.log` with a reference ID, and only the error number + message + ref are in the exception.

**ArrayAccess:** Copy-paste bug — `offsetSet`/`offsetUnset` reference `$name` (from `__set`) instead of `$offset` (the ArrayAccess parameter). `offsetExists`/`offsetGet` use `$this->data` (public, doesn't exist) instead of `$this->_data` (protected, where the data lives). All `ref_*` classes inherit this.

**Site tags:** `self::` has no meaning inside an anonymous function that isn't bound to a class. Changed to `document::$head_tags` / `document::$foot_tags`.

## Test plan

- [ ] MCP login with blocked account returns 401 (not a successful auth)
- [ ] Database error messages no longer contain SQL queries
- [ ] `isset($ref_product['price'])` returns true for existing properties
- [ ] Site tags with position "head" or "body" render without fatal error
- [ ] All 34 platform tests still pass