### PR TITLE
[v3] * Fix email/postcode not pre-filled in checkout

### DIFF
--- a/public_html/frontend/pages/shopping_cart.inc.php
+++ b/public_html/frontend/pages/shopping_cart.inc.php
@@ -80,8 +80,8 @@
 				'country_code',
 				'postcode',
 			] as $field) {
-				if (isset($_POST['customer'][$field])) {
-					$order->data['customer'][$field] = $_POST['customer'][$field];
+				if (isset($_POST[$field])) {
+					$order->data['customer'][$field] = $_POST[$field];
 				}
 			}
 


### PR DESCRIPTION
Follow-up to #436 — the quick-checkout form on the cart page wasn't passing its data through.

## Summary

The shopping cart quick-checkout form uses simple field names (`postcode`, `email`, `country_code`), but the PHP handler read from `$_POST['customer'][$field]` instead of `$_POST[$field]`. Values entered on the cart page were silently discarded, so the checkout customer form always started empty.

| Before | After |
|--------|-------|
| Email, postcode entered on cart page | Same |
| Checkout customer form: fields empty | Fields pre-filled from cart input |

## Change

- `shopping_cart.inc.php:83`: `$_POST['customer'][$field]` → `$_POST[$field]`

## Test plan

- [ ] Add product to cart
- [ ] Enter email, country, and postcode on cart page
- [ ] Click "Continue To Checkout"
- [ ] Verify email and postcode are pre-filled on customer details form