### PR TITLE
* Replace mt_rand with random_int for 2FA verification code

### DIFF
--- a/public_html/backend/pages/verify.inc.php
+++ b/public_html/backend/pages/verify.inc.php
@@ -12,7 +12,7 @@
 	$send_verification_code = function(){
 
 		session::$data['security_verification'] = [
-			'code' => mt_rand(100000, 999999),
+			'code' => random_int(100000, 999999),
 			'expires' => strtotime('+15 minutes'),
 			'attempts' => 0,
 		];


### PR DESCRIPTION
Same fix as #397 (A1) for the login page — the verify page was missed.

`verify.inc.php:15` uses `mt_rand(100000, 999999)` for the 2FA code resend flow. `login.inc.php:191` was already fixed to `random_int()` in PR #397. This brings the verify page in line.

One-liner: `mt_rand()` -> `random_int()`.