### PR TITLE
* Fix 4 audit findings: XSS, preload, fetch_all, regex

### DIFF
--- a/public_html/backend/apps/catalog/edit_product.inc.php
+++ b/public_html/backend/apps/catalog/edit_product.inc.php
@@ -517,11 +517,11 @@
 									<?php echo f::form_input_hidden('attributes['.$key.'][value_id]', true); ?>
 									<?php echo f::form_input_hidden('attributes['.$key.'][value_name]', true); ?>
 									<?php echo f::form_input_hidden('attributes['.$key.'][custom_value]', true); ?>
-									<?php echo $_POST['attributes'][$key]['group_name']; ?>
+									<?php echo f::escape_html($_POST['attributes'][$key]['group_name']); ?>
 								</td>
 								<td class="grabbable">
-									<?php echo $_POST['attributes'][$key]['value_name']; ?>
-									<?php echo $_POST['attributes'][$key]['custom_value']; ?>
+									<?php echo f::escape_html($_POST['attributes'][$key]['value_name']); ?>
+									<?php echo f::escape_html($_POST['attributes'][$key]['custom_value']); ?>
 								</td>
 								<td class="text-end">
 									<button name="remove" type="button" class="btn btn-default btn-sm" title="<?php echo t('title_remove', 'Remove'); ?>">
@@ -795,7 +795,7 @@
 										<span class="name"><?php echo $stock_option['name']; ?></span>
 									</td>
 									<td class="grabbable">
-										<span class="sku"><?php echo $_POST['stock_options'][$key]['sku']; ?></span>
+										<span class="sku"><?php echo f::escape_html($_POST['stock_options'][$key]['sku']); ?></span>
 									</td>
 									<td><?php echo f::form_select('stock_options['.$key.'][price_modifier]', ['+', '*', '%', '='], '+'); ?></td>
 									<td>

--- a/public_html/backend/apps/orders/edit_order.inc.php
+++ b/public_html/backend/apps/orders/edit_order.inc.php
@@ -974,7 +974,7 @@
 							<?php echo f::form_input_hidden('comments['.$key.'][author]', true); ?>
 							<?php echo f::form_input_hidden('comments['.$key.'][text]', true); ?>
 
-							<?php echo nl2br($_POST['comments'][$key]['text']); ?>
+							<?php echo nl2br(f::escape_html($_POST['comments'][$key]['text'])); ?>
 
 							<div class="date"><?php echo f::datetime_when($_POST['comments'][$key]['created_at']); ?></div>
 

--- a/public_html/backend/pages/login.inc.php
+++ b/public_html/backend/pages/login.inc.php
@@ -160,7 +160,7 @@
 					$is_known_ip = true;
 					$is_known_range = true;
 					break;
-				} else if (preg_replace('[0-9]{1,3}\.[0-9]{1,3}$', '', $_SERVER['REMOTE_ADDR']) == preg_replace('[0-9]{1,3}\.[0-9]{1,3}$', '', $known_ip)) {
+				} else if (preg_replace('#[0-9]{1,3}\.[0-9]{1,3}$#', '', $_SERVER['REMOTE_ADDR']) == preg_replace('#[0-9]{1,3}\.[0-9]{1,3}$#', '', $known_ip)) {
 					$is_known_range = true;
 					break;
 				}

--- a/public_html/includes/nodes/nod_database.inc.php
+++ b/public_html/includes/nodes/nod_database.inc.php
@@ -330,7 +330,7 @@
 		}
 
 		public static function fetch_all($result, $column=null, $index_column=null) {
-			return $result->fetch_all($column=null, $index_column=null);
+			return $result->fetch_all($column, $index_column);
 		}
 
 		public static function seek($result, $offset) {

--- a/public_html/includes/nodes/nod_document.inc.php
+++ b/public_html/includes/nodes/nod_document.inc.php
@@ -481,7 +481,7 @@
 				}
 			}
 
-			self::$preloads[$link] = $type;
+			self::$preloads[$url] = $type;
 		}
 
 		// Send a message to the console


### PR DESCRIPTION
Four one-liner fixes found during a deep dive into the v3 code. All independent, all minimal risk.

## Fixes

| Fix | File | Bug | Impact |
|-----|------|-----|--------|
| XSS | `edit_product.inc.php:520,523,524,798` | `$_POST` values echoed without escaping | Reflected XSS in admin product editor |
| XSS | `edit_order.inc.php:977` | `nl2br($_POST[...])` without escaping | Reflected XSS in admin order comments |
| Preload | `nod_document.inc.php:484` | `$link` used instead of `$url` (undefined variable) | `add_preload()` silently broken — preload headers never sent |
| fetch_all | `nod_database.inc.php:333` | `$column=null, $index_column=null` in call overwrites parameters | `database::fetch_all($result, 'name')` ignores the column filter |
| Regex | `login.inc.php:163` | `preg_replace('[0-9]...')` uses brackets as delimiter | IP range check for 2FA always matches — potentially bypasses 2FA on unknown IPs |

## Test plan

- [ ] All 34 platform tests pass
- [ ] Product editor with attributes renders correctly (no broken HTML)
- [ ] Order comments display correctly
- [ ] `database::fetch_all($result, 'column_name')` returns only that column