### PR TITLE
* Fix 3 variable name bugs in func_array and func_datetime

### DIFF
--- a/public_html/includes/functions/func_array.inc.php
+++ b/public_html/includes/functions/func_array.inc.php
@@ -70,7 +70,7 @@
 
 	// Return an array of values not defined by the given keys
 	function array_exclude(array $array, array $excluded_keys):array {
-		return array_diff_key($input, array_flip($excluded_keys));
+		return array_diff_key($array, array_flip($excluded_keys));
 	}
 
 	// Same as array_exclude(). Return an array of values not including any given keys
@@ -135,7 +135,7 @@
 		}
 
 		return array_filter($array, function($value) {
-			return is_array($v) ? !empty($v) : strlen(trim($v));
+			return is_array($value) ? !empty($value) : strlen(trim($value));
 		});
 	}
 

--- a/public_html/includes/functions/func_datetime.inc.php
+++ b/public_html/includes/functions/func_datetime.inc.php
@@ -242,7 +242,7 @@
 
 		$y = date('Y', $timestamp);
 		$m = date('m', $timestamp);
-		$d = date('m', $timestamp);
+		$d = date('d', $timestamp);
 
 		switch (true) {
 


### PR DESCRIPTION
## Summary

Three one-liner fixes found during unit test development.

| File | Bug | Fix |
|------|-----|-----|
| `func_array.inc.php:73` | `array_exclude()` uses `$input` (undefined) | `$array` |
| `func_array.inc.php:138` | `array_filter_recursive()` uses `$v` (undefined) | `$value` |
| `func_datetime.inc.php:245` | `datetime_last_by_interval()` uses `date('m')` (month) | `date('d')` (day) |

All three would cause PHP errors or wrong results when called.

## Test plan

- [x] CI green — 34/34 tests pass
- [ ] Verify `array_exclude()` filters correctly
- [ ] Verify `array_filter_recursive()` removes empty values
- [ ] Verify `datetime_last_by_interval()` returns correct day-based intervals