### PR TITLE
[v3] + Add title_person_name translation key (fixes #82)

### DIFF
--- a/public_html/backend/apps/administrators/administrators.inc.php
+++ b/public_html/backend/apps/administrators/administrators.inc.php
@@ -90,7 +90,7 @@
 					<th></th>
 					<th></th>
 					<th><?php echo t('title_username', 'Username'); ?></th>
-					<th><?php echo t('title_name', 'Name'); ?></th>
+					<th><?php echo t('title_person_name', 'Name'); ?></th>
 					<th class="main"><?php echo t('title_email', 'Email'); ?></th>
 					<th><?php echo t('title_restrictions', 'Restrictions'); ?></th>
 					<th class="text-end" style="min-width: 200px;"><?php echo t('title_valid_from', 'Valid From'); ?></th>

--- a/public_html/backend/apps/customers/customer_picker.inc.php
+++ b/public_html/backend/apps/customers/customer_picker.inc.php
@@ -25,7 +25,7 @@
 				<thead>
 					<tr>
 						<th><?php echo t('title_id', 'ID'); ?></th>
-						<th><?php echo t('title_name', 'Name'); ?></th>
+						<th><?php echo t('title_person_name', 'Name'); ?></th>
 						<th class="main"><?php echo t('title_email', 'Email'); ?></th>
 						<th><?php echo t('title_date_registered', 'Date Registered'); ?></th>
 					</tr>

--- a/public_html/backend/apps/customers/customers.inc.php
+++ b/public_html/backend/apps/customers/customers.inc.php
@@ -139,7 +139,7 @@
 					<th style="width: 40px;"><?php echo f::draw_fonticon('icon-square-check', 'data-toggle="checkbox-toggle"'); ?></th>
 					<th style="width: 40px;"></th>
 					<th data-sort="id" style="width: 50px;"><?php echo t('title_id', 'ID'); ?></th>
-					<th data-sort="name"><?php echo t('title_name', 'Name'); ?></th>
+					<th data-sort="name"><?php echo t('title_person_name', 'Name'); ?></th>
 					<th data-sort="email"><?php echo t('title_email', 'Email'); ?></th>
 					<th data-sort="company"><?php echo t('title_company_name', 'Company Name'); ?></th>
 					<th class="main"><?php echo t('title_last_hostname', 'Last Hostname'); ?></th>

--- a/public_html/backend/apps/customers/newsletter_recipients.inc.php
+++ b/public_html/backend/apps/customers/newsletter_recipients.inc.php
@@ -166,7 +166,7 @@
 					<th style="width: 50px;"><?php echo f::draw_fonticon('icon-square-check', 'data-toggle="checkbox-toggle"'); ?></th>
 					<th><?php echo t('title_subscribed', 'Subscribed'); ?></th>
 					<th style="width: 480px;"><?php echo t('title_email', 'Email'); ?></th>
-					<th class="main"><?php echo t('title_name', 'Name'); ?></th>
+					<th class="main"><?php echo t('title_person_name', 'Name'); ?></th>
 					<th><?php echo t('title_ip_address', 'IP Address'); ?></th>
 					<th style="width: 200px;"><?php echo t('title_hostname', 'Hostname'); ?></th>
 					<th class="text-end" style="width: 200px;"><?php echo t('title_updated_at', 'Updated At'); ?></th>


### PR DESCRIPTION
Nine years in the making — finally a clean fix for the Lithuanian name translation issue.

## Summary

Languages like Lithuanian, Czech, and Arabic use different words for "Name" depending on whether it refers to a person or a thing. The existing `title_name` key is used in 57 places for both contexts.

This PR introduces `title_person_name` for the 4 locations where "Name" refers to a person:

| File | Context |
|------|---------|
| `administrators/administrators.inc.php` | Admin listing table |
| `customers/customers.inc.php` | Customer listing table |
| `customers/customer_picker.inc.php` | Customer picker modal |
| `customers/newsletter_recipients.inc.php` | Newsletter recipients table |

The remaining 53 uses of `title_name` (products, categories, brands, modules, etc.) stay unchanged.

**Backwards-compatible:** The default is `"Name"` — identical to before. Languages that don't translate `title_person_name` see no change. Languages that need the distinction can now provide a separate translation.

## Test plan

- [ ] Admin list, customer list, customer picker, newsletter recipients all show "Name" column header (no visual change in English)
- [ ] All other admin pages still show "Name" for product/category/brand columns
- [ ] Translation system registers `title_person_name` as a new translatable key