### PR TITLE
[v3] * Restore compact formatting in structure.json

### DIFF
--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -2,178 +2,50 @@
 	"tables": {
 		"administrators": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"username": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"firstname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"lastname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"email": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"apps": {
-					"type": "VARCHAR",
-					"length": 4096,
-					"default": "''"
-				},
-				"widgets": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"password_hash": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"two_factor_auth": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"login_attempts": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"total_logins": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"known_ips": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"last_ip_address": {
-					"type": "VARCHAR",
-					"length": 39,
-					"default": "''"
-				},
-				"last_hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"last_user_agent": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"last_active": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"last_login": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"sessions_expiry": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"blocked_until": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_from": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_to": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"username": {"type":"VARCHAR","length":32,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"apps": {"type":"VARCHAR","length":4096,"default":"''"},
+				"widgets": {"type":"VARCHAR","length":512,"default":"''"},
+				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
+				"two_factor_auth": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"login_attempts": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
+				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"last_login": {"type":"TIMESTAMP","nullable":true},
+				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
+				"blocked_until": {"type":"TIMESTAMP","nullable":true},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"username": [
-					"username"
-				],
-				"email": [
-					"email"
-				]
+				"status": ["status"],
+				"username": ["username"],
+				"email": ["email"]
 			}
 		},
 		"attribute_groups": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"sort": {
-					"type": "ENUM('alphabetical','priority')",
-					"default": "'alphabetical'"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"sort": {"type":"ENUM('alphabetical','priority')","default":"'alphabetical'"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"code": [
-					"code"
-				]
+				"code": ["code"]
 			},
 			"check_constraints": {
 				"attribute_groups_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)"
@@ -181,43 +53,16 @@
 		},
 		"attribute_values": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true},
+				"name": {"type":"TEXT","nullable":true},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"group_id": [
-					"group_id"
-				]
+				"group_id": ["group_id"]
 			},
 			"check_constraints": {
 				"attribute_values_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)"
@@ -225,170 +70,47 @@
 		},
 		"banners": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"languages": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"html": {
-					"type": "TEXT"
-				},
-				"image": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"link": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"keywords": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"total_views": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"total_clicks": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"valid_from": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_to": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"languages": {"type":"VARCHAR","length":64,"default":"''"},
+				"html": {"type":"TEXT"},
+				"image": {"type":"VARCHAR","length":64,"default":"''"},
+				"link": {"type":"VARCHAR","length":255,"default":"''"},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"total_views": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"total_clicks": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			]
+			"primary_key": ["id"]
 		},
 		"brands": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"featured": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"short_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"h1_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"head_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"meta_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"link": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"keywords": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"image": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"h1_title": {"type":"TEXT","nullable":true},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"link": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"image": {"type":"VARCHAR","length":128,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"code": [
-					"code"
-				],
-				"status": [
-					"status"
-				],
-				"featured": [
-					"featured"
-				],
-				"name": [
-					"name"
-				]
+				"code": ["code"],
+				"status": ["status"],
+				"featured": ["featured"],
+				"name": ["name"]
 			},
 			"check_constraints": {
 				"brands_chk_short_description": "short_description IS NULL OR short_description = '' OR JSON_VALID(short_description)",
@@ -401,293 +123,74 @@
 		},
 		"campaigns": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 1
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 50,
-					"default": "''"
-				},
-				"valid_from": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_to": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"name": {"type":"VARCHAR","length":50,"default":"''"},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"valid_from": [
-					"valid_from"
-				],
-				"valid_to": [
-					"valid_to"
-				]
+				"status": ["status"],
+				"valid_from": ["valid_from"],
+				"valid_to": ["valid_to"]
 			}
 		},
 		"cart_items": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"cart_uid": {
-					"type": "VARCHAR",
-					"length": 13
-				},
-				"customer_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"key": {
-					"type": "VARCHAR",
-					"length": 32
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"stock_option_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"userdata": {
-					"type": "VARCHAR",
-					"length": 2048,
-					"default": "''"
-				},
-				"image": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"quantity": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 1
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"cart_uid": {"type":"VARCHAR","length":13},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"key": {"type":"VARCHAR","length":32},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"userdata": {"type":"VARCHAR","length":2048,"default":"''"},
+				"image": {"type":"VARCHAR","length":255,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"11,4","default":1},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"customer_id": [
-					"customer_id"
-				],
-				"cart_uid": [
-					"cart_uid"
-				]
+				"customer_id": ["customer_id"],
+				"cart_uid": ["cart_uid"]
 			},
 			"foreign_keys": {
-				"cart_item_to_customer": {
-					"columns": [
-						"customer_id"
-					],
-					"references": {
-						"table": "customers",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"cart_item_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"cart_item_to_stock_option": {
-					"columns": [
-						"stock_option_id"
-					],
-					"references": {
-						"table": "products_stock_options",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"cart_item_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"cart_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"cart_item_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"categories": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"parent_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"google_taxonomy_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"short_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"synonyms": {
-					"type": "TEXT"
-				},
-				"head_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"h1_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"meta_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"keywords": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"image": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"google_taxonomy_id": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"code": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"synonyms": {"type":"TEXT"},
+				"head_title": {"type":"TEXT","nullable":true},
+				"h1_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"image": {"type":"VARCHAR","length":255,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"code": [
-					"code"
-				],
-				"parent_id": [
-					"parent_id"
-				],
-				"status": [
-					"status"
-				]
-			},
-			"fulltext_keys": {
-				"name": [
-					"name"
-				],
-				"short_description": [
-					"short_description"
-				],
-				"description": [
-					"description"
-				],
-				"synonyms": [
-					"synonyms"
-				]
+				"code": ["code"],
+				"parent_id": ["parent_id"],
+				"status": ["status"]
 			},
 			"foreign_keys": {
-				"category_to_parent": {
-					"columns": [
-						"parent_id"
-					],
-					"references": {
-						"table": "categories",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "RESTRICT"
-					}
-				}
+				"category_to_parent": {"columns":["parent_id"],"references":{"table":"categories","columns":["id"],"on_update":"CASCADE","on_delete":"RESTRICT"}}
 			},
 			"check_constraints": {
 				"categories_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -700,576 +203,153 @@
 		},
 		"categories_filters": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"category_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"attribute_group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"select_multiple": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"category_id": {"type":"INT","length":10,"unsigned":true},
+				"attribute_group_id": {"type":"INT","length":10,"unsigned":true},
+				"select_multiple": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"attribute_filter": [
-					"category_id",
-					"attribute_group_id"
-				]
+				"attribute_filter": ["category_id","attribute_group_id"]
 			},
 			"keys": {
-				"category_id": [
-					"category_id"
-				]
+				"category_id": ["category_id"]
 			},
 			"foreign_keys": {
-				"category_filter_to_category": {
-					"columns": [
-						"category_id"
-					],
-					"references": {
-						"table": "categories",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"category_filter_to_attribute_group": {
-					"columns": [
-						"attribute_group_id"
-					],
-					"references": {
-						"table": "attribute_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"category_filter_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"category_filter_to_attribute_group": {"columns":["attribute_group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"countries": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"iso_code_1": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"iso_code_2": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"iso_code_3": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"domestic_name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"tax_id_format": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"address_format": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"postcode_format": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"postcode_required": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2
-				},
-				"currency_code": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"phone_code": {
-					"type": "VARCHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"iso_code_1": {"type":"CHAR","length":3,"default":"''"},
+				"iso_code_2": {"type":"CHAR","length":2,"default":"''"},
+				"iso_code_3": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"domestic_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"tax_id_format": {"type":"VARCHAR","length":64,"default":"''"},
+				"address_format": {"type":"VARCHAR","length":128,"default":"''"},
+				"postcode_format": {"type":"VARCHAR","length":255,"default":"''"},
+				"postcode_required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"language_code": {"type":"CHAR","length":2},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"phone_code": {"type":"VARCHAR","length":3,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"iso_code_1": [
-					"iso_code_1"
-				],
-				"iso_code_2": [
-					"iso_code_2"
-				],
-				"iso_code_3": [
-					"iso_code_3"
-				]
+				"iso_code_1": ["iso_code_1"],
+				"iso_code_2": ["iso_code_2"],
+				"iso_code_3": ["iso_code_3"]
 			},
 			"keys": {
-				"status": [
-					"status"
-				]
+				"status": ["status"]
 			}
 		},
 		"currencies": {
 			"columns": {
-				"id": {
-					"type": "TINYINT",
-					"length": 3,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"code": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"number": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"value": {
-					"type": "DECIMAL",
-					"length": "11,6",
-					"unsigned": true,
-					"default": 1.0
-				},
-				"decimals": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 2
-				},
-				"prefix": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"suffix": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"TINYINT","length":3,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"code": {"type":"CHAR","length":3,"default":"''"},
+				"number": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":1},
+				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
+				"prefix": {"type":"VARCHAR","length":8,"default":"''"},
+				"suffix": {"type":"VARCHAR","length":8,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"code": [
-					"code"
-				],
-				"number": [
-					"number"
-				]
+				"status": ["status"],
+				"code": ["code"],
+				"number": ["number"]
 			}
 		},
 		"customer_groups": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"type": {
-					"type": "ENUM('retail', 'wholesale')",
-					"default": "'retail'"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"type": {"type":"ENUM('retail', 'wholesale')","default":"'retail'"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"description": {"type":"VARCHAR","length":248,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			]
+			"primary_key": ["id"]
 		},
 		"customers": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 1
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"tax_id": {
-					"type": "VARCHAR",
-					"length": 24,
-					"default": "''"
-				},
-				"company": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"firstname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"lastname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"address1": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"address2": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"postcode": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"city": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"zone_code": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"phone": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"different_shipping_address": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"shipping_company": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_firstname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_lastname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_address1": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_address2": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_postcode": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"shipping_city": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"shipping_zone_code": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"shipping_phone": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"shipping_email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2,
-					"nullable": true
-				},
-				"notes": {
-					"type": "TEXT"
-				},
-				"password_hash": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"password_reset_token": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"login_attempts": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"total_logins": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"known_ips": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"last_ip_address": {
-					"type": "VARCHAR",
-					"length": 39,
-					"default": "''"
-				},
-				"last_hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"last_user_agent": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"last_login": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"last_active": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"blocked_until": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"sessions_expiry": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"email": {"type":"VARCHAR","length":64,"default":"''"},
+				"tax_id": {"type":"VARCHAR","length":24,"default":"''"},
+				"company": {"type":"VARCHAR","length":32,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"city": {"type":"VARCHAR","length":32,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"default":"''"},
+				"zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"different_shipping_address": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"notes": {"type":"TEXT"},
+				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
+				"password_reset_token": {"type":"VARCHAR","length":128,"default":"''"},
+				"login_attempts": {"type":"INT","length":11,"default":0},
+				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
+				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_login": {"type":"TIMESTAMP","nullable":true},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"blocked_until": {"type":"TIMESTAMP","nullable":true},
+				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"email": [
-					"email"
-				]
+				"email": ["email"]
 			},
 			"keys": {
-				"group_id": [
-					"group_id"
-				]
+				"group_id": ["group_id"]
 			},
 			"foreign_keys": {
-				"customer_to_customer_group": {
-					"columns": [
-						"group_id"
-					],
-					"references": {
-						"table": "customer_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"customer_to_customer_group": {"columns":["group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"delivery_statuses": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"check_constraints": {
 				"delivery_statuses_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
 				"delivery_statuses_chk_description": "description IS NULL OR description = '' OR JSON_VALID(description)"
@@ -1277,236 +357,67 @@
 		},
 		"emails": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "ENUM('draft','scheduled','sent','error')",
-					"default": "'draft'"
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"reference": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"language_code": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"sender": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"recipients": {
-					"type": "TEXT"
-				},
-				"ccs": {
-					"type": "TEXT"
-				},
-				"bccs": {
-					"type": "TEXT"
-				},
-				"subject": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"multiparts": {
-					"type": "MEDIUMTEXT"
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 39,
-					"default": "''"
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"scheduled_at": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"sent_at": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"ENUM('draft','scheduled','sent','error')","default":"'draft'"},
+				"code": {"type":"VARCHAR","length":255,"default":"''"},
+				"reference": {"type":"VARCHAR","length":255,"default":"''"},
+				"language_code": {"type":"VARCHAR","length":2,"default":"''"},
+				"sender": {"type":"VARCHAR","length":255,"default":"''"},
+				"recipients": {"type":"TEXT"},
+				"ccs": {"type":"TEXT"},
+				"bccs": {"type":"TEXT"},
+				"subject": {"type":"VARCHAR","length":255,"default":"''"},
+				"multiparts": {"type":"MEDIUMTEXT"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"scheduled_at": {"type":"TIMESTAMP","nullable":true},
+				"sent_at": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"scheduled_at": [
-					"scheduled_at"
-				],
-				"code": [
-					"code"
-				],
-				"created_at": [
-					"created_at"
-				],
-				"sender_email": [
-					"sender"
-				]
+				"scheduled_at": ["scheduled_at"],
+				"code": ["code"],
+				"created_at": ["created_at"],
+				"sender_email": ["sender"]
 			}
 		},
 		"event_logs": {
 			"columns": {
-				"id": {
-					"type": "BIGINT",
-					"length": 20,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"session_id": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"customer_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"customer_email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"customer_phone": {
-					"type": "VARCHAR",
-					"length": 16,
-					"nullable": true
-				},
-				"type": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"data": {
-					"type": "VARCHAR",
-					"length": 1024,
-					"default": "'{}'"
-				},
-				"conversions": {
-					"type": "VARCHAR",
-					"length": 1024,
-					"default": "'{}'"
-				},
-				"url": {
-					"type": "VARCHAR",
-					"length": 248,
-					"nullable": true
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 47,
-					"nullable": true
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"nullable": true
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 248,
-					"nullable": true
-				},
-				"fingerprint": {
-					"type": "VARCHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"expires_at": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
+				"session_id": {"type":"VARCHAR","length":64,"nullable":true},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_email": {"type":"VARCHAR","length":64,"nullable":true},
+				"customer_phone": {"type":"VARCHAR","length":16,"nullable":true},
+				"type": {"type":"VARCHAR","length":64,"nullable":true},
+				"description": {"type":"VARCHAR","length":248,"default":"''"},
+				"data": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"url": {"type":"VARCHAR","length":248,"nullable":true},
+				"ip_address": {"type":"VARCHAR","length":47,"nullable":true},
+				"hostname": {"type":"VARCHAR","length":128,"nullable":true},
+				"user_agent": {"type":"VARCHAR","length":248,"nullable":true},
+				"fingerprint": {"type":"VARCHAR","length":32,"nullable":true},
+				"expires_at": {"type":"TIMESTAMP","nullable":true},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"session_id": [
-					"session_id"
-				],
-				"customer_id": [
-					"customer_id"
-				],
-				"customer_email": [
-					"customer_email"
-				],
-				"customer_phone": [
-					"customer_phone"
-				],
-				"type": [
-					"type"
-				],
-				"ip_address": [
-					"ip_address"
-				],
-				"hostname": [
-					"hostname"
-				],
-				"user_agent": [
-					"user_agent"
-				],
-				"fingerprint": [
-					"fingerprint"
-				],
-				"expires_at": [
-					"expires_at"
-				]
+				"session_id": ["session_id"],
+				"customer_id": ["customer_id"],
+				"customer_email": ["customer_email"],
+				"customer_phone": ["customer_phone"],
+				"type": ["type"],
+				"ip_address": ["ip_address"],
+				"hostname": ["hostname"],
+				"user_agent": ["user_agent"],
+				"fingerprint": ["fingerprint"],
+				"expires_at": ["expires_at"]
 			},
 			"foreign_keys": {
-				"event_log_to_customer": {
-					"columns": [
-						"customer_id"
-					],
-					"references": {
-						"table": "customers",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"event_log_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			},
 			"check_constraints": {
 				"event_logs_chk_data": "data IS NULL OR data = '' OR JSON_VALID(data)",
@@ -1515,1260 +426,308 @@
 		},
 		"geo_zones": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":255,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			]
+			"primary_key": ["id"]
 		},
 		"languages": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"code2": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"direction": {
-					"type": "ENUM('ltr','rtl')",
-					"default": "'ltr'"
-				},
-				"locale": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"locale_intl": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"mysql_collation": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"url_type": {
-					"type": "ENUM('','none','root','path','domain')",
-					"default": "''"
-				},
-				"domain_name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"raw_date": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"raw_time": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"raw_datetime": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"format_date": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"format_time": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"format_datetime": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"decimal_point": {
-					"type": "VARCHAR",
-					"length": 1,
-					"default": "''"
-				},
-				"thousands_sep": {
-					"type": "VARCHAR",
-					"length": 1,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"code": {"type":"CHAR","length":2,"default":"''"},
+				"code2": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"direction": {"type":"ENUM('ltr','rtl')","default":"'ltr'"},
+				"locale": {"type":"VARCHAR","length":64,"default":"''"},
+				"locale_intl": {"type":"VARCHAR","length":16,"default":"''"},
+				"mysql_collation": {"type":"VARCHAR","length":32,"default":"''"},
+				"url_type": {"type":"ENUM('','none','root','path','domain')","default":"''"},
+				"domain_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"raw_date": {"type":"VARCHAR","length":32,"default":"''"},
+				"raw_time": {"type":"VARCHAR","length":32,"default":"''"},
+				"raw_datetime": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_date": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_time": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_datetime": {"type":"VARCHAR","length":32,"default":"''"},
+				"decimal_point": {"type":"VARCHAR","length":1,"default":"''"},
+				"thousands_sep": {"type":"VARCHAR","length":1,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				]
+				"status": ["status"]
 			}
 		},
 		"modules": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"module_id": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"type": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"settings": {
-					"type": "TEXT"
-				},
-				"last_log": {
-					"type": "TEXT"
-				},
-				"last_pushed": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"last_processed": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"module_id": {"type":"VARCHAR","length":64,"default":"''"},
+				"type": {"type":"VARCHAR","length":16,"default":"''"},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"settings": {"type":"TEXT"},
+				"last_log": {"type":"TEXT"},
+				"last_pushed": {"type":"TIMESTAMP","nullable":true},
+				"last_processed": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"module_id": [
-					"module_id"
-				]
+				"module_id": ["module_id"]
 			},
 			"keys": {
-				"type": [
-					"type"
-				],
-				"status": [
-					"status"
-				]
+				"type": ["type"],
+				"status": ["status"]
 			}
 		},
 		"newsletter_recipients": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"subscribed": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 1
-				},
-				"lastname": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"firstname": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"email": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2,
-					"nullable": true
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"nullable": true
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"subscribed": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"lastname": {"type":"VARCHAR","length":64,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":64,"default":"''"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"country_code": {"type":"CHAR","length":2,"nullable":true},
+				"ip_address": {"type":"VARCHAR","length":64,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":248,"default":"''"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
-			"keys": {
-				"subscribed": [
-					"subscribed"
-				]
-			},
+			"primary_key": ["id"],
 			"unique_keys": {
-				"email": [
-					"email"
-				]
+				"email": ["email"]
+			},
+			"keys": {
+				"subscribed": ["subscribed"]
 			}
 		},
 		"orders": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"no": {
-					"type": "VARCHAR",
-					"length": 16,
-					"nullable": true
-				},
-				"starred": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"unread": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"order_status_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"customer_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"customer_tax_id": {
-					"type": "VARCHAR",
-					"length": 24,
-					"default": "''"
-				},
-				"customer_company": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_firstname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_lastname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_address1": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_address2": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_city": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"customer_postcode": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"customer_country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"customer_zone_code": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"customer_phone": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"customer_email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"shipping_tax_id": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_company": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_firstname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_lastname": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_address1": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_address2": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_city": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_postcode": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"shipping_country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"shipping_zone_code": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"shipping_phone": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"shipping_email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"shipping_option_id": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shipping_option_name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"shipping_option_userdata": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"shipping_option_fee": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"shipping_option_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"shipping_purchase_cost": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"shipping_tracking_id": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"shipping_tracking_url": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"shipping_progress": {
-					"type": "TINYINT",
-					"length": 3,
-					"default": 0
-				},
-				"shipping_current_status": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"shipping_current_location": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"payment_option_id": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"payment_option_name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"payment_option_userdata": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"payment_option_fee": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"payment_option_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"payment_transaction_id": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"payment_transaction_fee": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"nullable": true
-				},
-				"payment_receipt_url": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"payment_terms": {
-					"type": "VARCHAR",
-					"length": 8,
-					"default": "''"
-				},
-				"incoterm": {
-					"type": "VARCHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"reference": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2,
-					"nullable": true
-				},
-				"weight_total": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"weight_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"currency_code": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"currency_value": {
-					"type": "DECIMAL",
-					"length": "11,6",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"display_prices_including_tax": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"subtotal": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"subtotal_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"discount": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"discount_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"total": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"total_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"notes": {
-					"type": "VARCHAR",
-					"length": 1024,
-					"default": "''"
-				},
-				"conversions": {
-					"type": "VARCHAR",
-					"length": 1024,
-					"default": "'{}'"
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 39,
-					"default": "''"
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"domain": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"public_key": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"date_paid": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"date_dispatched": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"no": {"type":"VARCHAR","length":16,"nullable":true},
+				"starred": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"unread": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"order_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_tax_id": {"type":"VARCHAR","length":24,"default":"''"},
+				"customer_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"customer_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"customer_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"customer_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"customer_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_tax_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_option_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_option_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
+				"shipping_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_purchase_cost": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_tracking_id": {"type":"VARCHAR","length":128,"default":"''"},
+				"shipping_tracking_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"shipping_progress": {"type":"TINYINT","length":3,"default":0},
+				"shipping_current_status": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_current_location": {"type":"VARCHAR","length":128,"default":"''"},
+				"payment_option_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"payment_option_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"payment_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
+				"payment_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
+				"payment_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"payment_transaction_id": {"type":"VARCHAR","length":128,"default":"''"},
+				"payment_transaction_fee": {"type":"DECIMAL","length":"10,4","nullable":true},
+				"payment_receipt_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"payment_terms": {"type":"VARCHAR","length":8,"default":"''"},
+				"incoterm": {"type":"VARCHAR","length":3,"default":"''"},
+				"reference": {"type":"VARCHAR","length":128,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"weight_total": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"currency_value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":0},
+				"display_prices_including_tax": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"subtotal": {"type":"DECIMAL","length":"10,4","default":0},
+				"subtotal_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"total": {"type":"DECIMAL","length":"10,4","default":0},
+				"total_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"notes": {"type":"VARCHAR","length":1024,"default":"''"},
+				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"domain": {"type":"VARCHAR","length":64,"nullable":true},
+				"public_key": {"type":"VARCHAR","length":32,"default":"''"},
+				"date_paid": {"type":"TIMESTAMP","nullable":true},
+				"date_dispatched": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
-			"keys": {
-				"no": [
-					"no"
-				],
-				"order_status_id": [
-					"order_status_id"
-				],
-				"starred": [
-					"starred"
-				],
-				"unread": [
-					"unread"
-				]
-			},
+			"primary_key": ["id"],
 			"unique_keys": {
-				"public_key": [
-					"public_key"
-				]
+				"public_key": ["public_key"]
+			},
+			"keys": {
+				"no": ["no"],
+				"order_status_id": ["order_status_id"],
+				"starred": ["starred"],
+				"unread": ["unread"]
+			},
+			"foreign_keys": {
+				"order_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"order_to_order_status": {"columns":["order_status_id"],"references":{"table":"order_statuses","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"orders_chk_conversions": "conversions IS NULL OR conversions = '' OR JSON_VALID(conversions)"
-			},
-			"foreign_keys": {
-				"order_to_customer": {
-					"columns": [
-						"customer_id"
-					],
-					"references": {
-						"table": "customers",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"order_to_order_status": {
-					"columns": [
-						"order_status_id"
-					],
-					"references": {
-						"table": "order_statuses",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
 			}
 		},
 		"orders_comments": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"order_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"author_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"author": {
-					"type": "ENUM('system','staff','customer')",
-					"default": "'system'"
-				},
-				"text": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"hidden": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"author_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"author": {"type":"ENUM('system','staff','customer')","default":"'system'"},
+				"text": {"type":"VARCHAR","length":512,"default":"''"},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"order_id": [
-					"order_id"
-				]
+				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_comment_to_order": {
-					"columns": [
-						"order_id"
-					],
-					"references": {
-						"table": "orders",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"order_comment_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"orders_items": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"order_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"line_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"stock_item_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"serial_number": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"sku": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"gtin": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"taric": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"quantity": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"price": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"tax_rate": {
-					"type": "DECIMAL",
-					"length": "4,2",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"tax_class_id": {
-					"type": "INT",
-					"length": "10",
-					"unsigned": true,
-					"nullable": true
-				},
-				"discount": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"discount_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"sum": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"sum_tax": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"weight": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"weight_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"length": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"width": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"height": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"length_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"downloads": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"line_id": {"type":"INT","length":10,"unsigned":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":32,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
+				"price": {"type":"DECIMAL","length":"10,4","default":0},
+				"tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"tax_rate": {"type":"DECIMAL","length":"4,2","unsigned":true,"default":0},
+				"tax_class_id": {"type":"INT","length":"10","unsigned":true,"nullable":true},
+				"discount": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"sum": {"type":"DECIMAL","length":"10,4","default":0},
+				"sum_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"length": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"width": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"height": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"order_id": [
-					"order_id"
-				]
+				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_item_to_order": {
-					"columns": [
-						"order_id"
-					],
-					"references": {
-						"table": "orders",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"order_item_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"order_item_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"order_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"orders_lines": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"order_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"stock_option_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"serial_number": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"userdata": {
-					"type": "VARCHAR",
-					"length": 2048,
-					"default": "'{}'"
-				},
-				"quantity": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"price": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"tax_class_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"tax_rate": {
-					"type": "DECIMAL",
-					"length": "6,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"tax": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"discount": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"discount_tax": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"sum": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"sum_tax": {
-					"type": "DECIMAL",
-					"length": "11,4",
-					"default": 0.0
-				},
-				"weight": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"weight_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"code": {"type":"VARCHAR","length":32,"nullable":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
+				"userdata": {"type":"VARCHAR","length":2048,"default":"'{}'"},
+				"quantity": {"type":"DECIMAL","length":"11,4","default":0},
+				"price": {"type":"DECIMAL","length":"11,4","default":0},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"tax_rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
+				"tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"discount": {"type":"DECIMAL","length":"11,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"sum": {"type":"DECIMAL","length":"11,4","default":0},
+				"sum_tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"order_id": [
-					"order_id"
-				],
-				"tax_class_id": [
-					"tax_class_id"
-				],
-				"product_id": [
-					"product_id"
-				],
-				"stock_option_id": [
-					"stock_option_id"
-				],
-				"code": [
-					"code"
-				]
+				"order_id": ["order_id"],
+				"tax_class_id": ["tax_class_id"],
+				"product_id": ["product_id"],
+				"stock_option_id": ["stock_option_id"],
+				"code": ["code"]
+			},
+			"foreign_keys": {
+				"order_line_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
+				"order_line_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
+				"order_line_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"orders_lines_chk_userdata": "userdata IS NULL OR userdata = '' OR JSON_VALID(userdata)"
-			},
-			"foreign_keys": {
-				"order_line_to_order": {
-					"columns": [
-						"order_id"
-					],
-					"references": {
-						"table": "orders",
-						"columns": [
-							"id"
-						],
-						"on_update": "RESTRICT",
-						"on_delete": "RESTRICT"
-					}
-				},
-				"order_line_to_tax_class": {
-					"columns": [
-						"tax_class_id"
-					],
-					"references": {
-						"table": "tax_classes",
-						"columns": [
-							"id"
-						],
-						"on_update": "RESTRICT",
-						"on_delete": "RESTRICT"
-					}
-				},
-				"order_line_to_stock_option": {
-					"columns": [
-						"stock_option_id"
-					],
-					"references": {
-						"table": "products_stock_options",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
 			}
 		},
 		"order_statuses": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"state": {
-					"type": "ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')",
-					"default": "''"
-				},
-				"hidden": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"icon": {
-					"type": "VARCHAR",
-					"length": 24,
-					"default": "''"
-				},
-				"color": {
-					"type": "VARCHAR",
-					"length": 7,
-					"default": "''"
-				},
-				"name": {
-					"type": "TEXT",
-					"length": 64,
-					"nullable": true
-				},
-				"description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"email_subject": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"email_message": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"is_sale": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"is_archived": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"is_trackable": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"stock_action": {
-					"type": "ENUM('none','reserve','commit')",
-					"default": "'none'"
-				},
-				"notify": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"state": {"type":"ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')","default":"''"},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"icon": {"type":"VARCHAR","length":24,"default":"''"},
+				"color": {"type":"VARCHAR","length":7,"default":"''"},
+				"name": {"type":"TEXT","length":64,"nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"email_subject": {"type":"TEXT","nullable":true},
+				"email_message": {"type":"MEDIUMTEXT","nullable":true},
+				"is_sale": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"is_archived": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"is_trackable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"stock_action": {"type":"ENUM('none','reserve','commit')","default":"'none'"},
+				"notify": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"hidden": [
-					"hidden"
-				],
-				"is_archived": [
-					"is_archived"
-				],
-				"is_sale": [
-					"is_sale"
-				],
-				"is_trackable": [
-					"is_trackable"
-				]
+				"hidden": ["hidden"],
+				"is_archived": ["is_archived"],
+				"is_sale": ["is_sale"],
+				"is_trackable": ["is_trackable"]
 			},
 			"check_constraints": {
 				"order_statuses_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -2779,72 +738,23 @@
 		},
 		"pages": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"parent_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"dock": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"content": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"head_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"meta_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"dock": {"type":"VARCHAR","length":64,"default":"''"},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"title": {"type":"TEXT","nullable":true},
+				"content": {"type":"MEDIUMTEXT","nullable":true},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"parent_id": [
-					"parent_id"
-				],
-				"dock": [
-					"dock"
-				]
+				"status": ["status"],
+				"parent_id": ["parent_id"],
+				"dock": ["dock"]
 			},
 			"check_constraints": {
 				"pages_chk_title": "title IS NULL OR title = '' OR JSON_VALID(title)",
@@ -2855,267 +765,64 @@
 		},
 		"products": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"type": {
-					"type": "ENUM('virtual','physical','digital','variable','bundle')",
-					"default": "'virtual'"
-				},
-				"featured": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"pinned": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"brand_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"supplier_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"delivery_status_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"sold_out_status_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"default_category_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"sku": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"mpn": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"gtin": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"taric": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"shelf": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"short_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"technical_data": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"autofill_technical_data": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"head_title": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"meta_description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"synonyms": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"keywords": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"stock_option_type": {
-					"type": "ENUM('variants','bundle')",
-					"default": "'variants'"
-				},
-				"quantity_min": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 1.0
-				},
-				"quantity_max": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"quantity_step": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"quantity_unit_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"recommended_price": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"tax_class_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"default_image": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"video_url": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"replaced_by": {
-					"type": "VARCHAR",
-					"length": 24
-				},
-				"valid_from": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_to": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"type": {"type":"ENUM('virtual','physical','digital','variable','bundle')","default":"'virtual'"},
+				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"pinned": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"delivery_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"sold_out_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"default_category_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":16,"default":"''"},
+				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"technical_data": {"type":"TEXT","nullable":true},
+				"autofill_technical_data": {"type":"TINYINT","length":1,"default":0},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"synonyms": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"stock_option_type": {"type":"ENUM('variants','bundle')","default":"'variants'"},
+				"quantity_min": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
+				"quantity_max": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"quantity_step": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"recommended_price": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"default_image": {"type":"VARCHAR","length":255,"default":"''"},
+				"video_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"replaced_by": {"type":"VARCHAR","length":24},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"featured": [
-					"featured"
-				],
-				"pinned": [
-					"pinned"
-				],
-				"default_category_id": [
-					"default_category_id"
-				],
-				"brand_id": [
-					"brand_id"
-				],
-				"supplier_id": [
-					"supplier_id"
-				],
-				"delivery_status_id": [
-					"delivery_status_id"
-				],
-				"sold_out_status_id": [
-					"sold_out_status_id"
-				],
-				"keywords": [
-					"keywords"
-				],
-				"code": [
-					"code"
-				],
-				"sku": [
-					"sku"
-				],
-				"mpn": [
-					"mpn"
-				],
-				"gtin": [
-					"gtin"
-				],
-				"taric": [
-					"taric"
-				],
-				"valid_from": [
-					"valid_from"
-				],
-				"valid_to": [
-					"valid_to"
-				]
-			},
-			"fulltext_keys": {
-				"name": [
-					"name"
-				],
-				"short_description": [
-					"short_description"
-				],
-				"description": [
-					"description"
-				]
+				"status": ["status"],
+				"featured": ["featured"],
+				"pinned": ["pinned"],
+				"default_category_id": ["default_category_id"],
+				"brand_id": ["brand_id"],
+				"supplier_id": ["supplier_id"],
+				"delivery_status_id": ["delivery_status_id"],
+				"sold_out_status_id": ["sold_out_status_id"],
+				"keywords": ["keywords"],
+				"code": ["code"],
+				"sku": ["sku"],
+				"mpn": ["mpn"],
+				"gtin": ["gtin"],
+				"taric": ["taric"],
+				"valid_from": ["valid_from"],
+				"valid_to": ["valid_to"]
 			},
 			"check_constraints": {
 				"products_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -3129,539 +836,135 @@
 		},
 		"products_attributes": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"value_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"custom_value": {
-					"type": "VARCHAR",
-					"length": 215,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true},
+				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"custom_value": {"type":"VARCHAR","length":215,"default":"''"},
+				"priority": {"type":"INT","length":10,"unsigned":true,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"id": [
-					"id",
-					"product_id",
-					"group_id",
-					"value_id"
-				]
+				"id": ["id","product_id","group_id","value_id"]
 			},
 			"keys": {
-				"product_id": [
-					"product_id"
-				],
-				"group_id": [
-					"group_id"
-				],
-				"value_id": [
-					"value_id"
-				]
+				"product_id": ["product_id"],
+				"group_id": ["group_id"],
+				"value_id": ["value_id"]
 			},
 			"foreign_keys": {
-				"product_attribute_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_attribute_to_attribute_group": {
-					"columns": [
-						"group_id"
-					],
-					"references": {
-						"table": "attribute_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_attribute_to_attribute_value": {
-					"columns": [
-						"value_id"
-					],
-					"references": {
-						"table": "attribute_values",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_attribute_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_attribute_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_attribute_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"products_customizations": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"function": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"required": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"sort": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"priority": {
-					"type": "TINYINT",
-					"length": 2,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"function": {"type":"VARCHAR","length":32,"default":"''"},
+				"required": {"type":"TINYINT","length":1,"default":0},
+				"sort": {"type":"VARCHAR","length":16,"default":"''"},
+				"priority": {"type":"TINYINT","length":2,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option": [
-					"product_id",
-					"group_id"
-				]
+				"product_option": ["product_id","group_id"]
 			},
 			"keys": {
-				"product_id": [
-					"product_id"
-				],
-				"priority": [
-					"priority"
-				]
+				"product_id": ["product_id"],
+				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_to_attribute_group": {
-					"columns": [
-						"group_id"
-					],
-					"references": {
-						"table": "attribute_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_customization_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_customizations_values": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"value_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"custom_value": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"price_modifier": {
-					"type": "CHAR",
-					"length": 1,
-					"default": "'+'"
-				},
-				"price_adjustment": {
-					"type": "VARCHAR",
-					"length": 1,
-					"default": "''"
-				},
-				"priority": {
-					"type": "TINYINT",
-					"length": 2,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"custom_value": {"type":"VARCHAR","length":64,"default":"''"},
+				"price_modifier": {"type":"CHAR","length":1,"default":"'+'"},
+				"price_adjustment": {"type":"VARCHAR","length":1,"default":"''"},
+				"priority": {"type":"TINYINT","length":2,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option_value": [
-					"product_id",
-					"group_id",
-					"value_id"
-				]
+				"product_option_value": ["product_id","group_id","value_id"]
 			},
 			"keys": {
-				"product_id": [
-					"product_id"
-				],
-				"priority": [
-					"priority"
-				]
+				"product_id": ["product_id"],
+				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_value_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_value_to_attribute_group": {
-					"columns": [
-						"group_id"
-					],
-					"references": {
-						"table": "attribute_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_value_to_attribute_value": {
-					"columns": [
-						"value_id"
-					],
-					"references": {
-						"table": "attribute_values",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_customization_value_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_value_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_value_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_images": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"filename": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"checksum": {
-					"type": "CHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"filename": {"type":"VARCHAR","length":255,"default":"''"},
+				"checksum": {"type":"CHAR","length":32,"nullable":true},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"product_id": [
-					"product_id"
-				]
+				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_image_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_image_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"product_notification_recipients": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"email": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"email": {"type":"VARCHAR","length":64,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"default":"''"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
-			"keys": {
-				"product_id": [
-					"product_id"
-				]
-			},
+			"primary_key": ["id"],
 			"unique_keys": {
-				"notification_recipient": [
-					"product_id",
-					"email"
-				]
+				"notification_recipient": ["product_id","email"]
+			},
+			"keys": {
+				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"notification_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"notification_to_language": {
-					"columns": [
-						"language_code"
-					],
-					"references": {
-						"table": "languages",
-						"columns": [
-							"code"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"notification_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"notification_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_prices": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"campaign_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"customer_group_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"geo_zone_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"min_quantity": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"unsigned": true,
-					"default": 1.0
-				},
-				"price": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "'{}'"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"campaign_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"min_quantity": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
+				"price": {"type":"VARCHAR","length":512,"default":"'{}'"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"product_id": [
-					"product_id"
-				],
-				"geo_zone_id": [
-					"geo_zone_id"
-				],
-				"customer_group_id": [
-					"customer_group_id"
-				],
-				"campaign_id": [
-					"campaign_id"
-				],
-				"min_quantity": [
-					"min_quantity"
-				]
+				"product_id": ["product_id"],
+				"geo_zone_id": ["geo_zone_id"],
+				"customer_group_id": ["customer_group_id"],
+				"campaign_id": ["campaign_id"],
+				"min_quantity": ["min_quantity"]
 			},
 			"foreign_keys": {
-				"product_price_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_customer_group": {
-					"columns": [
-						"customer_group_id"
-					],
-					"references": {
-						"table": "customer_groups",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_campaign": {
-					"columns": [
-						"campaign_id"
-					],
-					"references": {
-						"table": "campaigns",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_geo_zone": {
-					"columns": [
-						"geo_zone_id"
-					],
-					"references": {
-						"table": "geo_zones",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_price_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_customer_group": {"columns":["customer_group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_campaign": {"columns":["campaign_id"],"references":{"table":"campaigns","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			},
 			"check_constraints": {
 				"products_prices_chk_min_quantity": "min_quantity > 0",
@@ -3670,171 +973,48 @@
 		},
 		"products_stock_options": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"stock_item_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"price_modifier": {
-					"type": "ENUM('+','%','*','=')",
-					"default": "'+'"
-				},
-				"price_adjustment": {
-					"type": "VARCHAR(512)",
-					"default": "'+'"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"price_modifier": {"type":"ENUM('+','%','*','=')","default":"'+'"},
+				"price_adjustment": {"type":"VARCHAR(512)","default":"'+'"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"stock_option": [
-					"product_id",
-					"stock_item_id"
-				]
+				"stock_option": ["product_id","stock_item_id"]
 			},
 			"keys": {
-				"product_id": [
-					"product_id"
-				]
+				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_stock_option_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_stock_option_to_stock_item": {
-					"columns": [
-						"stock_item_id"
-					],
-					"references": {
-						"table": "stock_items",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_stock_option_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_stock_option_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"products_to_categories": {
 			"columns": {
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"category_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				}
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"category_id": {"type":"INT","length":10,"unsigned":true}
 			},
-			"primary_key": [
-				"product_id",
-				"category_id"
-			],
+			"primary_key": ["product_id","category_id"],
 			"foreign_keys": {
-				"product_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_to_category": {
-					"columns": [
-						"category_id"
-					],
-					"references": {
-						"table": "categories",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"quantity_units": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"decimals": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 2
-				},
-				"separate": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
+				"separate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"check_constraints": {
 				"quantity_units_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
 				"quantity_units_chk_description": "description IS NULL OR description = '' OR JSON_VALID(description)"
@@ -3842,456 +1022,133 @@
 		},
 		"redirects": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"immediate": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"pattern": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"destination": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"http_response_code": {
-					"type": "ENUM('301','302')",
-					"default": "'301'"
-				},
-				"redirects": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"last_redirected": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_from": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"valid_to": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"immediate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"pattern": {"type":"VARCHAR","length":248,"default":"''"},
+				"destination": {"type":"VARCHAR","length":248,"default":"''"},
+				"http_response_code": {"type":"ENUM('301','302')","default":"'301'"},
+				"redirects": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"last_redirected": {"type":"TIMESTAMP","nullable":true},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"pattern": [
-					"pattern"
-				]
+				"pattern": ["pattern"]
 			},
 			"keys": {
-				"status": [
-					"status"
-				],
-				"immediate": [
-					"immediate"
-				]
+				"status": ["status"],
+				"immediate": ["immediate"]
 			}
 		},
 		"sessions": {
 			"columns": {
-				"id": {
-					"type": "VARCHAR",
-					"length": 128
-				},
-				"customer_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"data": {
-					"type": "TEXT"
-				},
-				"language_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"currency_code": {
-					"type": "CHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 45
-				},
-				"ip_country": {
-					"type": "CHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"fingerprint": {
-					"type": "VARCHAR",
-					"length": 128
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 128
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 256,
-					"default": "''"
-				},
-				"referrer": {
-					"type": "VARCHAR",
-					"length": 256,
-					"default": "''"
-				},
-				"page_views": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"last_url": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"last_request": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"last_active": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"expires_at": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"VARCHAR","length":128},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"data": {"type":"TEXT"},
+				"language_code": {"type":"CHAR","length":2,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"default":"''"},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"ip_address": {"type":"VARCHAR","length":45},
+				"ip_country": {"type":"CHAR","length":2,"default":"''"},
+				"fingerprint": {"type":"VARCHAR","length":128},
+				"hostname": {"type":"VARCHAR","length":128},
+				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
+				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
+				"page_views": {"type":"INT","length":11,"default":0},
+				"last_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_request": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"expires_at": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"customer_id": [
-					"customer_id"
-				],
-				"language_code": [
-					"language_code"
-				],
-				"country_code": [
-					"country_code"
-				],
-				"currency_code": [
-					"currency_code"
-				],
-				"ip_country": [
-					"ip_country"
-				],
-				"fingerprint": [
-					"fingerprint"
-				]
+				"customer_id": ["customer_id"],
+				"language_code": ["language_code"],
+				"country_code": ["country_code"],
+				"currency_code": ["currency_code"],
+				"ip_country": ["ip_country"],
+				"fingerprint": ["fingerprint"]
 			},
 			"foreign_keys": {
-				"session_to_customer": {
-					"columns": [
-						"customer_id"
-					],
-					"references": {
-						"table": "customers",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"session_to_language": {
-					"columns": [
-						"language_code"
-					],
-					"references": {
-						"table": "languages",
-						"columns": [
-							"code"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"session_to_currency": {
-					"columns": [
-						"currency_code"
-					],
-					"references": {
-						"table": "currencies",
-						"columns": [
-							"code"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"session_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"session_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"session_to_currency": {"columns":["currency_code"],"references":{"table":"currencies","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"settings": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"group_key": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"key": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"value": {
-					"type": "VARCHAR",
-					"length": 2048,
-					"default": "''"
-				},
-				"title": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"required": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"function": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_key": {"type":"VARCHAR","length":64,"nullable":true},
+				"key": {"type":"VARCHAR","length":64,"default":"''"},
+				"value": {"type":"VARCHAR","length":2048,"default":"''"},
+				"title": {"type":"VARCHAR","length":128,"default":"''"},
+				"description": {"type":"VARCHAR","length":512,"default":"''"},
+				"required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"function": {"type":"VARCHAR","length":128,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"key": [
-					"key"
-				]
+				"key": ["key"]
 			},
 			"keys": {
-				"group_key": [
-					"group_key"
-				]
+				"group_key": ["group_key"]
 			}
 		},
 		"settings_groups": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"key": {
-					"type": "VARCHAR",
-					"length": 32
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"key": {"type":"VARCHAR","length":32},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":255,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"key": [
-					"key"
-				]
+				"key": ["key"]
 			}
 		},
 		"site_tags": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"default": 0
-				},
-				"position": {
-					"type": "ENUM('head','body')",
-					"default": "'head'"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"content": {
-					"type": "TEXT"
-				},
-				"require_consent": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"priority": {
-					"type": "TINYINT",
-					"length": 4,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"position": {"type":"ENUM('head','body')","default":"'head'"},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"content": {"type":"TEXT"},
+				"require_consent": {"type":"VARCHAR","length":64,"nullable":true},
+				"priority": {"type":"TINYINT","length":4,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"position": [
-					"position"
-				],
-				"priority": [
-					"priority"
-				]
+				"status": ["status"],
+				"position": ["position"],
+				"priority": ["priority"]
 			}
 		},
 		"sold_out_statuses": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"hidden": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"orderable": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"description": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"orderable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"hidden": [
-					"hidden"
-				],
-				"orderable": [
-					"orderable"
-				]
+				"hidden": ["hidden"],
+				"orderable": ["orderable"]
 			},
 			"check_constraints": {
 				"sold_out_statuses_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -4300,252 +1157,65 @@
 		},
 		"statistics": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"type": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"entity_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"entity_type": {
-					"type": "VARCHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"measure_group_type": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"measure_group_value": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"count": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"type": {"type":"VARCHAR","length":32,"default":"''"},
+				"entity_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"entity_type": {"type":"VARCHAR","length":32,"nullable":true},
+				"measure_group_type": {"type":"VARCHAR","length":32,"default":"''"},
+				"measure_group_value": {"type":"VARCHAR","length":64,"default":"''"},
+				"count": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
-			"keys": {
-				"entity_id": [
-					"entity_id"
-				],
-				"entity_type": [
-					"entity_type"
-				],
-				"measure_group_type": [
-					"measure_group_type"
-				],
-				"measure_group_value": [
-					"measure_group_value"
-				]
-			},
+			"primary_key": ["id"],
 			"unique_keys": {
-				"measure": [
-					"type",
-					"entity_id",
-					"entity_type",
-					"measure_group_type",
-					"measure_group_value"
-				]
+				"measure": ["type","entity_id","entity_type","measure_group_type","measure_group_value"]
+			},
+			"keys": {
+				"entity_id": ["entity_id"],
+				"entity_type": ["entity_type"],
+				"measure_group_type": ["measure_group_type"],
+				"measure_group_value": ["measure_group_value"]
 			}
 		},
 		"stock_items": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"brand_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"supplier_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"name": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"attributes": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"sku": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"mpn": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"gtin": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"shelf": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"taric": {
-					"type": "VARCHAR",
-					"length": 16,
-					"default": "''"
-				},
-				"image": {
-					"type": "VARCHAR",
-					"length": 512,
-					"default": "''"
-				},
-				"weight": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"weight_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"length": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"width": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"height": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"length_unit": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"quantity": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"quantity_unit_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0.0
-				},
-				"backordered": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"purchase_price": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0.0
-				},
-				"purchase_price_currency_code": {
-					"type": "VARCHAR",
-					"length": 3,
-					"default": "''"
-				},
-				"file": {
-					"type": "VARCHAR",
-					"length": 248,
-					"nullable": true
-				},
-				"filename": {
-					"type": "VARCHAR",
-					"length": 64,
-					"nullable": true
-				},
-				"mime_type": {
-					"type": "VARCHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"downloads": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"priority": {
-					"type": "INT",
-					"length": 11,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"name": {"type":"TEXT","nullable":true},
+				"attributes": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":16,"default":"''"},
+				"image": {"type":"VARCHAR","length":512,"default":"''"},
+				"weight": {"type":"DECIMAL","length":"10,4","default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"length": {"type":"DECIMAL","length":"10,4","default":0},
+				"width": {"type":"DECIMAL","length":"10,4","default":0},
+				"height": {"type":"DECIMAL","length":"10,4","default":0},
+				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
+				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"backordered": {"type":"DECIMAL","length":"10,4","default":0},
+				"purchase_price": {"type":"DECIMAL","length":"10,4","default":0},
+				"purchase_price_currency_code": {"type":"VARCHAR","length":3,"default":"''"},
+				"file": {"type":"VARCHAR","length":248,"nullable":true},
+				"filename": {"type":"VARCHAR","length":64,"nullable":true},
+				"mime_type": {"type":"VARCHAR","length":32,"nullable":true},
+				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"mpn": [
-					"mpn"
-				],
-				"gtin": [
-					"gtin"
-				],
-				"sku": [
-					"sku"
-				],
-				"brand_id": [
-					"brand_id"
-				],
-				"supplier_id": [
-					"supplier_id"
-				]
-			},
-			"fulltext_keys": {
-				"name": [
-					"name"
-				]
+				"mpn": ["mpn"],
+				"gtin": ["gtin"],
+				"sku": ["sku"],
+				"brand_id": ["brand_id"],
+				"supplier_id": ["supplier_id"]
 			},
 			"check_constraints": {
 				"stock_items_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)"
@@ -4553,500 +1223,132 @@
 		},
 		"stock_items_references": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"stock_item_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"supplier_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"stock_item_id": [
-					"stock_item_id"
-				]
+				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_item": {
-					"columns": [
-						"stock_item_id"
-					],
-					"references": {
-						"table": "stock_items",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"supplier": {
-					"columns": [
-						"supplier_id"
-					],
-					"references": {
-						"table": "suppliers",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"supplier": {"columns":["supplier_id"],"references":{"table":"suppliers","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"stock_transactions": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"description": {
-					"type": "MEDIUMTEXT"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"description": {"type":"MEDIUMTEXT"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			]
+			"primary_key": ["id"]
 		},
 		"stock_transactions_contents": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"transaction_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"product_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"stock_item_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"nullable": true
-				},
-				"quantity_adjustment": {
-					"type": "DECIMAL",
-					"length": "10,4",
-					"default": 0
-				},
-				"sku": {
-					"type": "VARCHAR",
-					"length": 32
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"transaction_id": {"type":"INT","length":10,"unsigned":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"quantity_adjustment": {"type":"DECIMAL","length":"10,4","default":0},
+				"sku": {"type":"VARCHAR","length":32}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"transaction_id": [
-					"transaction_id"
-				],
-				"product_id": [
-					"product_id"
-				],
-				"stock_item_id": [
-					"stock_item_id"
-				]
+				"transaction_id": ["transaction_id"],
+				"product_id": ["product_id"],
+				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_transaction_content_to_transaction": {
-					"columns": [
-						"transaction_id"
-					],
-					"references": {
-						"table": "stock_transactions",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"stock_transaction_content_to_product": {
-					"columns": [
-						"product_id"
-					],
-					"references": {
-						"table": "products",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"stock_transaction_content_to_stock_item": {
-					"columns": [
-						"stock_item_id"
-					],
-					"references": {
-						"table": "stock_items",
-						"columns": [
-							"id"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"stock_transaction_content_to_transaction": {"columns":["transaction_id"],"references":{"table":"stock_transactions","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"stock_transaction_content_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"stock_transaction_content_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"suppliers": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "TEXT"
-				},
-				"email": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"phone": {
-					"type": "VARCHAR",
-					"length": 24,
-					"default": "''"
-				},
-				"link": {
-					"type": "VARCHAR",
-					"length": 255,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"TEXT"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"phone": {"type":"VARCHAR","length":24,"default":"''"},
+				"link": {"type":"VARCHAR","length":255,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"code": [
-					"code"
-				]
+				"code": ["code"]
 			}
 		},
 		"tax_classes": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":64,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			]
+			"primary_key": ["id"]
 		},
 		"tax_rates": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"tax_class_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"geo_zone_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 32,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"rate": {
-					"type": "DECIMAL",
-					"length": "6,4",
-					"unsigned": true,
-					"default": 0.0
-				},
-				"address_type": {
-					"type": "ENUM('shipping','payment')",
-					"default": "'shipping'"
-				},
-				"rule_companies_with_tax_id": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"rule_companies_without_tax_id": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"rule_individuals_with_tax_id": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"rule_individuals_without_tax_id": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":128,"default":"''"},
+				"rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
+				"address_type": {"type":"ENUM('shipping','payment')","default":"'shipping'"},
+				"rule_companies_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_companies_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_individuals_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_individuals_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"tax_class_id": [
-					"tax_class_id"
-				],
-				"geo_zone_id": [
-					"geo_zone_id"
-				]
+				"tax_class_id": ["tax_class_id"],
+				"geo_zone_id": ["geo_zone_id"]
 			},
 			"foreign_keys": {
-				"tax_rate_to_tax_class": {
-					"columns": [
-						"tax_class_id"
-					],
-					"references": {
-						"table": "tax_classes",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"tax_rate_to_geo_zone": {
-					"columns": [
-						"geo_zone_id"
-					],
-					"references": {
-						"table": "geo_zones",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "RESTRICT"
-					}
-				}
+				"tax_rate_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"tax_rate_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"RESTRICT"}}
 			}
 		},
 		"third_parties": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"status": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"privacy_classes": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"category": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"description": {
-					"type": "MEDIUMTEXT",
-					"nullable": true
-				},
-				"collected_data": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"purposes": {
-					"type": "TEXT",
-					"nullable": true
-				},
-				"homepage": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"cookie_policy_url": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"privacy_policy_url": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"opt_out_url": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"do_not_sell_url": {
-					"type": "VARCHAR",
-					"length": 248,
-					"default": "''"
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2,
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "current_timestamp()"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "current_timestamp()"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"privacy_classes": {"type":"VARCHAR","length":64,"default":"''"},
+				"category": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"collected_data": {"type":"TEXT","nullable":true},
+				"purposes": {"type":"TEXT","nullable":true},
+				"homepage": {"type":"VARCHAR","length":248,"default":"''"},
+				"cookie_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"privacy_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"opt_out_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"do_not_sell_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"current_timestamp()"},
+				"created_at": {"type":"TIMESTAMP","default":"current_timestamp()"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"status": [
-					"status"
-				],
-				"country_code": [
-					"country_code"
-				]
+				"status": ["status"],
+				"country_code": ["country_code"]
 			},
 			"foreign_keys": {
-				"third_party_to_country": {
-					"columns": [
-						"country_code"
-					],
-					"references": {
-						"table": "countries",
-						"columns": [
-							"iso_code_2"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"third_party_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"third_parties_chk_description": "description IS NULL OR description = '' OR JSON_VALID(description)",
@@ -5056,322 +1358,93 @@
 		},
 		"translations": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"text_en": {
-					"type": "TEXT"
-				},
-				"html": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"frontend": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"backend": {
-					"type": "TINYINT",
-					"length": 1,
-					"unsigned": true,
-					"default": 0
-				},
-				"last_accessed": {
-					"type": "TIMESTAMP",
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":128,"default":"''"},
+				"text_en": {"type":"TEXT"},
+				"html": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"frontend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"backend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"last_accessed": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"code": [
-					"code"
-				]
+				"code": ["code"]
 			},
 			"keys": {
-				"frontend": [
-					"frontend"
-				],
-				"backend": [
-					"backend"
-				],
-				"created_at": [
-					"created_at"
-				]
+				"frontend": ["frontend"],
+				"backend": ["backend"],
+				"created_at": ["created_at"]
 			}
 		},
 		"visitors": {
 			"columns": {
-				"id": {
-					"type": "BIGINT",
-					"length": 20,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"session_id": {
-					"type": "VARCHAR",
-					"length": 13,
-					"default": "''"
-				},
-				"cart_uid": {
-					"type": "VARCHAR",
-					"length": 13,
-					"default": "''"
-				},
-				"referrer": {
-					"type": "VARCHAR",
-					"length": 256,
-					"default": "''"
-				},
-				"ip_address": {
-					"type": "VARCHAR",
-					"length": 39,
-					"default": "''"
-				},
-				"hostname": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"user_agent": {
-					"type": "VARCHAR",
-					"length": 256,
-					"default": "''"
-				},
-				"language": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"country_code": {
-					"type": "VARCHAR",
-					"length": 2,
-					"default": "''"
-				},
-				"pageviews": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"default": 0
-				},
-				"last_page": {
-					"type": "VARCHAR",
-					"length": 128,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
+				"session_id": {"type":"VARCHAR","length":13,"default":"''"},
+				"cart_uid": {"type":"VARCHAR","length":13,"default":"''"},
+				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":64,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
+				"language": {"type":"VARCHAR","length":2,"default":"''"},
+				"country_code": {"type":"VARCHAR","length":2,"default":"''"},
+				"pageviews": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"last_page": {"type":"VARCHAR","length":128,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"session_id": [
-					"session_id"
-				],
-				"country_code": [
-					"country_code"
-				],
-				"language": [
-					"language"
-				],
-				"updated_at": [
-					"updated_at"
-				],
-				"created_at": [
-					"created_at"
-				]
+				"session_id": ["session_id"],
+				"country_code": ["country_code"],
+				"language": ["language"],
+				"updated_at": ["updated_at"],
+				"created_at": ["created_at"]
 			}
 		},
 		"zones": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2
-				},
-				"code": {
-					"type": "VARCHAR",
-					"length": 8
-				},
-				"name": {
-					"type": "VARCHAR",
-					"length": 64,
-					"default": "''"
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"country_code": {"type":"CHAR","length":2},
+				"code": {"type":"VARCHAR","length":8},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"keys": {
-				"country_code": [
-					"country_code"
-				],
-				"code": [
-					"code"
-				]
+				"country_code": ["country_code"],
+				"code": ["code"]
 			},
 			"foreign_keys": {
-				"zone_to_country": {
-					"columns": [
-						"country_code"
-					],
-					"references": {
-						"table": "countries",
-						"columns": [
-							"iso_code_2"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"zone_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"zones_to_geo_zones": {
 			"columns": {
-				"id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true,
-					"auto_increment": true
-				},
-				"geo_zone_id": {
-					"type": "INT",
-					"length": 10,
-					"unsigned": true
-				},
-				"country_code": {
-					"type": "CHAR",
-					"length": 2
-				},
-				"zone_code": {
-					"type": "VARCHAR",
-					"length": 8,
-					"nullable": true
-				},
-				"city": {
-					"type": "VARCHAR",
-					"length": 32,
-					"nullable": true
-				},
-				"updated_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP",
-					"on_update": "CURRENT_TIMESTAMP"
-				},
-				"created_at": {
-					"type": "TIMESTAMP",
-					"default": "CURRENT_TIMESTAMP"
-				}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
+				"country_code": {"type":"CHAR","length":2},
+				"zone_code": {"type":"VARCHAR","length":8,"nullable":true},
+				"city": {"type":"VARCHAR","length":32,"nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
-			"primary_key": [
-				"id"
-			],
+			"primary_key": ["id"],
 			"unique_keys": {
-				"region": [
-					"geo_zone_id",
-					"country_code",
-					"zone_code",
-					"city"
-				]
+				"region": ["geo_zone_id","country_code","zone_code","city"]
 			},
 			"keys": {
-				"geo_zone_id": [
-					"geo_zone_id"
-				],
-				"country_code": [
-					"country_code"
-				],
-				"zone_code": [
-					"zone_code"
-				],
-				"city": [
-					"city"
-				]
+				"geo_zone_id": ["geo_zone_id"],
+				"country_code": ["country_code"],
+				"zone_code": ["zone_code"],
+				"city": ["city"]
 			},
 			"foreign_keys": {
-				"zone_entry_to_geo_zone": {
-					"columns": [
-						"geo_zone_id"
-					],
-					"references": {
-						"table": "geo_zones",
-						"columns": [
-							"id"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"zone_entry_to_country": {
-					"columns": [
-						"country_code"
-					],
-					"references": {
-						"table": "countries",
-						"columns": [
-							"iso_code_2"
-						],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"zone_entry_to_zone": {
-					"columns": [
-						"zone_code"
-					],
-					"references": {
-						"table": "zones",
-						"columns": [
-							"code"
-						],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"zone_entry_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"zone_entry_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"zone_entry_to_zone": {"columns":["zone_code"],"references":{"table":"zones","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		}
 	}


### PR DESCRIPTION
Restores the single-line column definitions that got expanded to multi-line in 58cd5d6.

All MySQL 8 compatibility fixes are preserved — only whitespace changed. 5377 → 1452 lines.

## Test plan

- [ ] \`node -e "JSON.parse(require('fs').readFileSync('public_html/install/structure.json','utf8'))"\` passes
- [ ] Fresh install against MySQL 8 still works