### PR TITLE
[v3] * Fix checkout flow: order persistence, payment selection, JS errors

### DIFF
--- a/public_html/frontend/pages/checkout/customer.inc.php
+++ b/public_html/frontend/pages/checkout/customer.inc.php
@@ -273,7 +273,6 @@
 			exit;
 
 		} catch(Exception $e) {
-			die($e->getMessage());
 			notices::add('errors', $e->getMessage());
 		}
 	}

--- a/public_html/frontend/pages/checkout/index.inc.php
+++ b/public_html/frontend/pages/checkout/index.inc.php
@@ -23,7 +23,6 @@
 
 		// Halt on no lines
 		if (empty($order->data['lines'])) {
-			var_dump($order);exit;
 			throw new Exception(t('error_order_appears_empty', 'The order appears empty'), 404);
 		}
 
@@ -111,7 +110,8 @@
 	}
 
 	if (!empty($order->shipping->selected)) {
-		$_POST['shipping_option'] = $order->shipping->selected;
+		if (!isset($_POST['confirm'])) $_POST['shipping_option'] = $order->shipping->selected;
+		$order->data['shipping_option'] = $order->shipping->selected;
 	}
 
 	// Prepare payment options
@@ -130,9 +130,11 @@
 	}
 
 	if (!empty($order->payment->selected)) {
-		$_POST['payment_option'] = $order->payment->selected;
+		if (!isset($_POST['confirm'])) $_POST['payment_option'] = $order->payment->selected;
+		$order->data['payment_option'] = $order->payment->selected;
 	}
 
+	$order->refresh_total();
 
 	// If Confirm Order button was pressed
 	if (isset($_POST['confirm'])) {
@@ -146,6 +148,19 @@
 			}
 
 			$session_order = &session::$data['checkout']['order'];
+
+			// Re-select shipping/payment from form POST data
+			if (!empty($_POST['shipping_option']['id'])) {
+				$session_order->shipping->select($_POST['shipping_option']['id'], $_POST);
+				$session_order->data['shipping_option'] = $session_order->shipping->selected;
+			}
+
+			if (!empty($_POST['payment_option']['id'])) {
+				$session_order->payment->select($_POST['payment_option']['id'], $_POST);
+				$session_order->data['payment_option'] = $session_order->payment->selected;
+			}
+
+			$session_order->refresh_total();
 
 			customer::log([
 				'type' => 'checkout_confirm',
@@ -172,8 +187,8 @@
 				exit;
 			}
 
-			$payment = new mod_payment();
-			if ($payment->options($session_order)) {
+			$payment = $session_order->payment;
+			if ($payment->options()) {
 
 				if (empty($payment->selected)) {
 					notices::add('errors', t('error_no_payment_method_selected', 'No payment method selected'));
@@ -194,15 +209,15 @@
 					];
 				}
 
-				if ($gateway = $payment->transfer($session_order, (string)document::ilink('checkout/process'))) {
+				$gateway = $payment->transfer($session_order, (string)document::ilink('checkout/process'));
 
-					if (!empty($gateway['error'])) {
-						notices::add('errors', $gateway['error']);
-						redirect(document::ilink('checkout/index'), 303);
-						exit;
-					}
+				if (!empty($gateway['error'])) {
+					notices::add('errors', $gateway['error']);
+					redirect(document::ilink('checkout/index'), 303);
+					exit;
+				}
 
-					if (!empty($gateway['method'])) {
+				if (!empty($gateway['method']) && !empty($gateway['action'])) {
 						switch (strtoupper($gateway['method'])) {
 
 							case 'POST':
@@ -249,11 +264,10 @@
 						}
 					}
 				}
-			}
 
-			$session_order->data['processable'] = true;
-			redirect(document::ilink('checkout/process'), 303);
-			exit;
+				$session_order->data['processable'] = true;
+				redirect(document::ilink('checkout/process'), 303);
+				exit;
 
 		} catch (Exception $e) {
 
@@ -319,14 +333,16 @@
 
 	$order = &session::$data['checkout']['order'];
 
-	if (!empty($shipping->data['selected'])) {
-		$order->data['shipping_option'] = $shipping->data['selected'];
-		$order->data['incoterm'] = $shipping->data['selected']['incoterm'];
+	if (!empty($order->shipping->selected['id'])) {
+		$order->data['shipping_option'] = $order->shipping->selected;
+		$order->data['incoterm'] = !empty($order->shipping->selected['incoterm']) ? $order->shipping->selected['incoterm'] : '';
 	}
 
-	if (!empty($payment->selected)) {
-		$order->data['payment_option'] = $payment->selected;
+	if (!empty($order->payment->selected['id'])) {
+		$order->data['payment_option'] = $order->payment->selected;
 	}
+
+	$order->refresh_total();
 
 	$order->data['processable'] = false; // Whether or not it is allowed to be processed in checkout/process
 

--- a/public_html/frontend/pages/checkout/payment.inc.php
+++ b/public_html/frontend/pages/checkout/payment.inc.php
@@ -1,0 +1,11 @@
+<?php
+
+  // Payment validation stub for checkout confirmation flow
+
+  if (empty(session::$data['checkout']['order'])) return;
+
+  $order = &session::$data['checkout']['order'];
+
+  if (empty($order->payment->selected['id'])) {
+    notices::add('errors', t('error_no_payment_method_selected', 'No payment method selected'));
+  }

--- a/public_html/frontend/pages/checkout/process.inc.php
+++ b/public_html/frontend/pages/checkout/process.inc.php
@@ -67,6 +67,7 @@
 	}
 
 	// Save order
+	$session_order = $order;
 	$order = new ent_order();
 
 	$fields = [
@@ -78,13 +79,16 @@
 		'weight_unit'
 	];
 
-	$order->data = array_replace($order->data, array_intersect_key($order->data, array_flip($fields)));
+	$order->data = array_replace($order->data, array_intersect_key($session_order->data, array_flip($fields)));
 	$order->data['currency_value'] = currency::$currencies[$order->data['currency_code']]['value'];
+	$order->data['display_prices_including_tax'] = !empty($session_order->data['display_prices_including_tax']);
 	$order->data['unread'] = true;
+	$order->shipping = $session_order->shipping;
+	$order->payment = $session_order->payment;
 
 	// Set items
-	foreach ($order->data['items'] as $item) {
-		$order->add_item($item);
+	foreach ($session_order->data['lines'] as $item) {
+		$order->add_line($item, !empty($item['stock_items']) ? $item['stock_items'] : []);
 	}
 
 	// Set order status id
@@ -112,6 +116,7 @@
 		$order->data['date_paid'] = $result['date_paid'];
 	}
 
+	$order->refresh_total();
 	$order->save();
 
 	customer::log([
@@ -130,27 +135,27 @@
 	// Clean up cart
 	cart::clear();
 
-	session::$data['checkout']['order'] = null;
-
 	// Send order confirmation email
 	if (settings::get('send_order_confirmation')) {
 		$bccs = [];
 
-		if (settings::get('send_order_copy_email')) {
-			foreach (preg_split('#[\s;,]+#', settings::get('send_order_copy_email')) as $email) {
+		if (settings::get('email_order_copy')) {
+			foreach (preg_split('#[\s;,]+#', settings::get('email_order_copy')) as $email) {
 				if (empty($email)) continue;
 				$bccs[] = $email;
 			}
 		}
 
-		$order->send_order_copy_email($order->data['customer']['email'], $bccs, $order->data['language_code']);
+		$order->send_order_copy($order->data['customer']['email'], [], $bccs, $order->data['language_code']);
 	}
 
 	// Run after process operations
 	$order->shipping->after_process($order);
 	$order->payment->after_process($order);
 
-	$order_modules->after_process($order);
+	$redirect_url = document::ilink('checkout/success', ['order_id' => $order->data['id'], 'public_key' => $order->data['public_key']]);
 
-	redirect(document::ilink('checkout/success', ['order_id' => $order->data['id'], 'public_key' => $order->data['public_key']]), 303);
+	session::$data['checkout']['order'] = null;
+
+	redirect($redirect_url, 303);
 	exit;

--- a/public_html/frontend/pages/checkout/shipping.inc.php
+++ b/public_html/frontend/pages/checkout/shipping.inc.php
@@ -1,0 +1,11 @@
+<?php
+
+  // Shipping validation stub for checkout confirmation flow
+
+  if (empty(session::$data['checkout']['order'])) return;
+
+  $order = &session::$data['checkout']['order'];
+
+  if (empty($order->shipping->selected['id'])) {
+    notices::add('errors', t('error_no_shipping_method_selected', 'No shipping method selected'));
+  }

--- a/public_html/frontend/pages/checkout/summary.inc.php
+++ b/public_html/frontend/pages/checkout/summary.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+  // Summary validation stub for checkout confirmation flow
+
+  if (empty(session::$data['checkout']['order'])) return;
+
+  $order = &session::$data['checkout']['order'];
+
+  $order->refresh_total();

--- a/public_html/frontend/templates/default/pages/checkout/customer.inc.php
+++ b/public_html/frontend/templates/default/pages/checkout/customer.inc.php
@@ -98,14 +98,14 @@
 					<div class="col-sm-6">
 						<label class="form-group">
 							<div class="form-label"><?php echo t('title_postcode', 'Postal Code'); ?></div>
-							<?php echo f::form_input_text('customer[postcode]', true); ?>
+							<?php echo f::form_input_text('customer[postcode]', true, 'required'); ?>
 						</label>
 					</div>
 
 					<div class="col-sm-6">
 						<label class="form-group">
 							<div class="form-label"><?php echo t('title_city', 'City'); ?></div>
-							<?php echo f::form_input_text('customer[city]', true); ?>
+							<?php echo f::form_input_text('customer[city]', true, 'required'); ?>
 						</label>
 					</div>
 				</div>
@@ -197,14 +197,14 @@
 							<div class="col-sm-6">
 								<label class="form-group">
 									<div class="form-label"><?php echo t('title_postcode', 'Postal Code'); ?></div>
-									<?php echo f::form_input_text('shipping_address[postcode]', true); ?>
+									<?php echo f::form_input_text('shipping_address[postcode]', true, 'required'); ?>
 								</label>
 							</div>
 
 							<div class="col-sm-6">
 								<label class="form-group">
 									<div class="form-label"><?php echo t('title_city', 'City'); ?></div>
-									<?php echo f::form_input_text('shipping_address[city]', true); ?>
+									<?php echo f::form_input_text('shipping_address[city]', true, 'required'); ?>
 								</label>
 							</div>
 						</div>

--- a/public_html/frontend/templates/default/pages/checkout/index.inc.php
+++ b/public_html/frontend/templates/default/pages/checkout/index.inc.php
@@ -283,7 +283,7 @@
 
 	$checkout.on('update', function(e, task) {
 
-		var updateQueue = this.data('updateQueue');
+		var updateQueue = $checkout.data('updateQueue');
 
 		if (task && task.component) {
 			updateQueue = jQuery.grep(updateQueue, function(tasks) {
@@ -292,16 +292,16 @@
 
 			updateQueue.push(task);
 
-			this.data('updateQueue', updateQueue);
+			$checkout.data('updateQueue', updateQueue);
 		}
 
-		if (this.prop('updateLock')) return;
-		if (this.data('updateQueue').length == 0) return;
+		if ($checkout.prop('updateLock')) return;
+		if ($checkout.data('updateQueue').length == 0) return;
 
-		this.prop('updateLock', true);
+		$checkout.prop('updateLock', true);
 
 		var task = updateQueue.shift();
-		this.data('updateQueue', updateQueue);
+		$checkout.data('updateQueue', updateQueue);
 
 		if (!$('body > .loader-wrapper').length) {
 
@@ -342,6 +342,12 @@
 		if (task.component == 'summary') {
 			var comments = $(':input[name="comments"]').val();
 			var terms_agreed = $(':input[name="terms_agreed"]').prop('checked');
+		}
+
+		// Prepend CSRF token to POST data
+		if (task.data) {
+			var csrf = $('input[name="csrf_token"]').serialize();
+			if (csrf) task.data = csrf + '&' + task.data;
 		}
 
 		$.ajax({
@@ -392,9 +398,9 @@
 	$('input[name="shipping_option[id]"]').on('change', function(e) {
 
 		$('input[name="shipping_option[id]"]:not(:checked) + .option :input').prop('disabled', true);
-		this.next('.option').find(':input').prop('disabled', false);
+		$(this).next('.option').find(':input').prop('disabled', false);
 
-		let formdata = this.closest('.option-wrapper :input').serialize();
+		let formdata = $(this).closest('.wrapper').find(':input').serialize();
 
 		$checkout
 			.trigger('update', [{component: 'shipping', data: formdata + '&select_shipping=true', refresh: false}])
@@ -408,9 +414,9 @@
 	$(':input[name="payment_option[id]"]').on('change', function(e) {
 
 		$('input[name="payment_option[id]"]:not(:checked) + .option :input').prop('disabled', true);
-		this.next('.option').find(':input').prop('disabled', false);
+		$(this).next('.option').find(':input').prop('disabled', false);
 
-		let formdata = this.closest('.option-wrapper :input').serialize();
+		let formdata = $(this).closest('.wrapper').find(':input').serialize();
 
 		$checkout
 			.trigger('update', [{component: 'payment', data: formdata + '&select_payment=true', refresh: false}])
@@ -419,8 +425,8 @@
 
 	// Display remaining characters
 	$('textarea[name="comments"][maxlength]').on('input', function() {
-		let remaining = this.attr('maxlength') - this.val().length;
-		this.closest('.comments').find('.remaining').text(remaining);
+		let remaining = $(this).attr('maxlength') - $(this).val().length;
+		$(this).closest('.comments').find('.remaining').text(remaining);
 	});
 
 	// Replace submit button with spinner when form is submitting

--- a/public_html/includes/entities/ent_order.inc.php
+++ b/public_html/includes/entities/ent_order.inc.php
@@ -54,7 +54,7 @@
 				'currency_value' => currency::$selected['value'],
 				'language_code' => language::$selected['code'],
 				'incoterm' => settings::get('default_incoterm'),
-				'items' => [],
+				'lines' => [],
 				'comments' => [],
 				'subtotal' => 0,
 				'subtotal_tax' => 0,
@@ -76,6 +76,7 @@
 
 			$this->data['payment_due'] = &$this->data['total']; // Backwards compatibility <3.0.0
 			$this->data['tax_total'] = &$this->data['total_tax']; // Backwards compatibility <3.0.0
+			$this->data['items'] = &$this->data['lines']; // Alias: add_line() writes to lines, checkout reads items
 
 			$this->previous = $this->data;
 		}
@@ -224,8 +225,8 @@
 
 				database::query(
 					"insert into ". DB_TABLE_PREFIX ."orders
-					(created_at)
-					values ('". ($this->data['created_at'] = date('Y-m-d H:i:s')) ."');"
+					(public_key, created_at)
+					values ('". database::input($this->data['public_key']) ."', '". ($this->data['created_at'] = date('Y-m-d H:i:s')) ."');"
 				);
 
 				$this->data['id'] = database::insert_id();
@@ -267,14 +268,16 @@
 					shipping_zone_code = '". database::input($this->data['customer']['shipping_address']['zone_code']) ."',
 					shipping_phone = '". database::input($this->data['customer']['shipping_address']['phone']) ."',
 					shipping_email = '". database::input($this->data['customer']['shipping_address']['email']) ."',
-					shipping_option_id = '". (!empty($this->shipping->selected['id']) ? database::input($this->data['shipping_option']['id']) : '') ."',
-					shipping_option_name = '". (!empty($this->shipping->selected['id']) ? database::input($this->shipping->selected['name']) : '') ."',
-					shipping_option_userdata = '". (!empty($this->shipping->selected['userdata']) ? database::input(f::format_json($this->data['shipping_option']['userdata'])) : '') ."',
+					shipping_option_id = '". (!empty($this->data['shipping_option']['id']) ? database::input($this->data['shipping_option']['id']) : '') ."',
+					shipping_option_name = '". (!empty($this->data['shipping_option']['name']) ? database::input($this->data['shipping_option']['name']) : '') ."',
+					shipping_option_fee = ". (float)(!empty($this->data['shipping_option']['fee']) ? $this->data['shipping_option']['fee'] : 0) .",
+					shipping_option_userdata = '". (!empty($this->data['shipping_option']['userdata']) ? database::input(f::format_json($this->data['shipping_option']['userdata'])) : '') ."',
 					shipping_purchase_cost = ". (float)$this->data['shipping_purchase_cost'] .",
 					shipping_tracking_id = '". database::input($this->data['shipping_tracking_id']) ."',
 					shipping_tracking_url = '". database::input($this->data['shipping_tracking_url']) ."',
 					payment_option_id = '". (!empty($this->data['payment_option']['id']) ? database::input($this->data['payment_option']['id']) : '') ."',
 					payment_option_name = '". (!empty($this->data['payment_option']['name']) ? database::input($this->data['payment_option']['name']) : '') ."',
+					payment_option_fee = ". (float)(!empty($this->data['payment_option']['fee']) ? $this->data['payment_option']['fee'] : 0) .",
 					payment_option_userdata = '". (!empty($this->data['payment_option']['userdata']) ? database::input(f::format_json($this->data['payment_option']['userdata'])) : '') ."',
 					payment_transaction_id = '". database::input($this->data['payment_transaction_id']) ."',
 					payment_transaction_fee = ". (float)$this->data['payment_transaction_fee'] .",
@@ -540,6 +543,16 @@
 				$this->data['total'] += ($item['price'] - (float)$item['discount']) * (float)$item['quantity'];
 				$this->data['total_tax'] += ((float)$item['tax'] - (float)$item['discount_tax']) * (float)$item['quantity'];
 				$this->data['weight_total'] += (float)weight::convert($item['weight'], $item['weight_unit'], $this->data['weight_unit']) * abs($item['quantity']);
+			}
+
+			// Add shipping fee
+			if (!empty($this->data['shipping_option']['fee'])) {
+				$this->data['total'] += (float)$this->data['shipping_option']['fee'];
+			}
+
+			// Add payment fee
+			if (!empty($this->data['payment_option']['fee'])) {
+				$this->data['total'] += (float)$this->data['payment_option']['fee'];
 			}
 		}
 

--- a/public_html/includes/modules/mod_payment.inc.php
+++ b/public_html/includes/modules/mod_payment.inc.php
@@ -119,6 +119,51 @@
 			return $this->_cache[$checksum]['options'];
 		}
 
+		public function receipt($order) {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'receipt')) return;
+
+			return $this->modules[$this->selected['module_id']]->receipt($order);
+		}
+
+		public function after_process($order) {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'after_process')) return;
+
+			return $this->modules[$this->selected['module_id']]->after_process($order);
+		}
+
+		public function pre_check($order) {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'pre_check')) return;
+
+			return $this->modules[$this->selected['module_id']]->pre_check($order);
+		}
+
+		public function transfer($order, $success_url='', $cancel_url='') {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'transfer')) return;
+
+			return $this->modules[$this->selected['module_id']]->transfer($order, $success_url, $cancel_url);
+		}
+
+		public function verify($order) {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'verify')) return;
+
+			return $this->modules[$this->selected['module_id']]->verify($order);
+		}
+
 		public function cheapest() {
 
 			if (empty($this->_options)) {

--- a/public_html/includes/modules/mod_shipping.inc.php
+++ b/public_html/includes/modules/mod_shipping.inc.php
@@ -121,6 +121,15 @@
 			return $this->_cache[$checksum]['options'];
 		}
 
+		public function after_process($order) {
+
+			if (empty($this->selected['module_id'])) return;
+			if (empty($this->modules[$this->selected['module_id']])) return;
+			if (!method_exists($this->modules[$this->selected['module_id']], 'after_process')) return;
+
+			return $this->modules[$this->selected['module_id']]->after_process($order);
+		}
+
 		public function cheapest($order) {
 
 			if (empty($this->_options)) {

--- a/public_html/includes/modules/shipping/sm_flat_rate.inc.php
+++ b/public_html/includes/modules/shipping/sm_flat_rate.inc.php
@@ -1,0 +1,98 @@
+<?php
+
+  class sm_flat_rate extends abs_module {
+
+    public $id = __CLASS__;
+    public $name = 'Flat Rate';
+    public $description = '';
+    public $author = 'Wachhund';
+    public $version = '1.0';
+    public $website = '';
+
+    public function __construct() {
+      $this->name = t(__CLASS__.':title_flat_rate', 'Flat Rate');
+    }
+
+    public function options($items, $subtotal, $tax, $currency_code, $customer) {
+
+      if (empty($this->settings['status'])) return;
+
+      if (!empty($this->settings['geo_zones'])) {
+        if (!reference::country($customer['shipping_address']['country_code'])->in_geo_zone($this->settings['geo_zones'], $customer['shipping_address'])) return;
+      }
+
+      return [
+        [
+          'id' => 'flat_rate',
+          'icon' => $this->settings['icon'],
+          'name' => $this->settings['name'] ?: $this->name,
+          'description' => $this->settings['description'] ?: '',
+          'fields' => '',
+          'fee' => (float)$this->settings['fee'],
+          'tax_class_id' => $this->settings['tax_class_id'],
+        ],
+      ];
+    }
+
+    function settings() {
+
+      return [
+        [
+          'key' => 'status',
+          'default_value' => '0',
+          'title' => t(__CLASS__.':title_status', 'Status'),
+          'description' => t(__CLASS__.':description_status', 'Enables or disables the module.'),
+          'function' => 'toggle("e/d")',
+        ],
+        [
+          'key' => 'name',
+          'default_value' => 'Standard Shipping',
+          'title' => t(__CLASS__.':title_name', 'Name'),
+          'description' => t(__CLASS__.':description_name', 'The name displayed to the customer.'),
+          'function' => 'text()',
+        ],
+        [
+          'key' => 'description',
+          'default_value' => '',
+          'title' => t(__CLASS__.':title_description', 'Description'),
+          'description' => t(__CLASS__.':description_description', 'A short description displayed to the customer.'),
+          'function' => 'text()',
+        ],
+        [
+          'key' => 'icon',
+          'default_value' => '',
+          'title' => t(__CLASS__.':title_icon', 'Icon'),
+          'description' => t(__CLASS__.':description_icon', 'Path to an image to be displayed.'),
+          'function' => 'text()',
+        ],
+        [
+          'key' => 'fee',
+          'default_value' => '0',
+          'title' => t(__CLASS__.':title_fee', 'Shipping Fee'),
+          'description' => t(__CLASS__.':description_fee', 'The flat rate shipping fee.'),
+          'function' => 'decimal()',
+        ],
+        [
+          'key' => 'tax_class_id',
+          'default_value' => '',
+          'title' => t(__CLASS__.':title_tax_class', 'Tax Class'),
+          'description' => t(__CLASS__.':description_tax_class', 'The tax class for the shipping fee.'),
+          'function' => 'tax_class()',
+        ],
+        [
+          'key' => 'geo_zones[]',
+          'default_value' => '',
+          'title' => t('title_geo_zone_limitation', 'Geo Zone Limitation'),
+          'description' => t('modules:description_geo_zone', 'Limit this module to the selected geo zone. Otherwise, leave it blank.'),
+          'function' => 'geo_zone()',
+        ],
+        [
+          'key' => 'priority',
+          'default_value' => '0',
+          'title' => t('title_priority', 'Priority'),
+          'description' => t('modules:description_priority', 'Process this module in the given priority order.'),
+          'function' => 'number()',
+        ],
+      ];
+    }
+  }


### PR DESCRIPTION
Closes #435

Took a day off with friends, came back, tried to buy a rubber duck. The checkout had other plans — 30+ bugs between cart and success page. Spent the weekend untangling them.

## Summary

The v3 checkout was non-functional end-to-end. Every step from cart to order success had at least one fatal error, silent data loss, or logic bug. This patch makes the complete flow work: Cart → Customer Details → Checkout → Payment → Order Success.

### Order Data Loss (the big one)

`process.inc.php` created a `new ent_order()` and then read its own empty data back via `array_intersect_key`. The session order with all customer/item data was overwritten and lost.

| What | Before | After |
|------|--------|-------|
| Customer data in saved order | Empty | Correct |
| Order line items | Missing | Saved to DB |
| Shipping option + fee | Empty, 0.00 | Saved to DB |
| Payment option + fee | Empty, 0.00 | Saved to DB |
| Order total | Items only | Items + shipping + payment fees |

### Payment Selection

`mod_payment` and `mod_shipping` had no method delegation — `transfer()`, `verify()`, `receipt()`, `after_process()`, `pre_check()` were all undefined. Added delegation pattern matching the existing `select()` approach.

The confirm flow created `new mod_payment()` without order context, so `options()` always returned empty. Now uses `$session_order->payment` which has the cart data.

Payment selection from the form radio was overwritten by auto-select (cheapest) before the confirm block could read it. Now preserves `$_POST` when `confirm` is set.

### Checkout Template JS

Every jQuery event handler used `this.data()`, `this.next()`, `this.prop()` — but inside handlers, `this` is a raw DOM element, not a jQuery object. Fixed 12 occurrences.

AJAX POST requests were blocked by CSRF protection (403) because the token field sits outside the serialized `.wrapper` divs. Now prepends `csrf_token` to every AJAX POST.

### Other Fixes

| File | Fix |
|------|-----|
| `process.inc.php` | `send_order_copy_email()` → `send_order_copy()`, setting `send_order_copy_email` → `email_order_copy` |
| `process.inc.php` | Session cleanup moved after email send (was nullifying `$order` before use) |
| `process.inc.php` | Removed undefined `$order_modules->after_process()` |
| `checkout/index.inc.php` | Removed `var_dump($order);exit;` debug statement |
| `checkout/index.inc.php` | Check both `method` AND `action` in gateway response — CoD returns empty values |
| `customer.inc.php` | Removed `die()` in catch block, added `required` to postcode/city fields |
| `ent_order` | `items`/`lines` reference alias, `public_key` in INSERT, fee columns in `save()` |

### Included: sm_flat_rate shipping module

A simple flat-rate shipping module is included to make the checkout flow testable without complex zone/weight configuration. Can be removed before release if desired — it was essential for end-to-end testing.

### Included: Checkout validation stubs

`shipping.inc.php`, `payment.inc.php`, `summary.inc.php` — these are `include_once`d during order confirmation but didn't exist. Minimal stubs that validate selection and refresh totals.

## Known Issues

These are display-only — the data is correctly saved and processed during payment:

- **Payment fee not reflected in displayed total** — switching payment method (e.g. SumUp → CoD) doesn't update the total on the checkout page until a full page reload. The correct total including all fees is used for the actual payment and saved order.
- **Shipping/payment fees not itemized in Order Summary** — fees are included in the total but not shown as separate rows in the summary table on the checkout page.
- **Order Copy (printable invoice) incomplete** — line items, shipping, and payment details are not yet rendered in the order copy template. This is the next item to address.

## Test plan

- [x] Add product to cart, proceed through checkout as guest
- [x] Customer details: postcode and city show required asterisk
- [x] Checkout page: shipping option displayed and selected
- [x] Checkout page: payment options displayed, selection works
- [x] Checkout page: total includes shipping fee
- [x] Confirm with payment module (e.g. CoD): order created with correct data
- [x] Order success page shows correct total
- [ ] No `var_dump` output, no JS errors in console