### PR TITLE
[v3] + Category-wide percentage discounts

### DIFF
--- a/public_html/backend/apps/catalog/edit_category.inc.php
+++ b/public_html/backend/apps/catalog/edit_category.inc.php
@@ -64,6 +64,10 @@
 				'synonyms',
 				'filters',
 				'priority',
+				'discount_percent',
+				'discount_valid_from',
+				'discount_valid_to',
+				'discount_stacking',
 			] as $field) {
 				if (isset($_POST[$field])) {
 					$category->data[$field] = $_POST[$field];
@@ -178,6 +182,35 @@
 								<div class="form-label"><?php echo t('title_priority', 'Priority'); ?></div>
 								<?php echo f::form_input_number('priority', true); ?>
 							</label>
+
+							<fieldset style="margin-top: 15px; padding: 15px; border: 1px solid var(--border-color); border-radius: 5px;">
+								<legend style="font-weight: bold; padding: 0 5px;"><?php echo t('title_discount', 'Discount'); ?></legend>
+
+								<label class="form-group">
+									<div class="form-label"><?php echo t('title_discount_percent', 'Discount (%)'); ?></div>
+									<?php echo f::form_input_number('discount_percent', true, 'min="0" max="100" step="0.01"'); ?>
+								</label>
+
+								<div class="grid">
+									<div class="col-md-6">
+										<label class="form-group">
+											<div class="form-label"><?php echo t('title_valid_from', 'Valid From'); ?></div>
+											<?php echo f::form_input_datetime('discount_valid_from', true); ?>
+										</label>
+									</div>
+									<div class="col-md-6">
+										<label class="form-group">
+											<div class="form-label"><?php echo t('title_valid_to', 'Valid To'); ?></div>
+											<?php echo f::form_input_datetime('discount_valid_to', true); ?>
+										</label>
+									</div>
+								</div>
+
+								<label class="form-group">
+									<div class="form-label"><?php echo t('title_discount_stacking', 'Stackable With Discount Codes'); ?></div>
+									<?php echo f::form_toggle('discount_stacking', 'y/n', true); ?>
+								</label>
+							</fieldset>
 						</div>
 
 						<div class="col-md-4">

--- a/public_html/frontend/pages/product.inc.php
+++ b/public_html/frontend/pages/product.inc.php
@@ -232,7 +232,9 @@
 	}
 
 	// Sticker
-	if (!empty($product->campaign['price']) && $product->price > 0 && $product->campaign['price'] > 0) {
+	if ($product->category_discount > 0) {
+		$_page->snippets['sticker'] = '<div class="sticker sale">-'. (int)$product->category_discount .'%</div>';
+	} else if (!empty($product->campaign['price']) && $product->price > 0 && $product->campaign['price'] > 0) {
 		$percentage = round(($product->price - $product->campaign['price']) / $product->price * 100);
 		$_page->snippets['sticker'] = '<div class="sticker sale">'. t('sticker_sale', 'Sale') .' -'. $percentage .'%</div>';
 	} else if ($product->created_at > date('Y-m-d', strtotime('-'.settings::get('new_products_max_age')))) {

--- a/public_html/includes/entities/ent_category.inc.php
+++ b/public_html/includes/entities/ent_category.inc.php
@@ -136,6 +136,10 @@
 					synonyms = '". database::input(f::format_json($this->data['synonyms'])) ."',
 					keywords = '". database::input($this->data['keywords']) ."',
 					priority = ". (int)$this->data['priority'] .",
+					discount_percent = ". min(100, max(0, (float)$this->data['discount_percent'])) .",
+					discount_valid_from = ". (!empty($this->data['discount_valid_from']) ? "'". database::input($this->data['discount_valid_from']) ."'" : "null") .",
+					discount_valid_to = ". (!empty($this->data['discount_valid_to']) ? "'". database::input($this->data['discount_valid_to']) ."'" : "null") .",
+					discount_stacking = ". (int)$this->data['discount_stacking'] .",
 					updated_at = '". ($this->data['updated_at'] = date('Y-m-d H:i:s')) ."'
 				where id = ". (int)$this->data['id'] ."
 				limit 1;"

--- a/public_html/includes/functions/func_catalog.inc.php
+++ b/public_html/includes/functions/func_catalog.inc.php
@@ -241,7 +241,9 @@
 
 		$query = (
 			"select p.*, b.id as brand_id, b.name as brand_name,
-				pp.regular_price, pp.final_price,
+				pp.regular_price,
+				if(cd.category_discount is not null, round(pp.final_price * (1 - cd.category_discount / 100), 4), pp.final_price) as final_price,
+				cd.category_discount,
 				ifnull(pso.num_stock_options, 0) as num_stock_options, pso.total_quantity, pso.quantity_available,
 				pa.attributes, ss.hidden
 
@@ -323,6 +325,17 @@
 			) pso on (pso.product_id = p.id)
 
 			left join ". DB_TABLE_PREFIX ."sold_out_statuses ss on (p.sold_out_status_id = ss.id)
+
+			left join (
+				select ptc.product_id, max(c.discount_percent) as category_discount
+				from ". DB_TABLE_PREFIX ."categories c
+				join ". DB_TABLE_PREFIX ."products_to_categories ptc on (ptc.category_id = c.id)
+				where c.discount_percent > 0
+				and c.status
+				and (c.discount_valid_from is null or c.discount_valid_from <= '". date('Y-m-d H:i:s') ."')
+				and (c.discount_valid_to is null or c.discount_valid_to >= '". date('Y-m-d H:i:s') ."')
+				group by ptc.product_id
+			) cd on (cd.product_id = p.id)
 
 			where (
 				(ifnull(pso.num_stock_options, 0) = 0 or pso.quantity_available > 0 or ss.hidden != 1)

--- a/public_html/includes/functions/func_draw.inc.php
+++ b/public_html/includes/functions/func_draw.inc.php
@@ -331,7 +331,9 @@
 		$listing_product = new ent_view('app://frontend/templates/'.settings::get('template').'/partials/listing_product.inc.php');
 
 		$sticker = '';
-		if ($product['final_price'] && $product['final_price'] < $product['regular_price']) {
+		if (!empty($product['category_discount'])) {
+			$sticker = '<div class="sticker sale" title="'. t('title_on_sale', 'On Sale') .'">-'. (int)$product['category_discount'] .'%</div>';
+		} else if ($product['final_price'] && $product['final_price'] < $product['regular_price']) {
 			$sticker = '<div class="sticker sale" title="'. t('title_on_sale', 'On Sale') .'">'. t('sticker_sale', 'Sale') .'</div>';
 		} else if ($product['created_at'] > date('Y-m-d', strtotime('-'.settings::get('new_products_max_age')))) {
 			$sticker = '<div class="sticker new" title="'. t('title_new', 'New') .'">'. t('sticker_new', 'New') .'</div>';

--- a/public_html/includes/references/ref_category.inc.php
+++ b/public_html/includes/references/ref_category.inc.php
@@ -22,6 +22,24 @@
 
 			switch($field) {
 
+				case 'active_discount':
+
+					$this->_data['active_discount'] = null;
+
+					if (empty($this->discount_percent) || $this->discount_percent <= 0) break;
+
+					if (!empty($this->discount_valid_from) && $this->discount_valid_from > date('Y-m-d H:i:s')) break;
+					if (!empty($this->discount_valid_to) && $this->discount_valid_to < date('Y-m-d H:i:s')) break;
+
+					$this->_data['active_discount'] = [
+						'percent' => (float)$this->discount_percent,
+						'valid_from' => $this->discount_valid_from,
+						'valid_to' => $this->discount_valid_to,
+						'stacking' => (bool)$this->discount_stacking,
+					];
+
+					break;
+
 				case 'parent':
 
 					$this->_data['parent'] = false;

--- a/public_html/includes/references/ref_product.inc.php
+++ b/public_html/includes/references/ref_product.inc.php
@@ -134,7 +134,28 @@
 
 				break;
 
-			case 'categories':
+			case 'category_discount':
+
+					$this->_data['category_discount'] = null;
+
+					$discount = database::query(
+						"select max(c.discount_percent) as discount_percent
+						from ". DB_TABLE_PREFIX ."categories c
+						join ". DB_TABLE_PREFIX ."products_to_categories ptc on (ptc.category_id = c.id)
+						where ptc.product_id = ". (int)$this->_data['id'] ."
+						and c.discount_percent > 0
+						and (c.discount_valid_from is null or c.discount_valid_from <= '". date('Y-m-d H:i:s') ."')
+						and (c.discount_valid_to is null or c.discount_valid_to >= '". date('Y-m-d H:i:s') ."')
+						limit 1;"
+					)->fetch('discount_percent');
+
+					if ($discount > 0) {
+						$this->_data['category_discount'] = (float)$discount;
+					}
+
+					break;
+
+				case 'categories':
 
 					$this->_data['categories'] = [];
 
@@ -229,6 +250,14 @@
 
 						if ($customer_price && $customer_price < $this->_data['final_price']) {
 							$this->_data['final_price'] = $customer_price;
+						}
+					}
+
+					// Category Discount (highest active discount wins)
+					if ($this->category_discount > 0) {
+						$discounted_price = $this->_data['final_price'] * (1 - $this->category_discount / 100);
+						if ($discounted_price < $this->_data['final_price']) {
+							$this->_data['final_price'] = round($discounted_price, 4);
 						}
 					}
 

--- a/public_html/install/migrations/3.0.0.inc.php
+++ b/public_html/install/migrations/3.0.0.inc.php
@@ -1289,3 +1289,14 @@
 		drop column `length_unit`,
 		drop column `quantity`;"
 	);
+
+	// Category discounts
+	if (!database::query("show columns from ". DB_TABLE_PREFIX ."categories like 'discount_percent';")->num_rows) {
+		database::query(
+			"alter table ". DB_TABLE_PREFIX ."categories
+			add column `discount_percent` decimal(5,2) not null default 0 after `priority`,
+			add column `discount_valid_from` datetime default null after `discount_percent`,
+			add column `discount_valid_to` datetime default null after `discount_valid_from`,
+			add column `discount_stacking` tinyint(1) unsigned not null default 1 after `discount_valid_to`;"
+		);
+	}

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -636,6 +636,25 @@
 					"length": 11,
 					"default": 0
 				},
+				"discount_percent": {
+					"type": "DECIMAL",
+					"length": "5,2",
+					"default": 0
+				},
+				"discount_valid_from": {
+					"type": "DATETIME",
+					"nullable": true
+				},
+				"discount_valid_to": {
+					"type": "DATETIME",
+					"nullable": true
+				},
+				"discount_stacking": {
+					"type": "TINYINT",
+					"length": 1,
+					"unsigned": true,
+					"default": 1
+				},
 				"updated_at": {
 					"type": "TIMESTAMP",
 					"default": "CURRENT_TIMESTAMP",


### PR DESCRIPTION
This one's been on the community wishlist for a while — merchants can now slap a discount on an entire category without touching individual products.

## Summary

| What | Details |
|------|---------|
| **New fields on categories** | `discount_percent` (0-100%), `discount_valid_from`, `discount_valid_to`, `discount_stacking` |
| **Price pipeline** | Applied after campaign + customer group prices as percentage reduction on `final_price` |
| **Multiple categories** | Highest active discount wins (`max()`) |
| **Validity** | Optional date range — NULL means always active. Expired/future discounts have no effect |
| **Frontend** | Strikethrough price + "-X%" badge on category listings and product pages |
| **Admin** | New "Discount" fieldset on category edit form |
| **Migration** | ALTER TABLE for existing installations (idempotent) |

### Files changed (9)

| Layer | File | Change |
|-------|------|--------|
| Schema | `install/structure.json` | 4 new columns on `categories` |
| Migration | `install/migrations/3.0.0.inc.php` | ALTER TABLE (idempotent) |
| Entity | `entities/ent_category.inc.php` | `save()` writes discount fields, server-side 0-100% clamp |
| Reference | `references/ref_category.inc.php` | Lazy property `active_discount` with validity check |
| Reference | `references/ref_product.inc.php` | `final_price` applies category discount; lazy property `category_discount` |
| Catalog query | `functions/func_catalog.inc.php` | JOIN category discounts, apply to `final_price` in SQL |
| Sticker | `functions/func_draw.inc.php` | "-X%" badge for category discounts |
| Product page | `frontend/pages/product.inc.php` | "-X%" sticker on product detail |
| Admin | `backend/apps/catalog/edit_category.inc.php` | Discount fieldset (percent, dates, stacking toggle) |

### Known limitations (v1)

- **Stacking with discount codes:** The `discount_stacking` field is stored but not enforced at checkout — discount codes are an add-on, so integration depends on the add-on's API. The field is ready for when that integration makes sense.
- **Order line tracking:** The discounted price is saved correctly in orders, but the discount source (category vs campaign) is not yet written to `orders_lines.userdata`. Planned for a follow-up.
- **Campaign + category:** Both discounts compound (category % applied on top of campaign price). This is more generous to customers but could give unexpectedly deep discounts.

### Use case

A merchant wants to run a Black Friday sale on their own products (grouped in a specific category), while excluding dealer products in other categories. No coupon code needed — the discount applies automatically with a visible "-20%" badge.

**Source:** Community forum request ([tomydevon, Nov 2025](https://www.litecart.net/de/forums/5/feature-requests-and-new-ideas/24435/discount-on-an-entire-product-category-rather-than-on-individual)). Tim noted it's been requested multiple times.

## Test plan

- [ ] Create a category, set 20% discount, save
- [ ] Verify products in that category show strikethrough price + "-20%" badge on category page
- [ ] Verify same display on product detail page
- [ ] Add to cart — discounted price used as line item price
- [ ] Set `valid_from` in the future — discount should NOT apply
- [ ] Set `valid_to` in the past — discount should NOT apply
- [ ] Set discount to 0% — products show regular price
- [ ] Product in two categories with different discounts — highest applies
- [ ] Products in subcategories are NOT affected by parent's discount
- [ ] Existing campaign products still show campaign sticker when no category discount