### PR TITLE
[v3] * Fix HTML validity and JS anti-patterns in storefront

### DIFF
--- a/public_html/assets/litecore/js/components/dropdown.js
+++ b/public_html/assets/litecore/js/components/dropdown.js
@@ -21,8 +21,6 @@ waitFor('jQuery', ($) => {
 		if (!values.length) {
 			values = [ $dropdown.find('.dropdown-toggle').data('placeholder') ];
 		}
-		console.log('"'+values.join(', ')+'"');
-
 		$dropdown.find('.dropdown-toggle').text(values.join(', '));
 	});
 

--- a/public_html/assets/litecore/js/framework.js
+++ b/public_html/assets/litecore/js/framework.js
@@ -634,8 +634,6 @@ waitFor('jQuery', ($) => {
 		if (!values.length) {
 			values = [ $dropdown.find('.dropdown-toggle').data('placeholder') ];
 		}
-		console.log('"'+values.join(', ')+'"');
-
 		$dropdown.find('.dropdown-toggle').text(values.join(', '));
 	});
 

--- a/public_html/frontend/templates/default/js/app.js
+++ b/public_html/frontend/templates/default/js/app.js
@@ -192,7 +192,7 @@ waitFor('jQuery', ($) => {
 			});
 		};
 
-		let timerCart = setInterval('updateCart()', 60e3); // Keeps session alive
+		let timerCart = setInterval(updateCart, 60e3); // Keeps session alive
 	}
 });
 

--- a/public_html/frontend/templates/default/js/components/cart.js
+++ b/public_html/frontend/templates/default/js/components/cart.js
@@ -149,6 +149,6 @@ waitFor('jQuery', ($) => {
 			});
 		};
 
-		let timerCart = setInterval('updateCart()', 60e3); // Keeps session alive
+		let timerCart = setInterval(updateCart, 60e3); // Keeps session alive
 	}
 });

--- a/public_html/frontend/templates/default/pages/checkout/index.inc.php
+++ b/public_html/frontend/templates/default/pages/checkout/index.inc.php
@@ -204,10 +204,10 @@
 							<table class="table data-table">
 								<thead>
 									<tr>
-										<th class="text-start"><?php echo t('title_item', 'Item'); ?></td>
-										<th class="text-end"><?php echo t('title_price', 'Price'); ?></td>
-										<th class="text-end"><?php echo t('title_discount', 'Discount'); ?></td>
-										<th class="text-end"><?php echo t('title_sum', 'Sum'); ?></td>
+										<th class="text-start"><?php echo t('title_item', 'Item'); ?></th>
+										<th class="text-end"><?php echo t('title_price', 'Price'); ?></th>
+										<th class="text-end"><?php echo t('title_discount', 'Discount'); ?></th>
+										<th class="text-end"><?php echo t('title_sum', 'Sum'); ?></th>
 									</tr>
 								</thead>
 

--- a/public_html/frontend/templates/default/pages/order_success.inc.php
+++ b/public_html/frontend/templates/default/pages/order_success.inc.php
@@ -19,7 +19,7 @@
 					<?php } ?>
 				</ul>
 
-				<p><strong><?php echo t('title_order_total', 'Order Total'); ?></strong>: <?php echo currency::format($order['total'], false, $order['currency_code'], $order['currency_value']); ?>
+				<p><strong><?php echo t('title_order_total', 'Order Total'); ?></strong>: <?php echo currency::format($order['total'], false, $order['currency_code'], $order['currency_value']); ?></p>
 
 				<p><a href="{{printable_link|escape}}" target="_blank"><?php echo t('description_click_printable_copy', 'Click here for a printable copy'); ?></a></p>
 

--- a/public_html/frontend/templates/default/pages/shopping_cart.inc.php
+++ b/public_html/frontend/templates/default/pages/shopping_cart.inc.php
@@ -64,7 +64,7 @@
 										</div>
 
 										<div class="col-1 text-end">
-											<td><?php echo f::form_button('remove_cart_item', [$key, f::draw_fonticon('icon-trash')], 'submit', 'class="btn btn-danger" title="'. f::escape_attr(t('title_remove', 'Remove')) .'" formnovalidate'); ?></td>
+											<?php echo f::form_button('remove_cart_item', [$key, f::draw_fonticon('icon-trash')], 'submit', 'class="btn btn-danger" title="'. f::escape_attr(t('title_remove', 'Remove')) .'" formnovalidate'); ?>
 										</div>
 									</div>
 								</li>
@@ -92,7 +92,7 @@
 
 			<div class="col-md-5">
 
-				<section id="box-shopping-cart" class="card">
+				<section id="box-checkout-start" class="card">
 
 					<div class="card-header">
 						<h2 class="card-title"><?php echo t('title_checkout', 'Checkout'); ?></h2>

--- a/public_html/frontend/templates/default/partials/site_footer.inc.php
+++ b/public_html/frontend/templates/default/partials/site_footer.inc.php
@@ -92,7 +92,7 @@
 						<?php if (settings::get('store_phone')) { ?>
 						<p class="phone">
 							<?php echo f::draw_fonticon('icon-phone'); ?> <a href="tel:<?php echo settings::get('store_phone'); ?>"><?php echo settings::get('store_phone'); ?></a>
-						<p>
+						</p>
 						<?php } ?>
 
 						<p class="email">


### PR DESCRIPTION
Handful of correctness fixes found during a frontend audit — no functional changes, just cleaning up invalid markup and JS patterns.

## Summary

| Fix | Files | Impact |
|-----|-------|--------|
| Duplicate `id="box-shopping-cart"` on cart page | `shopping_cart.inc.php` | Renamed checkout section to `id="box-checkout-start"` |
| `<th>` closed with `</td>` in checkout summary | `checkout/index.inc.php` | 4 closing tags fixed |
| `<td>` outside `<table>` context | `shopping_cart.inc.php` | Removed stray wrapper |
| `setInterval('string')` (implicit eval) | `cart.js`, `app.js` | Changed to function reference — enables strict CSP |
| `console.log` in dropdown component | `framework.js`, `dropdown.js` | Removed (already cleaned up in LiteCore upstream) |
| Unclosed `<p>` tags | `site_footer.inc.php`, `order_success.inc.php` | Proper closing tags |

## Test plan

- [x] Cart page: remove button still works, no duplicate ID warnings in dev tools
- [x] Checkout: order summary table renders correctly
- [x] Cart session keep-alive timer still fires (verify in Network tab)
- [x] Dropdown selections still display correctly (no console spam)
- [x] Footer phone number renders in its own paragraph
- [x] Order success page: Order Total on its own line