### PR TITLE
+ Add CSRF protection for all state-changing requests

### DIFF
--- a/public_html/backend/pages/login.inc.php
+++ b/public_html/backend/pages/login.inc.php
@@ -149,6 +149,7 @@
 
 			session::$data['administrator_security_timestamp'] = time();
 			session::regenerate_id();
+			session::rotate_csrf_token();
 
 			unset(session::$data['security_verification']);
 

--- a/public_html/backend/pages/logout.inc.php
+++ b/public_html/backend/pages/logout.inc.php
@@ -3,6 +3,7 @@
 	administrator::reset();
 
 	session::regenerate_id();
+	session::rotate_csrf_token();
 
 	if (!empty($_COOKIE['remember_me'])) {
 		header('Set-Cookie: remember_me=; Path='. WS_DIR_APP .'; Max-Age=-1; HttpOnly; SameSite=Lax', false);

--- a/public_html/backend/template/js/app.js
+++ b/public_html/backend/template/js/app.js
@@ -7,6 +7,13 @@
 
 waitFor('jQuery', ($) => {
 
+	// CSRF token for AJAX requests
+	$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+		if (!/^(GET|HEAD|OPTIONS)$/i.test(options.type) && window._env && window._env.csrf_token) {
+			jqXHR.setRequestHeader('X-CSRF-Token', window._env.csrf_token);
+		}
+	});
+
 	// Filter
 	$('#sidebar input[name="filter"]').on({
 

--- a/public_html/frontend/pages/account/sign_in.inc.php
+++ b/public_html/frontend/pages/account/sign_in.inc.php
@@ -123,6 +123,7 @@
 
 			session::$data['customer_security_timestamp'] = time();
 			session::regenerate_id();
+			session::rotate_csrf_token();
 
 			if (!empty($_POST['remember_me']) && defined('HMAC_KEY_REMEMBER_ME')) {
 				$token = f::token_create_remember($customer['id'], $customer['password_hash']);

--- a/public_html/frontend/pages/account/sign_out.inc.php
+++ b/public_html/frontend/pages/account/sign_out.inc.php
@@ -12,6 +12,7 @@
 	customer::reset();
 
 	session::regenerate_id();
+	session::rotate_csrf_token();
 	session::$data['cart']['uid'] = null;
 
 	header('Set-Cookie: cart[uid]=; Path='. WS_DIR_APP .'; Max-Age=-1; SameSite=Lax', false);

--- a/public_html/frontend/templates/default/js/app.js
+++ b/public_html/frontend/templates/default/js/app.js
@@ -9,6 +9,13 @@
 
 waitFor('jQuery', ($) => {
 
+	// CSRF token for AJAX requests
+	$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+		if (!/^(GET|HEAD|OPTIONS)$/i.test(options.type) && window._env && window._env.csrf_token) {
+			jqXHR.setRequestHeader('X-CSRF-Token', window._env.csrf_token);
+		}
+	});
+
 	var mouseOverAd = null;
 
 	$('.banner[data-id]').hover(function() {

--- a/public_html/includes/app_header.inc.php
+++ b/public_html/includes/app_header.inc.php
@@ -51,6 +51,35 @@
 	class_exists('notices');
 	class_exists('stats');
 
+	// CSRF protection for state-changing requests
+	if (!in_array($_SERVER['REQUEST_METHOD'], ['GET', 'HEAD', 'OPTIONS']) && !empty(session::$data['id'])) {
+
+		// Excluded paths (payment gateway callbacks, MCP endpoints)
+		$csrf_excluded_paths = ['order_process', 'mcp'];
+		$csrf_skip = false;
+		$request_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+		foreach ($csrf_excluded_paths as $path) {
+			if (preg_match('#/' . preg_quote($path, '#') . '(?:/|$)#', $request_path)) {
+				$csrf_skip = true;
+				break;
+			}
+		}
+
+		if (!$csrf_skip) {
+			$submitted_token = $_POST['csrf_token'] ?? $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+			if (!hash_equals(session::csrf_token(), $submitted_token)) {
+				http_response_code(403);
+				if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest') {
+					header('Content-Type: application/json');
+					echo json_encode(['error' => 'CSRF token mismatch. Please reload the page and try again.']);
+				} else {
+					echo '<h1>403 Forbidden</h1><p>CSRF token mismatch. Please <a href="javascript:history.back()">go back</a> and try again.</p>';
+				}
+				exit;
+			}
+		}
+	}
+
 	// Run operations before capture
 	event::fire('before_capture');
 

--- a/public_html/includes/functions/func_form.inc.php
+++ b/public_html/includes/functions/func_form.inc.php
@@ -1,7 +1,12 @@
 <?php
 
 	function form_begin($name='', $method='post', $action='', $multipart=false, $parameters='') {
-		return '<form'. (($name) ? ' name="'. f::escape_attr($name) .'"' : '') .' method="'. ((strtolower($method) == 'get') ? 'get' : 'post') .'" enctype="'. (($multipart == true) ? 'multipart/form-data' : 'application/x-www-form-urlencoded') .'" accept-charset="'. mb_http_output() .'"'. (($action) ? ' action="'. f::escape_attr($action) .'"' : '') . ($parameters ? ' ' . $parameters : '') .'>';
+		$html = '<form'. (($name) ? ' name="'. f::escape_attr($name) .'"' : '') .' method="'. ((strtolower($method) == 'get') ? 'get' : 'post') .'" enctype="'. (($multipart == true) ? 'multipart/form-data' : 'application/x-www-form-urlencoded') .'" accept-charset="'. mb_http_output() .'"'. (($action) ? ' action="'. f::escape_attr($action) .'"' : '') . ($parameters ? ' ' . $parameters : '') .'>';
+	// Auto-inject CSRF token for POST forms
+		if (strtolower($method) !== 'get' && class_exists('session', false)) {
+			$html .= '<input type="hidden" name="csrf_token" value="'. f::escape_attr(session::csrf_token()) .'" />';
+		}
+		return $html;
 	}
 
 	function form_end() {

--- a/public_html/includes/nodes/nod_document.inc.php
+++ b/public_html/includes/nodes/nod_document.inc.php
@@ -135,6 +135,7 @@
 			}
 
 			self::$jsenv['session']['id'] = session::$data['id'];
+			self::$jsenv['csrf_token'] = session::csrf_token();
 
 			document::$jsenv['currency'] = [
 				'code' => &currency::$selected['code'],

--- a/public_html/includes/nodes/nod_session.inc.php
+++ b/public_html/includes/nodes/nod_session.inc.php
@@ -254,6 +254,18 @@
 			header('Set-Cookie: LCSESSID='. rawurlencode(self::$data['id']) .';Path=/;'. ($is_secure ? 'Secure;' : '') .'HttpOnly;SameSite=' . $samesite);
 		}
 
+		public static function csrf_token() {
+			if (empty(self::$data['csrf_token'])) {
+				self::$data['csrf_token'] = bin2hex(random_bytes(32));
+			}
+			return self::$data['csrf_token'];
+		}
+
+		public static function rotate_csrf_token() {
+			self::$data['csrf_token'] = bin2hex(random_bytes(32));
+			return self::$data['csrf_token'];
+		}
+
 		public static function close() {
 			trigger_error('Calling '.__CLASS__.'::close() is deprecated and can be removed.', E_USER_DEPRECATED);
 		}


### PR DESCRIPTION
Every form was just... trusting. Again. Same fix as v2 (#411), now for v3.

## How it works

| Layer | What happens |
|-------|-------------|
| **Session** | session::csrf_token() lazily generates a 32-byte hex token per session |
| **Forms** | form_begin() auto-injects a hidden csrf_token field for POST forms |
| **AJAX** | jQuery ajaxPrefilter sends X-CSRF-Token header on non-GET requests |
| **Guard** | app_header.inc.php validates the token on POST/PUT/DELETE/PATCH before any route runs |
| **Login/Logout** | Token rotation via session::rotate_csrf_token() on all 4 login/logout handlers |

## Design decisions

- **Excluded paths**: MCP endpoints (HTTP Basic Auth) and order_process (payment gateway callbacks) are skipped
- **Constant-time comparison**: Uses hash_equals() to prevent timing attacks
- **Backwards compatible**: Existing forms using form_begin() get CSRF protection automatically
- **Graceful error**: AJAX gets JSON error, regular requests get a human-readable message with back link

Per discussion in v2 #411 -- Tim mentioned route modules could declare csrf_exempt via a property. The current excluded_paths array is a starting point; module-based exemption can be layered on top.

## Test plan

- [ ] Submit any admin form -- should work normally
- [ ] Submit a storefront form (login, account edit) -- should work normally
- [ ] Remove csrf_token field via devtools, submit -- should get 403
- [ ] AJAX requests include X-CSRF-Token header (devtools network tab)
- [ ] Login/logout rotates the token
- [ ] MCP endpoints still work without CSRF token (HTTP Basic Auth)
- [ ] All 34 platform tests pass