### PR TITLE
[v3] * Fix syntax error in Data Studio import

### DIFF
--- a/public_html/backend/apps/data_studio/import.inc.php
+++ b/public_html/backend/apps/data_studio/import.inc.php
@@ -199,7 +199,7 @@
 					];
 
 					$class_name = 'ent_' . $entity;
-					$properties = array_keys(f::array_flatten(new $class_name()->data));
+					$properties = array_keys(f::array_flatten((new $class_name())->data));
 
 					break;
 


### PR DESCRIPTION
Spotted this one in CI — the new Data Studio is cool, just needs some parens.

## Summary

`new $class_name()->data` is a parse error on PHP < 8.4. Wrapping the instantiation in parentheses fixes it: `(new $class_name())->data`.

| File | Line | Fix |
|------|------|-----|
| `backend/apps/data_studio/import.inc.php` | 202 | `new $class_name()->data` → `(new $class_name())->data` |

## Test plan

- [x] CI passes (PHP lint)
- [x] Data Studio import still works on PHP 8.3