### PR TITLE
* Fix sitemap generator discarding product image data

### DIFF
--- a/public_html/includes/modules/jobs/job_sitemap_generator.inc.php
+++ b/public_html/includes/modules/jobs/job_sitemap_generator.inc.php
@@ -46,7 +46,7 @@
 				$fh = fopen($last_sitemap_path, 'x');
 				fwrite($fh, implode(PHP_EOL, [
 					'<?xml version="1.0" encoding="UTF-8"?>',
-					'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+					'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
 				]) . PHP_EOL);
 			};
 
@@ -145,9 +145,9 @@
 				"select id, default_image, updated_at from ". DB_TABLE_PREFIX ."products
 				where status
 				order by id;"
-			)->each(function($product) use (&$output) {
+			)->each(function($product) use (&$fh, &$count, &$bump_sitemap) {
 
-				$output[] = implode(PHP_EOL, array_filter([
+				fwrite($fh, implode(PHP_EOL, array_filter([
 					'  <url>',
 					'    <loc>'. document::ilink('f:product', ['product_id' => $product['id']]) .'</loc>',
 
@@ -172,7 +172,12 @@
 					'    <changefreq>weekly</changefreq>',
 					'    <priority>0.8</priority>',
 					'  </url>',
-				])) . PHP_EOL;
+				])) . PHP_EOL);
+
+				if (++$count == $this->settings['entries_per_sitemap']) {
+					$bump_sitemap();
+					$count = 0;
+				}
 			});
 
 			$close_sitemap();


### PR DESCRIPTION
## Summary

The sitemap generator's "Product Images" section collected XML into a local `$output` array — that was never written anywhere. Every product image was silently discarded.

| What | Before | After |
|------|--------|-------|
| Product images in sitemap | Lost to the void | Written to file via `fwrite()` |
| `xmlns:image` namespace | Missing | Declared in `<urlset>` |
| Sitemap splitting | Skipped for images | Count/bump logic like all other sections |

## Changes

- **`$output[]` → `fwrite($fh, ...)`** — aligns with the pattern used by Categories, Products, and the `$draw_url_node` helper
- **Added `xmlns:image`** namespace to the `<urlset>` declaration — without it, `<image:image>` elements are invalid XML
- **Added count/bump logic** so product images respect the `entries_per_sitemap` setting

## Test plan

- [ ] Run sitemap generator job
- [ ] Verify product images appear in generated sitemap XML
- [ ] Verify `xmlns:image` namespace is present in `<urlset>`
- [ ] Verify sitemap splitting still works when entry count exceeds limit