### PR TITLE
+ Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: .
+
+jobs:
+  lint-and-build:
+    name: PHP Lint & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: none
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: PHP lint
+        run: npm run phplint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
No safety net? No problem. Until now.

## What it does

Runs on every PR against `dev` and on manual dispatch:

1. **PHP Lint** — syntax check all PHP files
2. **Grunt Build** — compile LESS, SCSS, uglify JS (verifies nothing is broken in the build pipeline)

## Setup

- PHP 8.3 (matches the Docker dev environment)
- Node.js 20 with npm cache
- Single job, fast (~30s)

## Why now

v3 has had CI since PR #401. v2 has been flying blind — this brings it up to baseline. More checks (debug statement scanner, PRNG scanner, JSON lint) can be added later.

## Test plan

- [ ] CI runs on this PR
- [ ] PHP lint passes
- [ ] Grunt build passes