### PR TITLE
+ Add platform tests for campaign and newsletter_recipient, fix missing columns

### DIFF
--- a/public_html/includes/entities/ent_newsletter_recipient.inc.php
+++ b/public_html/includes/entities/ent_newsletter_recipient.inc.php
@@ -69,7 +69,11 @@
 			database::query(
 				"update ". DB_TABLE_PREFIX ."newsletter_recipients
 				set subscribed = ". (!empty($this->data['subscribed']) ? 1 : 0) .",
-				email = '". database::input($this->data['email']) ."',
+					firstname = '". database::input($this->data['firstname']) ."',
+					lastname = '". database::input($this->data['lastname']) ."',
+					email = '". database::input($this->data['email']) ."',
+					language_code = ". (!empty($this->data['language_code']) ? "'". database::input($this->data['language_code']) ."'" : "null") .",
+					country_code = ". (!empty($this->data['country_code']) ? "'". database::input($this->data['country_code']) ."'" : "null") .",
 					ip_address = '". database::input($this->data['ip_address']) ."',
 					hostname = '". database::input($this->data['hostname']) ."',
 					user_agent = '". database::input($this->data['user_agent']) ."'

--- a/tests/campaign.php
+++ b/tests/campaign.php
@@ -1,0 +1,162 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		// Get the current auto increment ID - this will be used to revert the ID after the test
+		$auto_increment_id = database::query(
+			"SHOW TABLE STATUS LIKE '". DB_TABLE_PREFIX ."campaigns';"
+		)->fetch('Auto_increment');
+
+		// Start a MySQL transaction - so we can rollback the changes
+		database::query("start transaction;");
+
+		// Define some example data
+		$data = [
+			'name' => 'Test Campaign',
+			'valid_from' => date('Y-m-d H:i:s', strtotime('-1 day')),
+			'valid_to' => date('Y-m-d H:i:s', strtotime('+30 days')),
+		];
+
+		########################################################################
+		## Creating a new campaign
+		########################################################################
+
+		$campaign = new ent_campaign();
+		$campaign->data = f::array_update($campaign->data, $data);
+		$campaign->save();
+
+		if (!$campaign_id = $campaign->data['id']) {
+			throw new Exception('Failed to create campaign');
+		}
+
+		########################################################################
+		## Load and check the campaign
+		########################################################################
+
+		$campaign = new ent_campaign($campaign_id);
+
+		if ($campaign->data['id'] != $campaign_id) {
+			throw new Exception('Failed to load campaign');
+		}
+
+		if ($campaign->data['name'] != $data['name']) {
+			throw new Exception('Campaign name was not stored correctly');
+		}
+
+		########################################################################
+		## Update the campaign
+		########################################################################
+
+		$update_data = [
+			'name' => 'Updated Campaign',
+			'valid_from' => date('Y-m-d H:i:s', strtotime('+1 day')),
+			'valid_to' => date('Y-m-d H:i:s', strtotime('+60 days')),
+		];
+
+		$campaign->data = f::array_update($campaign->data, $update_data);
+		$campaign->save();
+
+		$campaign = new ent_campaign($campaign_id);
+
+		if ($campaign->data['name'] != $update_data['name']) {
+			throw new Exception('Campaign name was not updated correctly');
+		}
+
+		########################################################################
+		## Test campaign with product prices
+		########################################################################
+
+		// Find a product to associate with the campaign
+		$product = database::query(
+			"select id from ". DB_TABLE_PREFIX ."products
+			limit 1;"
+		)->fetch();
+
+		if ($product) {
+
+			$campaign->data['products'] = [
+				[
+					'id' => '',
+					'product_id' => $product['id'],
+					'customer_group_id' => '',
+					'geo_zone_id' => '',
+					'price' => [settings::get('store_currency_code') => '9.99'],
+				],
+			];
+
+			$campaign->save();
+
+			// Verify the campaign price was stored
+			$price = database::query(
+				"select * from ". DB_TABLE_PREFIX ."products_prices
+				where campaign_id = ". (int)$campaign_id ."
+				limit 1;"
+			)->fetch();
+
+			if (!$price) {
+				throw new Exception('Failed to store campaign product price');
+			}
+
+			// Update price
+			$campaign->data['products'][0]['price'] = [settings::get('store_currency_code') => '14.99'];
+			$campaign->save();
+
+			$price = database::query(
+				"select price from ". DB_TABLE_PREFIX ."products_prices
+				where campaign_id = ". (int)$campaign_id ."
+				limit 1;"
+			)->fetch('price');
+
+			$price_data = json_decode($price, true);
+
+			if (empty($price_data[settings::get('store_currency_code')]) || $price_data[settings::get('store_currency_code')] != '14.99') {
+				throw new Exception('Failed to update campaign product price');
+			}
+
+			// Remove product from campaign
+			$campaign->data['products'] = [];
+			$campaign->save();
+
+			$remaining = database::query(
+				"select count(*) as cnt from ". DB_TABLE_PREFIX ."products_prices
+				where campaign_id = ". (int)$campaign_id .";"
+			)->fetch('cnt');
+
+			if ($remaining != 0) {
+				throw new Exception('Failed to remove campaign product prices');
+			}
+		}
+
+		########################################################################
+		## Delete the campaign
+		########################################################################
+
+		$campaign->delete();
+
+		if (database::query(
+			"select * from ". DB_TABLE_PREFIX ."campaigns
+			where id = ". (int)$campaign_id ."
+			limit 1;"
+		)->num_rows) {
+			throw new Exception('Failed to delete campaign');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+
+		// Rollback changes to the database
+		database::query('rollback;');
+
+		// Revert the auto increment ID
+		database::query(
+			"ALTER TABLE ". DB_TABLE_PREFIX ."campaigns AUTO_INCREMENT = ". (int)$auto_increment_id .";"
+		);
+	}

--- a/tests/newsletter_recipient.php
+++ b/tests/newsletter_recipient.php
@@ -1,0 +1,122 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		// Get the current auto increment ID - this will be used to revert the ID after the test
+		$auto_increment_id = database::query(
+			"SHOW TABLE STATUS LIKE '". DB_TABLE_PREFIX ."newsletter_recipients';"
+		)->fetch('Auto_increment');
+
+		// Start a MySQL transaction - so we can rollback the changes
+		database::query("start transaction;");
+
+		// Define some example data
+		$data = [
+			'subscribed' => 1,
+			'email' => 'test-newsletter@example.com',
+			'firstname' => 'Test',
+			'lastname' => 'Subscriber',
+			'language_code' => 'en',
+			'country_code' => 'US',
+			'ip_address' => '127.0.0.1',
+			'hostname' => 'localhost',
+			'user_agent' => 'LiteCart Test Runner',
+		];
+
+		########################################################################
+		## Creating a new newsletter recipient
+		########################################################################
+
+		$recipient = new ent_newsletter_recipient();
+		$recipient->data = f::array_update($recipient->data, $data);
+		$recipient->save();
+
+		if (!$recipient_id = $recipient->data['id']) {
+			throw new Exception('Failed to create newsletter recipient');
+		}
+
+		########################################################################
+		## Load and check the recipient
+		########################################################################
+
+		$recipient = new ent_newsletter_recipient($recipient_id);
+
+		if ($recipient->data['id'] != $recipient_id) {
+			throw new Exception('Failed to load newsletter recipient by ID');
+		}
+
+		if ($recipient->data['email'] != $data['email']) {
+			throw new Exception('Recipient email was not stored correctly');
+		}
+
+		if ($recipient->data['firstname'] != $data['firstname']) {
+			throw new Exception('Recipient firstname was not stored correctly');
+		}
+
+		########################################################################
+		## Load by email address
+		########################################################################
+
+		$recipient_by_email = new ent_newsletter_recipient($data['email']);
+
+		if ($recipient_by_email->data['id'] != $recipient_id) {
+			throw new Exception('Failed to load newsletter recipient by email');
+		}
+
+		########################################################################
+		## Update the recipient
+		########################################################################
+
+		$update_data = [
+			'subscribed' => 0,
+			'email' => 'updated-newsletter@example.com',
+			'firstname' => 'Updated',
+			'lastname' => 'User',
+		];
+
+		$recipient->data = f::array_update($recipient->data, $update_data);
+		$recipient->save();
+
+		$recipient = new ent_newsletter_recipient($recipient_id);
+
+		if ($recipient->data['email'] != $update_data['email']) {
+			throw new Exception('Recipient email was not updated correctly');
+		}
+
+		if ($recipient->data['subscribed'] != 0) {
+			throw new Exception('Recipient subscribed status was not updated correctly');
+		}
+
+		########################################################################
+		## Delete the recipient
+		########################################################################
+
+		$recipient->delete();
+
+		if (database::query(
+			"select * from ". DB_TABLE_PREFIX ."newsletter_recipients
+			where id = ". (int)$recipient_id ."
+			limit 1;"
+		)->num_rows) {
+			throw new Exception('Failed to delete newsletter recipient');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+
+		// Rollback changes to the database
+		database::query('rollback;');
+
+		// Revert the auto increment ID
+		database::query(
+			"ALTER TABLE ". DB_TABLE_PREFIX ."newsletter_recipients AUTO_INCREMENT = ". (int)$auto_increment_id .";"
+		);
+	}


### PR DESCRIPTION
## Summary

Two new platform tests — and of course they found a bug on the way in.

| Entity | Tests | Bug Found |
|--------|-------|-----------|
| campaign | CRUD, product price association, price update, product removal | None |
| newsletter_recipient | CRUD, lookup by email, subscription toggle | `save()` missing 4 columns |

## Bug Fix

`ent_newsletter_recipient::save()` was missing `firstname`, `lastname`, `language_code`, and `country_code` in the UPDATE query. These columns exist in the table but were never written — any data entered would silently vanish on save.

## Test plan

- [x] CI green — 36/36 tests pass
- [ ] Verify newsletter recipients retain name and language/country after save