### PR TITLE
[v3] + Campaign scope discounts for categories and brands

### DIFF
--- a/public_html/backend/apps/catalog/campaigns.inc.php
+++ b/public_html/backend/apps/catalog/campaigns.inc.php
@@ -34,7 +34,7 @@
 
 	// Table Rows, Total Number of Rows, Total Number of Pages
 	$campaigns = database::query(
-		"select c.*, cp.num_products
+		"select c.*, cp.num_products, csp.num_scope_products
 		from ". DB_TABLE_PREFIX ."campaigns c
 		left join (
 			select campaign_id, count(*) as num_products
@@ -42,6 +42,14 @@
 			where campaign_id is not null
 			group by campaign_id
 		) cp on (cp.campaign_id = c.id)
+		left join (
+			select cs.campaign_id, count(distinct p.id) as num_scope_products
+			from ". DB_TABLE_PREFIX ."campaigns_scopes cs
+			left join ". DB_TABLE_PREFIX ."products_to_categories ptc on (cs.scope_type = 'category' and cs.scope_id = ptc.category_id)
+			left join ". DB_TABLE_PREFIX ."products p on (p.id = ptc.product_id or (cs.scope_type = 'brand' and p.brand_id = cs.scope_id))
+			where p.id is not null
+			group by cs.campaign_id
+		) csp on (csp.campaign_id = c.id)
 		order by c.status desc, c.valid_from, c.valid_to;"
 	)->fetch_page(null, null, $_GET['page'], null, $num_rows, $num_pages);
 
@@ -65,6 +73,7 @@
 					<th><?php echo f::draw_fonticon('icon-square-check checkbox-toggle', 'data-toggle="checkbox-toggle"'); ?></th>
 					<th><?php echo t('title_ID', 'ID'); ?></th>
 					<th class="main"><?php echo t('title_Name', 'Name'); ?></th>
+					<th><?php echo t('title_type', 'Type'); ?></th>
 					<th class="text-end"><?php echo t('title_valid_from', 'Valid From'); ?></th>
 					<th class="text-end"><?php echo t('title_valid_to', 'Valid To'); ?></th>
 					<th class="text-end"><?php echo t('title_products', 'Products'); ?></th>
@@ -78,9 +87,10 @@
 					<td><?php echo f::form_checkbox('campaigns[]', $campaign['id']); ?></td>
 					<td><?php echo $campaign['id']; ?></td>
 					<td><a class="link" href="<?php echo document::href_ilink(__APP__.'/edit_campaign', ['campaign_id' => $campaign['id']]); ?>"><?php echo $campaign['name']; ?></a></td>
+					<td><?php echo $campaign['discount_mode'] == 'percentage' ? '-'. (float)$campaign['discount_percent'] .'%' : t('title_fixed_prices', 'Fixed Prices'); ?></td>
 					<td class="text-end"><?php echo $campaign['valid_from'] ? f::datetime_format('datetime', $campaign['valid_from']) : ''; ?></td>
 					<td class="text-end"><?php echo $campaign['valid_to'] ? f::datetime_format('datetime', $campaign['valid_to']) : ''; ?></td>
-					<td class="text-center"><?php echo f::format_number($campaign['num_products']); ?></td>
+					<td class="text-center"><?php echo f::format_number($campaign['discount_mode'] == 'percentage' ? $campaign['num_scope_products'] : $campaign['num_products']); ?></td>
 					<td class="text-end">
 						<a class="btn btn-default btn-sm" href="<?php echo document::href_ilink(__APP__.'/edit_campaign', ['campaign_id' => $campaign['id']]); ?>" title="<?php echo t('title_edit', 'Edit'); ?>">
 							<?php echo f::draw_fonticon('edit'); ?>

--- a/public_html/backend/apps/catalog/edit_campaign.inc.php
+++ b/public_html/backend/apps/catalog/edit_campaign.inc.php
@@ -32,12 +32,25 @@
 				$_POST['products'] = [];
 			}
 
+			// Parse scope checkboxes (format: "category:5", "brand:3")
+			$_POST['scopes'] = array_map(function($val) {
+				list($type, $id) = explode(':', $val, 2);
+				return ['scope_type' => $type, 'scope_id' => (int)$id];
+			}, array_filter((array)($_POST['scopes'] ?? [])));
+
+			if ($_POST['discount_mode'] == 'percentage' && empty($_POST['scopes'])) {
+				throw new Exception(t('error_must_provide_scope', 'You must select at least one category or brand'));
+			}
+
 			foreach ([
 				'status',
 				'name',
+				'discount_mode',
+				'discount_percent',
 				'valid_from',
 				'valid_to',
 				'products',
+				'scopes',
 			] as $field) {
 				if (isset($_POST[$field])) {
 					$campaign->data[$field] = $_POST[$field];
@@ -125,9 +138,71 @@
 					</div>
 				</div>
 
+			<div class="grid">
+					<div class="col-md-12">
+						<label class="form-group">
+							<div class="form-label"><?php echo t('title_discount_mode', 'Discount Mode'); ?></div>
+							<?php echo f::form_toggle('discount_mode', ['fixed' => t('title_fixed_prices', 'Fixed Prices'), 'percentage' => t('title_percentage_discount', 'Percentage Discount')], true); ?>
+						</label>
+					</div>
+				</div>
+
+				<div id="percentage-settings" style="<?php echo ($_POST['discount_mode'] ?? 'fixed') != 'percentage' ? 'display: none;' : ''; ?>">
+					<div class="grid">
+						<div class="col-md-4">
+							<label class="form-group">
+								<div class="form-label"><?php echo t('title_discount_percent', 'Discount (%)'); ?></div>
+								<?php echo f::form_input_number('discount_percent', true, 'min="0" max="100" step="0.01"'); ?>
+							</label>
+						</div>
+					</div>
+
+					<div class="grid">
+						<div class="col-md-6">
+							<fieldset style="padding: 15px; border: 1px solid var(--default-border-color); border-radius: var(--border-radius);">
+								<legend style="font-weight: bold; padding: 0 5px;"><?php echo t('title_categories', 'Categories'); ?></legend>
+								<?php
+									$categories = database::query(
+										"select c.id, json_value(c.name, '$.". database::input(language::$selected['code']) ."') as name
+										from ". DB_TABLE_PREFIX ."categories c
+										where c.status
+										order by name;"
+									)->fetch_all();
+									$selected_category_ids = array_column(array_filter($_POST['scopes'] ?? [], function($s) { return $s['scope_type'] == 'category'; }), 'scope_id');
+									foreach ($categories as $cat) {
+								?>
+								<label class="form-group" style="margin-bottom: 0.25em;">
+									<input type="checkbox" name="scopes[]" value="category:<?php echo $cat['id']; ?>" <?php echo in_array($cat['id'], $selected_category_ids) ? 'checked' : ''; ?> /> <?php echo $cat['name']; ?>
+								</label>
+								<?php } ?>
+							</fieldset>
+						</div>
+
+						<div class="col-md-6">
+							<fieldset style="padding: 15px; border: 1px solid var(--default-border-color); border-radius: var(--border-radius);">
+								<legend style="font-weight: bold; padding: 0 5px;"><?php echo t('title_brands', 'Brands'); ?></legend>
+								<?php
+									$brands = database::query(
+										"select id, name from ". DB_TABLE_PREFIX ."brands
+										where status
+										order by name;"
+									)->fetch_all();
+									$selected_brand_ids = array_column(array_filter($_POST['scopes'] ?? [], function($s) { return $s['scope_type'] == 'brand'; }), 'scope_id');
+									foreach ($brands as $brand) {
+								?>
+								<label class="form-group" style="margin-bottom: 0.25em;">
+									<input type="checkbox" name="scopes[]" value="brand:<?php echo $brand['id']; ?>" <?php echo in_array($brand['id'], $selected_brand_ids) ? 'checked' : ''; ?> /> <?php echo $brand['name']; ?>
+								</label>
+								<?php } ?>
+							</fieldset>
+						</div>
+					</div>
+				</div>
+
 			</div>
 		</div>
 
+		<div id="fixed-price-settings" style="<?php echo ($_POST['discount_mode'] ?? 'fixed') == 'percentage' ? 'display: none;' : ''; ?>">
 		<table id="campaigns" class="table data-table">
 			<thead>
 				<tr>
@@ -180,6 +255,7 @@
 			<a href="<?php echo document::href_ilink(__APP__.'/product_picker'); ?>" class="btn btn-default" data-toggle="lightbox" data-max-width="800px" data-callback="add_product">
 				<?php echo f::draw_fonticon('icon-plus', 'style="margin-inline-end: .5em;"'); ?> <?php echo t('title_add_product', 'Add Product'); ?>
 			</a>
+		</div>
 		</div>
 
 		<div class="card-action">
@@ -253,6 +329,16 @@
 		e.preventDefault();
 		if (confirm('<?php echo t('text_are_you_sure', 'Are you sure?'); ?>')) {
 			this.closest('tr').remove();
+		}
+	});
+
+	$('input[name="discount_mode"]').on('change', function() {
+		if ($(this).val() == 'percentage') {
+			$('#percentage-settings').show();
+			$('#fixed-price-settings').hide();
+		} else {
+			$('#percentage-settings').hide();
+			$('#fixed-price-settings').show();
 		}
 	});
 

--- a/public_html/frontend/pages/product.inc.php
+++ b/public_html/frontend/pages/product.inc.php
@@ -232,7 +232,9 @@
 	}
 
 	// Sticker
-	if (!empty($product->campaign['price']) && $product->price > 0 && $product->campaign['price'] > 0) {
+	if (!empty($product->campaign['scope_discount_percent'])) {
+		$_page->snippets['sticker'] = '<div class="sticker sale">-'. (int)$product->campaign['scope_discount_percent'] .'%</div>';
+	} else if (!empty($product->campaign['price']) && $product->price > 0 && $product->campaign['price'] > 0) {
 		$percentage = round(($product->price - $product->campaign['price']) / $product->price * 100);
 		$_page->snippets['sticker'] = '<div class="sticker sale">'. t('sticker_sale', 'Sale') .' -'. $percentage .'%</div>';
 	} else if ($product->created_at > date('Y-m-d', strtotime('-'.settings::get('new_products_max_age')))) {

--- a/public_html/includes/entities/ent_campaign.inc.php
+++ b/public_html/includes/entities/ent_campaign.inc.php
@@ -24,6 +24,7 @@
 			});
 
 			$this->data['products']	= [];
+			$this->data['scopes'] = [];
 
 			$this->previous = $this->data;
 		}
@@ -47,6 +48,12 @@
 			}
 
 			$this->data = array_replace($this->data, array_intersect_key($campaign, $this->data));
+
+			$this->data['scopes'] = database::query(
+				"select * from ". DB_TABLE_PREFIX ."campaigns_scopes
+				where campaign_id = ". (int)$this->data['id'] ."
+				order by scope_type, scope_id;"
+			)->fetch_all();
 
 			$this->data['products'] = database::query(
 				"select pp.id, pp.product_id, pp.campaign_id, pp.customer_group_id, pp.geo_zone_id, pp.price,
@@ -93,6 +100,8 @@
 			database::query(
 				"update ". DB_TABLE_PREFIX ."campaigns
 				set name = '". database::input($this->data['name']) ."',
+					discount_mode = '". database::input($this->data['discount_mode'] ?: 'fixed') ."',
+					discount_percent = ". min(100, max(0, (float)$this->data['discount_percent'])) .",
 					valid_from = ". (!empty($this->data['valid_from']) ? "'". database::input($this->data['valid_from']) ."'" : "null") .",
 					valid_to = ". (!empty($this->data['valid_to']) ? "'". database::input($this->data['valid_to']) ."'" : "null") ."
 				where id = ". (int)$this->data['id'] ."
@@ -129,6 +138,26 @@
 					where id = ". (int)$campaign_product['id'] ."
 					limit 1;"
 				);
+			}
+
+			// Save scopes (percentage mode only)
+			if ($this->data['discount_mode'] == 'percentage') {
+
+				database::query(
+					"delete from ". DB_TABLE_PREFIX ."campaigns_scopes
+					where campaign_id = ". (int)$this->data['id'] .";"
+				);
+
+				if (!empty($this->data['scopes'])) {
+					foreach ($this->data['scopes'] as $scope) {
+						if (empty($scope['scope_type']) || empty($scope['scope_id'])) continue;
+						database::query(
+							"insert ignore into ". DB_TABLE_PREFIX ."campaigns_scopes
+							(campaign_id, scope_type, scope_id)
+							values (". (int)$this->data['id'] .", '". database::input($scope['scope_type']) ."', ". (int)$scope['scope_id'] .");"
+						);
+					}
+				}
 			}
 
 			$this->previous = $this->data;

--- a/public_html/includes/functions/func_catalog.inc.php
+++ b/public_html/includes/functions/func_catalog.inc.php
@@ -241,7 +241,9 @@
 
 		$query = (
 			"select p.*, b.id as brand_id, b.name as brand_name,
-				pp.regular_price, pp.final_price,
+				pp.regular_price,
+				if(csd.scope_discount is not null, least(pp.final_price, round(pp.final_price * (1 - csd.scope_discount / 100), 4)), pp.final_price) as final_price,
+				csd.scope_discount as campaign_scope_discount,
 				ifnull(pso.num_stock_options, 0) as num_stock_options, pso.total_quantity, pso.quantity_available,
 				pa.attributes, ss.hidden
 
@@ -323,6 +325,27 @@
 			) pso on (pso.product_id = p.id)
 
 			left join ". DB_TABLE_PREFIX ."sold_out_statuses ss on (p.sold_out_status_id = ss.id)
+
+			left join (
+				select product_id, max(scope_discount) as scope_discount from (
+					select ptc.product_id, c.discount_percent as scope_discount
+					from ". DB_TABLE_PREFIX ."campaigns c
+					join ". DB_TABLE_PREFIX ."campaigns_scopes cs on (cs.campaign_id = c.id and cs.scope_type = 'category')
+					join ". DB_TABLE_PREFIX ."products_to_categories ptc on (ptc.category_id = cs.scope_id)
+					where c.status and c.discount_mode = 'percentage' and c.discount_percent > 0
+					and (c.valid_from is null or c.valid_from <= '". date('Y-m-d H:i:s') ."')
+					and (c.valid_to is null or c.valid_to >= '". date('Y-m-d H:i:s') ."')
+					union all
+					select pr.id as product_id, c.discount_percent as scope_discount
+					from ". DB_TABLE_PREFIX ."campaigns c
+					join ". DB_TABLE_PREFIX ."campaigns_scopes cs on (cs.campaign_id = c.id and cs.scope_type = 'brand')
+					join ". DB_TABLE_PREFIX ."products pr on (pr.brand_id = cs.scope_id)
+					where c.status and c.discount_mode = 'percentage' and c.discount_percent > 0
+					and (c.valid_from is null or c.valid_from <= '". date('Y-m-d H:i:s') ."')
+					and (c.valid_to is null or c.valid_to >= '". date('Y-m-d H:i:s') ."')
+				) scope_discounts
+				group by product_id
+			) csd on (csd.product_id = p.id)
 
 			where (
 				(ifnull(pso.num_stock_options, 0) = 0 or pso.quantity_available > 0 or ss.hidden != 1)

--- a/public_html/includes/functions/func_draw.inc.php
+++ b/public_html/includes/functions/func_draw.inc.php
@@ -331,7 +331,9 @@
 		$listing_product = new ent_view('app://frontend/templates/'.settings::get('template').'/partials/listing_product.inc.php');
 
 		$sticker = '';
-		if ($product['final_price'] && $product['final_price'] < $product['regular_price']) {
+		if (!empty($product['campaign_scope_discount'])) {
+			$sticker = '<div class="sticker sale" title="'. t('title_on_sale', 'On Sale') .'">-'. (int)$product['campaign_scope_discount'] .'%</div>';
+		} else if ($product['final_price'] && $product['final_price'] < $product['regular_price']) {
 			$sticker = '<div class="sticker sale" title="'. t('title_on_sale', 'On Sale') .'">'. t('sticker_sale', 'Sale') .'</div>';
 		} else if ($product['created_at'] > date('Y-m-d', strtotime('-'.settings::get('new_products_max_age')))) {
 			$sticker = '<div class="sticker new" title="'. t('title_new', 'New') .'">'. t('sticker_new', 'New') .'</div>';

--- a/public_html/includes/references/ref_product.inc.php
+++ b/public_html/includes/references/ref_product.inc.php
@@ -106,6 +106,7 @@
 
 			case 'campaign':
 
+				// Fixed campaign price (existing behavior)
 				$this->_data['campaign'] = database::query(
 					"select *, min(
 						coalesce(
@@ -119,6 +120,7 @@
 					and campaign_id in (
 						select id from ". DB_TABLE_PREFIX ."campaigns
 						where status
+						and discount_mode = 'fixed'
 						and (valid_from is null or valid_from <= '". date('Y-m-d H:i:s') ."')
 						and (valid_to is null or valid_to >= '". date('Y-m-d H:i:s') ."')
 					)
@@ -131,6 +133,30 @@
 					group by product_id
 					limit 1;"
 				)->fetch();
+
+				// Scope campaign percentage (category/brand)
+				$scope_discount = database::query(
+					"select max(c.discount_percent) as discount_percent
+					from ". DB_TABLE_PREFIX ."campaigns c
+					join ". DB_TABLE_PREFIX ."campaigns_scopes cs on (cs.campaign_id = c.id)
+					where c.status
+					and c.discount_mode = 'percentage'
+					and c.discount_percent > 0
+					and (c.valid_from is null or c.valid_from <= '". date('Y-m-d H:i:s') ."')
+					and (c.valid_to is null or c.valid_to >= '". date('Y-m-d H:i:s') ."')
+					and (
+						(cs.scope_type = 'category' and cs.scope_id in (
+							select category_id from ". DB_TABLE_PREFIX ."products_to_categories
+							where product_id = ". (int)$this->_data['id'] ."
+						))
+						or (cs.scope_type = 'brand' and cs.scope_id = ". (int)$this->_data['brand_id'] .")
+					)
+					limit 1;"
+				)->fetch('discount_percent');
+
+				if ($scope_discount > 0) {
+					$this->_data['campaign']['scope_discount_percent'] = (float)$scope_discount;
+				}
 
 				break;
 
@@ -201,7 +227,7 @@
 					// Regular Price
 					$this->_data['final_price'] = $this->price;
 
-					// Campaign Price
+					// Campaign Fixed Price
 					if (isset($this->campaign['price']) && $this->campaign['price'] > 0 && $this->campaign['price'] < $this->_data['final_price']) {
 						$this->_data['final_price'] = $this->campaign['price'];
 					}
@@ -229,6 +255,14 @@
 
 						if ($customer_price && $customer_price < $this->_data['final_price']) {
 							$this->_data['final_price'] = $customer_price;
+						}
+					}
+
+					// Campaign Scope Percentage Discount (highest active wins)
+					if (!empty($this->campaign['scope_discount_percent'])) {
+						$scope_price = round($this->_data['final_price'] * (1 - $this->campaign['scope_discount_percent'] / 100), 4);
+						if ($scope_price < $this->_data['final_price']) {
+							$this->_data['final_price'] = $scope_price;
 						}
 					}
 

--- a/public_html/install/migrations/3.0.0.inc.php
+++ b/public_html/install/migrations/3.0.0.inc.php
@@ -1289,3 +1289,28 @@
 		drop column `length_unit`,
 		drop column `quantity`;"
 	);
+
+	// Campaign scope discounts
+	if (!database::query("show columns from ". DB_TABLE_PREFIX ."campaigns like 'discount_mode';")->num_rows) {
+		database::query(
+			"alter table ". DB_TABLE_PREFIX ."campaigns
+			add column `discount_mode` varchar(16) not null default 'fixed' after `name`,
+			add column `discount_percent` decimal(5,2) not null default 0 after `discount_mode`;"
+		);
+	}
+
+	if (!database::query("show tables like '". DB_TABLE_PREFIX ."campaigns_scopes';")->num_rows) {
+		database::query(
+			"create table `". DB_TABLE_PREFIX ."campaigns_scopes` (
+				`id` int(10) unsigned not null auto_increment,
+				`campaign_id` int(10) unsigned not null,
+				`scope_type` varchar(16) not null default '',
+				`scope_id` int(10) unsigned not null,
+				primary key (`id`),
+				unique key `campaign_scope` (`campaign_id`, `scope_type`, `scope_id`),
+				key `campaign_id` (`campaign_id`),
+				key `scope_type` (`scope_type`, `scope_id`),
+				constraint `". DB_TABLE_PREFIX ."campaigns_scopes_campaign_id` foreign key (`campaign_id`) references `". DB_TABLE_PREFIX ."campaigns` (`id`) on delete cascade
+			) engine=InnoDB default charset=utf8mb4;"
+		);
+	}

--- a/public_html/install/migrations/3.0.0.inc.php
+++ b/public_html/install/migrations/3.0.0.inc.php
@@ -1289,28 +1289,3 @@
 		drop column `length_unit`,
 		drop column `quantity`;"
 	);
-
-	// Campaign scope discounts
-	if (!database::query("show columns from ". DB_TABLE_PREFIX ."campaigns like 'discount_mode';")->num_rows) {
-		database::query(
-			"alter table ". DB_TABLE_PREFIX ."campaigns
-			add column `discount_mode` varchar(16) not null default 'fixed' after `name`,
-			add column `discount_percent` decimal(5,2) not null default 0 after `discount_mode`;"
-		);
-	}
-
-	if (!database::query("show tables like '". DB_TABLE_PREFIX ."campaigns_scopes';")->num_rows) {
-		database::query(
-			"create table `". DB_TABLE_PREFIX ."campaigns_scopes` (
-				`id` int(10) unsigned not null auto_increment,
-				`campaign_id` int(10) unsigned not null,
-				`scope_type` varchar(16) not null default '',
-				`scope_id` int(10) unsigned not null,
-				primary key (`id`),
-				unique key `campaign_scope` (`campaign_id`, `scope_type`, `scope_id`),
-				key `campaign_id` (`campaign_id`),
-				key `scope_type` (`scope_type`, `scope_id`),
-				constraint `". DB_TABLE_PREFIX ."campaigns_scopes_campaign_id` foreign key (`campaign_id`) references `". DB_TABLE_PREFIX ."campaigns` (`id`) on delete cascade
-			) engine=InnoDB default charset=utf8mb4;"
-		);
-	}

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -2,30 +2,30 @@
 	"tables": {
 		"administrators": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"username": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"apps": { "type": "VARCHAR", "length": 4096, "default": "''" },
-				"widgets": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"password_hash": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"two_factor_auth": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"login_attempts": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"total_logins": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"known_ips": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"last_ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
-				"last_hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"last_user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"last_active": { "type": "TIMESTAMP", "nullable": true },
-				"last_login": { "type": "TIMESTAMP", "nullable": true },
-				"sessions_expiry": { "type": "TIMESTAMP", "nullable": true },
-				"blocked_until": { "type": "TIMESTAMP", "nullable": true },
-				"valid_from": { "type": "TIMESTAMP", "nullable": true },
-				"valid_to": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"username": {"type":"VARCHAR","length":32,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"apps": {"type":"VARCHAR","length":4096,"default":"''"},
+				"widgets": {"type":"VARCHAR","length":512,"default":"''"},
+				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
+				"two_factor_auth": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"login_attempts": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
+				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"last_login": {"type":"TIMESTAMP","nullable":true},
+				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
+				"blocked_until": {"type":"TIMESTAMP","nullable":true},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -36,12 +36,12 @@
 		},
 		"attribute_groups": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "TEXT", "nullable": true },
-				"sort": { "type": "ENUM('alphabetical','priority')", "default": "'alphabetical'" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"sort": {"type":"ENUM('alphabetical','priority')","default":"'alphabetical'"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -53,12 +53,12 @@
 		},
 		"attribute_values": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"group_id": { "type": "INT", "length": 10, "unsigned": true },
-				"name": { "type": "TEXT", "nullable": true },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true},
+				"name": {"type":"TEXT","nullable":true},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -70,40 +70,40 @@
 		},
 		"banners": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"languages": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"html": { "type": "TEXT" },
-				"image": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"link": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"total_views": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"total_clicks": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"valid_from": { "type": "TIMESTAMP", "nullable": true },
-				"valid_to": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"languages": {"type":"VARCHAR","length":64,"default":"''"},
+				"html": {"type":"TEXT"},
+				"image": {"type":"VARCHAR","length":64,"default":"''"},
+				"link": {"type":"VARCHAR","length":255,"default":"''"},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"total_views": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"total_clicks": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"]
 		},
 		"brands": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"featured": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"short_description": { "type": "TEXT", "nullable": true },
-				"description": { "type": "MEDIUMTEXT", "nullable": true },
-				"h1_title": { "type": "TEXT", "nullable": true },
-				"head_title": { "type": "TEXT", "nullable": true },
-				"meta_description": { "type": "TEXT", "nullable": true },
-				"link": { "type": "TEXT", "nullable": true },
-				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"image": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"h1_title": {"type":"TEXT","nullable":true},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"link": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"image": {"type":"VARCHAR","length":128,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -123,13 +123,15 @@
 		},
 		"campaigns": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
-				"name": { "type": "VARCHAR", "length": 50, "default": "''" },
-				"valid_from": { "type": "TIMESTAMP", "nullable": true },
-				"valid_to": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"name": {"type":"VARCHAR","length":50,"default":"''"},
+				"discount_mode": {"type":"VARCHAR","length":16,"default":"'fixed'"},
+				"discount_percent": {"type":"DECIMAL","length":"5,2","default":0},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -138,19 +140,38 @@
 				"valid_to": ["valid_to"]
 			}
 		},
+		"campaigns_scopes": {
+			"columns": {
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"campaign_id": {"type":"INT","length":10,"unsigned":true},
+				"scope_type": {"type":"VARCHAR","length":16,"default":"''"},
+				"scope_id": {"type":"INT","length":10,"unsigned":true}
+			},
+			"primary_key": ["id"],
+			"unique_keys": {
+				"campaign_scope": ["campaign_id","scope_type","scope_id"]
+			},
+			"keys": {
+				"campaign_id": ["campaign_id"],
+				"scope_type": ["scope_type","scope_id"]
+			},
+			"foreign_keys": {
+				"campaign_id": {"columns":["campaign_id"],"references":{"table":"campaigns","columns":["id"]},"on_delete":"CASCADE"}
+			}
+		},
 		"cart_items": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"cart_uid": { "type": "VARCHAR", "length": 13 },
-				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"key": { "type": "VARCHAR", "length": 32 },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"stock_option_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"userdata": { "type": "VARCHAR", "length": 2048, "default": "''" },
-				"image": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"quantity": { "type": "DECIMAL", "length": "11,4", "default": 1 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"cart_uid": {"type":"VARCHAR","length":13},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"key": {"type":"VARCHAR","length":32},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"userdata": {"type":"VARCHAR","length":2048,"default":"''"},
+				"image": {"type":"VARCHAR","length":255,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"11,4","default":1},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -158,54 +179,30 @@
 				"cart_uid": ["cart_uid"]
 			},
 			"foreign_keys": {
-				"cart_item_to_customer": {
-					"columns": ["customer_id"],
-					"references": {
-						"table": "customers",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"cart_item_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"cart_item_to_stock_option": {
-					"columns": ["stock_option_id"],
-					"references": {
-						"table": "products_stock_options",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"cart_item_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"cart_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"cart_item_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"categories": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"parent_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"google_taxonomy_id": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"code": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"name": { "type": "TEXT", "nullable": true },
-				"short_description": { "type": "TEXT", "nullable": true },
-				"description": { "type": "MEDIUMTEXT", "nullable": true },
-				"synonyms": { "type": "TEXT" },
-				"head_title": { "type": "TEXT", "nullable": true },
-				"h1_title": { "type": "TEXT", "nullable": true },
-				"meta_description": { "type": "TEXT", "nullable": true },
-				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"image": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"google_taxonomy_id": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"code": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"synonyms": {"type":"TEXT"},
+				"head_title": {"type":"TEXT","nullable":true},
+				"h1_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"image": {"type":"VARCHAR","length":255,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -214,15 +211,7 @@
 				"status": ["status"]
 			},
 			"foreign_keys": {
-				"category_to_parent": {
-					"columns": ["parent_id"],
-					"references": {
-					"table": "categories",
-					"columns": ["id"],
-					"on_update": "CASCADE",
-					"on_delete": "RESTRICT"
-					}
-				}
+				"category_to_parent": {"columns":["parent_id"],"references":{"table":"categories","columns":["id"],"on_update":"CASCADE","on_delete":"RESTRICT"}}
 			},
 			"check_constraints": {
 				"categories_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -235,58 +224,42 @@
 		},
 		"categories_filters": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"category_id": { "type": "INT", "length": 10, "unsigned": true },
-				"attribute_group_id": { "type": "INT", "length": 10, "unsigned": true },
-				"select_multiple": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"category_id": {"type":"INT","length":10,"unsigned":true},
+				"attribute_group_id": {"type":"INT","length":10,"unsigned":true},
+				"select_multiple": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"attribute_filter": ["category_id", "attribute_group_id"]
+				"attribute_filter": ["category_id","attribute_group_id"]
 			},
 			"keys": {
 				"category_id": ["category_id"]
 			},
 			"foreign_keys": {
-				"category_filter_to_category": {
-					"columns": ["category_id"],
-					"references": {
-						"table": "categories",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"category_filter_to_attribute_group": {
-					"columns": ["attribute_group_id"],
-					"references": {
-						"table": "attribute_groups",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"category_filter_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"category_filter_to_attribute_group": {"columns":["attribute_group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"countries": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"iso_code_1": { "type": "CHAR", "length": 3, "default": "''" },
-				"iso_code_2": { "type": "CHAR", "length": 2, "default": "''" },
-				"iso_code_3": { "type": "CHAR", "length": 3, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"domestic_name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"tax_id_format": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"address_format": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"postcode_format": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"postcode_required": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"language_code": { "type": "CHAR", "length": 2 },
-				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
-				"phone_code": { "type": "VARCHAR", "length": 3, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"iso_code_1": {"type":"CHAR","length":3,"default":"''"},
+				"iso_code_2": {"type":"CHAR","length":2,"default":"''"},
+				"iso_code_3": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"domestic_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"tax_id_format": {"type":"VARCHAR","length":64,"default":"''"},
+				"address_format": {"type":"VARCHAR","length":128,"default":"''"},
+				"postcode_format": {"type":"VARCHAR","length":255,"default":"''"},
+				"postcode_required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"language_code": {"type":"CHAR","length":2},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"phone_code": {"type":"VARCHAR","length":3,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -300,18 +273,18 @@
 		},
 		"currencies": {
 			"columns": {
-				"id": { "type": "TINYINT", "length": 3, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "default": 0 },
-				"code": { "type": "CHAR", "length": 3, "default": "''" },
-				"number": { "type": "CHAR", "length": 3, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"value": { "type": "DECIMAL", "length": "11,6", "unsigned": true, "default": 1 },
-				"decimals": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 2 },
-				"prefix": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"suffix": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"TINYINT","length":3,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"code": {"type":"CHAR","length":3,"default":"''"},
+				"number": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":1},
+				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
+				"prefix": {"type":"VARCHAR","length":8,"default":"''"},
+				"suffix": {"type":"VARCHAR","length":8,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -322,61 +295,61 @@
 		},
 		"customer_groups": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"type": { "type": "ENUM('retail', 'wholesale')", "default": "'retail'" },
-				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"type": {"type":"ENUM('retail', 'wholesale')","default":"'retail'"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"description": {"type":"VARCHAR","length":248,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"]
 		},
 		"customers": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"email": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"tax_id": { "type": "VARCHAR", "length": 24, "default": "''" },
-				"company": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"address1": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"address2": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"city": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"country_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"phone": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"different_shipping_address": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"shipping_company": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"shipping_city": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_country_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"shipping_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"shipping_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"shipping_email": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
-				"notes": { "type": "TEXT" },
-				"password_hash": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"password_reset_token": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"login_attempts": { "type": "INT", "length": 11, "default": 0 },
-				"total_logins": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"known_ips": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"last_ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
-				"last_hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"last_user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"last_login": { "type": "TIMESTAMP", "nullable": true },
-				"last_active": { "type": "TIMESTAMP", "nullable": true },
-				"blocked_until": { "type": "TIMESTAMP", "nullable": true },
-				"sessions_expiry": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"email": {"type":"VARCHAR","length":64,"default":"''"},
+				"tax_id": {"type":"VARCHAR","length":24,"default":"''"},
+				"company": {"type":"VARCHAR","length":32,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"city": {"type":"VARCHAR","length":32,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"default":"''"},
+				"zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"different_shipping_address": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"notes": {"type":"TEXT"},
+				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
+				"password_reset_token": {"type":"VARCHAR","length":128,"default":"''"},
+				"login_attempts": {"type":"INT","length":11,"default":0},
+				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
+				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_login": {"type":"TIMESTAMP","nullable":true},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"blocked_until": {"type":"TIMESTAMP","nullable":true},
+				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -386,24 +359,16 @@
 				"group_id": ["group_id"]
 			},
 			"foreign_keys": {
-				"customer_to_customer_group": {
-					"columns": ["group_id"],
-					"references": {
-						"table": "customer_groups",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"customer_to_customer_group": {"columns":["group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"delivery_statuses": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"name": { "type": "TEXT", "nullable": true },
-				"description": { "type": "TEXT", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"check_constraints": {
@@ -413,24 +378,24 @@
 		},
 		"emails": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "ENUM('draft','scheduled','sent','error')", "default": "'draft'" },
-				"code": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"reference": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"language_code": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"sender": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"recipients": { "type": "TEXT" },
-				"ccs": { "type": "TEXT" },
-				"bccs": { "type": "TEXT" },
-				"subject": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"multiparts": { "type": "MEDIUMTEXT" },
-				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
-				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"scheduled_at": { "type": "TIMESTAMP", "nullable": true },
-				"sent_at": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"ENUM('draft','scheduled','sent','error')","default":"'draft'"},
+				"code": {"type":"VARCHAR","length":255,"default":"''"},
+				"reference": {"type":"VARCHAR","length":255,"default":"''"},
+				"language_code": {"type":"VARCHAR","length":2,"default":"''"},
+				"sender": {"type":"VARCHAR","length":255,"default":"''"},
+				"recipients": {"type":"TEXT"},
+				"ccs": {"type":"TEXT"},
+				"bccs": {"type":"TEXT"},
+				"subject": {"type":"VARCHAR","length":255,"default":"''"},
+				"multiparts": {"type":"MEDIUMTEXT"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"scheduled_at": {"type":"TIMESTAMP","nullable":true},
+				"sent_at": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -442,22 +407,22 @@
 		},
 		"event_logs": {
 			"columns": {
-				"id": { "type": "BIGINT", "length": 20, "unsigned": true, "auto_increment": true },
-				"session_id": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"customer_email": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"customer_phone": { "type": "VARCHAR", "length": 16, "nullable": true },
-				"type": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"description": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"data": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
-				"conversions": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
-				"url": { "type": "VARCHAR", "length": 248, "nullable": true },
-				"ip_address": { "type": "VARCHAR", "length": 47, "nullable": true },
-				"hostname": { "type": "VARCHAR", "length": 128, "nullable": true },
-				"user_agent": { "type": "VARCHAR", "length": 248, "nullable": true },
-				"fingerprint": { "type": "VARCHAR", "length": 32, "nullable": true },
-				"expires_at": { "type": "TIMESTAMP", "nullable": true },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
+				"session_id": {"type":"VARCHAR","length":64,"nullable":true},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_email": {"type":"VARCHAR","length":64,"nullable":true},
+				"customer_phone": {"type":"VARCHAR","length":16,"nullable":true},
+				"type": {"type":"VARCHAR","length":64,"nullable":true},
+				"description": {"type":"VARCHAR","length":248,"default":"''"},
+				"data": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"url": {"type":"VARCHAR","length":248,"nullable":true},
+				"ip_address": {"type":"VARCHAR","length":47,"nullable":true},
+				"hostname": {"type":"VARCHAR","length":128,"nullable":true},
+				"user_agent": {"type":"VARCHAR","length":248,"nullable":true},
+				"fingerprint": {"type":"VARCHAR","length":32,"nullable":true},
+				"expires_at": {"type":"TIMESTAMP","nullable":true},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -473,15 +438,7 @@
 				"expires_at": ["expires_at"]
 			},
 			"foreign_keys": {
-				"event_log_to_customer": {
-					"columns": ["customer_id"],
-					"references": {
-						"table": "customers",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"event_log_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			},
 			"check_constraints": {
 				"event_logs_chk_data": "data IS NULL OR data = '' OR JSON_VALID(data)",
@@ -490,39 +447,39 @@
 		},
 		"geo_zones": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":255,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"]
 		},
 		"languages": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "default": 0 },
-				"code": { "type": "CHAR", "length": 2, "default": "''" },
-				"code2": { "type": "CHAR", "length": 3, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"direction": { "type": "ENUM('ltr','rtl')", "default": "'ltr'" },
-				"locale": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"locale_intl": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"mysql_collation": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"url_type": { "type": "ENUM('','none','root','path','domain')", "default": "''" },
-				"domain_name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"raw_date": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"raw_time": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"raw_datetime": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"format_date": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"format_time": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"format_datetime": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"decimal_point": { "type": "VARCHAR", "length": 1, "default": "''" },
-				"thousands_sep": { "type": "VARCHAR", "length": 1, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"code": {"type":"CHAR","length":2,"default":"''"},
+				"code2": {"type":"CHAR","length":3,"default":"''"},
+				"name": {"type":"VARCHAR","length":32,"default":"''"},
+				"direction": {"type":"ENUM('ltr','rtl')","default":"'ltr'"},
+				"locale": {"type":"VARCHAR","length":64,"default":"''"},
+				"locale_intl": {"type":"VARCHAR","length":16,"default":"''"},
+				"mysql_collation": {"type":"VARCHAR","length":32,"default":"''"},
+				"url_type": {"type":"ENUM('','none','root','path','domain')","default":"''"},
+				"domain_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"raw_date": {"type":"VARCHAR","length":32,"default":"''"},
+				"raw_time": {"type":"VARCHAR","length":32,"default":"''"},
+				"raw_datetime": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_date": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_time": {"type":"VARCHAR","length":32,"default":"''"},
+				"format_datetime": {"type":"VARCHAR","length":32,"default":"''"},
+				"decimal_point": {"type":"VARCHAR","length":1,"default":"''"},
+				"thousands_sep": {"type":"VARCHAR","length":1,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -531,17 +488,17 @@
 		},
 		"modules": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"module_id": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"type": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"settings": { "type": "TEXT" },
-				"last_log": { "type": "TEXT" },
-				"last_pushed": { "type": "TIMESTAMP", "nullable": true },
-				"last_processed": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"module_id": {"type":"VARCHAR","length":64,"default":"''"},
+				"type": {"type":"VARCHAR","length":16,"default":"''"},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"settings": {"type":"TEXT"},
+				"last_log": {"type":"TEXT"},
+				"last_pushed": {"type":"TIMESTAMP","nullable":true},
+				"last_processed": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -554,17 +511,17 @@
 		},
 		"newsletter_recipients": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"subscribed": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
-				"lastname": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"firstname": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
-				"country_code": { "type": "CHAR", "length": 2, "nullable": true },
-				"ip_address": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"user_agent": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"subscribed": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
+				"lastname": {"type":"VARCHAR","length":64,"default":"''"},
+				"firstname": {"type":"VARCHAR","length":64,"default":"''"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"country_code": {"type":"CHAR","length":2,"nullable":true},
+				"ip_address": {"type":"VARCHAR","length":64,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":248,"default":"''"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -576,81 +533,81 @@
 		},
 		"orders": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"no": { "type": "VARCHAR", "length": 16, "nullable": true },
-				"starred": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"unread": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"order_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"customer_tax_id": { "type": "VARCHAR", "length": 24, "default": "''" },
-				"customer_company": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_city": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"customer_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"customer_country_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"customer_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"customer_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"customer_email": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"shipping_tax_id": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_company": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_city": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"shipping_country_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"shipping_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"shipping_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"shipping_email": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"shipping_option_id": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shipping_option_name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"shipping_option_userdata": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"shipping_option_fee": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"shipping_option_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"shipping_purchase_cost": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"shipping_tracking_id": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"shipping_tracking_url": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"shipping_progress": { "type": "TINYINT", "length": 3, "default": 0 },
-				"shipping_current_status": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"shipping_current_location": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"payment_option_id": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"payment_option_name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"payment_option_userdata": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"payment_option_fee": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"payment_option_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"payment_transaction_id": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"payment_transaction_fee": { "type": "DECIMAL", "length": "10,4", "nullable": true },
-				"payment_receipt_url": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"payment_terms": { "type": "VARCHAR", "length": 8, "default": "''" },
-				"incoterm": { "type": "VARCHAR", "length": 3, "default": "''" },
-				"reference": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
-				"weight_total": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
-				"currency_value": { "type": "DECIMAL", "length": "11,6", "unsigned": true, "default": 0 },
-				"display_prices_including_tax": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"subtotal": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"subtotal_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"discount": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"discount_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"total": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"total_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"notes": { "type": "VARCHAR", "length": 1024, "default": "''" },
-				"conversions": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
-				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
-				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"domain": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"public_key": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"date_paid": { "type": "TIMESTAMP", "nullable": true },
-				"date_dispatched": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"no": {"type":"VARCHAR","length":16,"nullable":true},
+				"starred": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"unread": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"order_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_tax_id": {"type":"VARCHAR","length":24,"default":"''"},
+				"customer_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"customer_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"customer_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"customer_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"customer_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"customer_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_tax_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
+				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
+				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
+				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_option_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"shipping_option_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
+				"shipping_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_purchase_cost": {"type":"DECIMAL","length":"10,4","default":0},
+				"shipping_tracking_id": {"type":"VARCHAR","length":128,"default":"''"},
+				"shipping_tracking_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"shipping_progress": {"type":"TINYINT","length":3,"default":0},
+				"shipping_current_status": {"type":"VARCHAR","length":64,"default":"''"},
+				"shipping_current_location": {"type":"VARCHAR","length":128,"default":"''"},
+				"payment_option_id": {"type":"VARCHAR","length":32,"default":"''"},
+				"payment_option_name": {"type":"VARCHAR","length":64,"default":"''"},
+				"payment_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
+				"payment_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
+				"payment_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"payment_transaction_id": {"type":"VARCHAR","length":128,"default":"''"},
+				"payment_transaction_fee": {"type":"DECIMAL","length":"10,4","nullable":true},
+				"payment_receipt_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"payment_terms": {"type":"VARCHAR","length":8,"default":"''"},
+				"incoterm": {"type":"VARCHAR","length":3,"default":"''"},
+				"reference": {"type":"VARCHAR","length":128,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"nullable":true},
+				"weight_total": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"currency_value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":0},
+				"display_prices_including_tax": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"subtotal": {"type":"DECIMAL","length":"10,4","default":0},
+				"subtotal_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"total": {"type":"DECIMAL","length":"10,4","default":0},
+				"total_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"notes": {"type":"VARCHAR","length":1024,"default":"''"},
+				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
+				"domain": {"type":"VARCHAR","length":64,"nullable":true},
+				"public_key": {"type":"VARCHAR","length":32,"default":"''"},
+				"date_paid": {"type":"TIMESTAMP","nullable":true},
+				"date_dispatched": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -663,24 +620,8 @@
 				"unread": ["unread"]
 			},
 			"foreign_keys": {
-				"order_to_customer": {
-					"columns": ["customer_id"],
-					"references": {
-						"table": "customers",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"order_to_order_status": {
-					"columns": ["order_status_id"],
-					"references": {
-						"table": "order_statuses",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"order_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"order_to_order_status": {"columns":["order_status_id"],"references":{"table":"order_statuses","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"orders_chk_conversions": "conversions IS NULL OR conversions = '' OR JSON_VALID(conversions)"
@@ -688,106 +629,82 @@
 		},
 		"orders_comments": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"order_id": { "type": "INT", "length": 10, "unsigned": true },
-				"author_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"author": { "type": "ENUM('system','staff','customer')", "default": "'system'" },
-				"text": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"author_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"author": {"type":"ENUM('system','staff','customer')","default":"'system'"},
+				"text": {"type":"VARCHAR","length":512,"default":"''"},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_comment_to_order": {
-					"columns": ["order_id"],
-					"references": {
-						"table": "orders",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"order_comment_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"orders_items": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"order_id": { "type": "INT", "length": 10, "unsigned": true },
-				"line_id": { "type": "INT", "length": 10, "unsigned": true },
-				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
-				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"serial_number": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"taric": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"quantity": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"price": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"tax_rate": { "type": "DECIMAL", "length": "4,2", "unsigned": true, "default": 0 },
-				"tax_class_id": { "type": "INT", "length": "10", "unsigned": true, "nullable": true },
-				"discount": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"discount_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"sum": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"sum_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"weight": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"length": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"width": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"height": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"length_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"downloads": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"line_id": {"type":"INT","length":10,"unsigned":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":32,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
+				"price": {"type":"DECIMAL","length":"10,4","default":0},
+				"tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"tax_rate": {"type":"DECIMAL","length":"4,2","unsigned":true,"default":0},
+				"tax_class_id": {"type":"INT","length":"10","unsigned":true,"nullable":true},
+				"discount": {"type":"DECIMAL","length":"10,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"sum": {"type":"DECIMAL","length":"10,4","default":0},
+				"sum_tax": {"type":"DECIMAL","length":"10,4","default":0},
+				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"length": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"width": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"height": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_item_to_order": {
-					"columns": ["order_id"],
-					"references": {
-						"table": "orders",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"order_item_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"order_item_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"order_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"orders_lines": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"order_id": { "type": "INT", "length": 10, "unsigned": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"stock_option_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"code": { "type": "VARCHAR", "length": 32, "nullable": true },
-				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"serial_number": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"userdata": { "type": "VARCHAR", "length": 2048, "default": "'{}'" },
-				"quantity": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"price": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"tax_rate": { "type": "DECIMAL", "length": "6,4", "unsigned": true, "default": 0 },
-				"tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"discount": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"discount_tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"sum": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"sum_tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
-				"weight": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"order_id": {"type":"INT","length":10,"unsigned":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"code": {"type":"VARCHAR","length":32,"nullable":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
+				"userdata": {"type":"VARCHAR","length":2048,"default":"'{}'"},
+				"quantity": {"type":"DECIMAL","length":"11,4","default":0},
+				"price": {"type":"DECIMAL","length":"11,4","default":0},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"tax_rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
+				"tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"discount": {"type":"DECIMAL","length":"11,4","default":0},
+				"discount_tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"sum": {"type":"DECIMAL","length":"11,4","default":0},
+				"sum_tax": {"type":"DECIMAL","length":"11,4","default":0},
+				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -798,33 +715,9 @@
 				"code": ["code"]
 			},
 			"foreign_keys": {
-				"order_line_to_order": {
-					"columns": ["order_id"],
-					"references": {
-						"table": "orders",
-						"columns": ["id"],
-						"on_update": "RESTRICT",
-						"on_delete": "RESTRICT"
-					}
-				},
-				"order_line_to_tax_class": {
-					"columns": ["tax_class_id"],
-					"references": {
-						"table": "tax_classes",
-						"columns": ["id"],
-						"on_update": "RESTRICT",
-						"on_delete": "RESTRICT"
-					}
-				},
-				"order_line_to_stock_option": {
-					"columns": ["stock_option_id"],
-					"references": {
-						"table": "products_stock_options",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"order_line_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
+				"order_line_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
+				"order_line_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"orders_lines_chk_userdata": "userdata IS NULL OR userdata = '' OR JSON_VALID(userdata)"
@@ -832,23 +725,23 @@
 		},
 		"order_statuses": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"state": { "type": "ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')", "default": "''" },
-				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"icon": { "type": "VARCHAR", "length": 24, "default": "''" },
-				"color": { "type": "VARCHAR", "length": 7, "default": "''" },
-				"name": { "type": "TEXT", "length": 64, "nullable": true },
-				"description": { "type": "TEXT", "nullable": true },
-				"email_subject": { "type": "TEXT", "nullable": true },
-				"email_message": { "type": "MEDIUMTEXT", "nullable": true },
-				"is_sale": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"is_archived": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"is_trackable": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"stock_action": { "type": "ENUM('none','reserve','commit')", "default": "'none'" },
-				"notify": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"state": {"type":"ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')","default":"''"},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"icon": {"type":"VARCHAR","length":24,"default":"''"},
+				"color": {"type":"VARCHAR","length":7,"default":"''"},
+				"name": {"type":"TEXT","length":64,"nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"email_subject": {"type":"TEXT","nullable":true},
+				"email_message": {"type":"MEDIUMTEXT","nullable":true},
+				"is_sale": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"is_archived": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"is_trackable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"stock_action": {"type":"ENUM('none','reserve','commit')","default":"'none'"},
+				"notify": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -866,17 +759,17 @@
 		},
 		"pages": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"parent_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"dock": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"status": { "type": "TINYINT", "length": 1, "default": 0 },
-				"title": { "type": "TEXT", "nullable": true },
-				"content": { "type": "MEDIUMTEXT", "nullable": true },
-				"head_title": { "type": "TEXT", "nullable": true },
-				"meta_description": { "type": "TEXT", "nullable": true },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"dock": {"type":"VARCHAR","length":64,"default":"''"},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"title": {"type":"TEXT","nullable":true},
+				"content": {"type":"MEDIUMTEXT","nullable":true},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -893,45 +786,45 @@
 		},
 		"products": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"type": { "type": "ENUM('virtual','physical','digital','variable','bundle')", "default": "'virtual'" },
-				"featured": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"pinned": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"brand_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"supplier_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"delivery_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"sold_out_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"default_category_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"mpn": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"taric": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"shelf": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "TEXT", "nullable": true },
-				"short_description": { "type": "TEXT", "nullable": true },
-				"description": { "type": "MEDIUMTEXT", "nullable": true },
-				"technical_data": { "type": "TEXT", "nullable": true },
-				"autofill_technical_data": { "type": "TINYINT", "length": 1, "default": 0 },
-				"head_title": { "type": "TEXT", "nullable": true },
-				"meta_description": { "type": "TEXT", "nullable": true },
-				"synonyms": { "type": "TEXT", "nullable": true },
-				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"stock_option_type": { "type": "ENUM('variants','bundle')", "default": "'variants'" },
-				"quantity_min": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 1 },
-				"quantity_max": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"quantity_step": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"quantity_unit_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"recommended_price": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
-				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"default_image": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"video_url": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"replaced_by": { "type": "VARCHAR", "length": 24 },
-				"valid_from": { "type": "TIMESTAMP", "nullable": true },
-				"valid_to": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"type": {"type":"ENUM('virtual','physical','digital','variable','bundle')","default":"'virtual'"},
+				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"pinned": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"delivery_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"sold_out_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"default_category_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":16,"default":"''"},
+				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"TEXT","nullable":true},
+				"short_description": {"type":"TEXT","nullable":true},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"technical_data": {"type":"TEXT","nullable":true},
+				"autofill_technical_data": {"type":"TINYINT","length":1,"default":0},
+				"head_title": {"type":"TEXT","nullable":true},
+				"meta_description": {"type":"TEXT","nullable":true},
+				"synonyms": {"type":"TEXT","nullable":true},
+				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
+				"stock_option_type": {"type":"ENUM('variants','bundle')","default":"'variants'"},
+				"quantity_min": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
+				"quantity_max": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"quantity_step": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"recommended_price": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"default_image": {"type":"VARCHAR","length":255,"default":"''"},
+				"video_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"replaced_by": {"type":"VARCHAR","length":24},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -964,16 +857,16 @@
 		},
 		"products_attributes": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true },
-				"group_id": { "type": "INT", "length": 10, "unsigned": true },
-				"value_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"custom_value": { "type": "VARCHAR", "length": 215, "default": "''" },
-				"priority": { "type": "INT", "length": 10, "unsigned": true, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true},
+				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"custom_value": {"type":"VARCHAR","length":215,"default":"''"},
+				"priority": {"type":"INT","length":10,"unsigned":true,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"id": ["id", "product_id", "group_id", "value_id"]
+				"id": ["id","product_id","group_id","value_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
@@ -981,192 +874,104 @@
 				"value_id": ["value_id"]
 			},
 			"foreign_keys": {
-				"product_attribute_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_attribute_to_attribute_group": {
-					"columns": ["group_id"],
-					"references": {
-						"table": "attribute_groups",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_attribute_to_attribute_value": {
-					"columns": ["value_id"],
-					"references": {
-						"table": "attribute_values",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_attribute_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_attribute_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_attribute_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"products_customizations": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"function": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"required": { "type": "TINYINT", "length": 1, "default": 0 },
-				"sort": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"priority": { "type": "TINYINT", "length": 2, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"function": {"type":"VARCHAR","length":32,"default":"''"},
+				"required": {"type":"TINYINT","length":1,"default":0},
+				"sort": {"type":"VARCHAR","length":16,"default":"''"},
+				"priority": {"type":"TINYINT","length":2,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option": ["product_id", "group_id"]
+				"product_option": ["product_id","group_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
 				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_to_attribute_group": {
-					"columns": ["group_id"],
-					"references": {
-						"table": "attribute_groups",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_customization_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_customizations_values": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"value_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"custom_value": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"price_modifier": { "type": "CHAR", "length": 1, "default": "'+'" },
-				"price_adjustment": { "type": "VARCHAR", "length": 1, "default": "''" },
-				"priority": { "type": "TINYINT", "length": 2, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"custom_value": {"type":"VARCHAR","length":64,"default":"''"},
+				"price_modifier": {"type":"CHAR","length":1,"default":"'+'"},
+				"price_adjustment": {"type":"VARCHAR","length":1,"default":"''"},
+				"priority": {"type":"TINYINT","length":2,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option_value": ["product_id", "group_id", "value_id"]
+				"product_option_value": ["product_id","group_id","value_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
 				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_value_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_value_to_attribute_group": {
-					"columns": ["group_id"],
-					"references": {
-						"table": "attribute_groups",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_customization_value_to_attribute_value": {
-					"columns": ["value_id"],
-					"references": {
-						"table": "attribute_values",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_customization_value_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_value_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_customization_value_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_images": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true },
-				"filename": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"checksum": { "type": "CHAR", "length": 32, "nullable": true },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"filename": {"type":"VARCHAR","length":255,"default":"''"},
+				"checksum": {"type":"CHAR","length":32,"nullable":true},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_image_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_image_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"product_notification_recipients": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"email": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"language_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"email": {"type":"VARCHAR","length":64,"default":"''"},
+				"language_code": {"type":"CHAR","length":2,"default":"''"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"notification_recipient": ["product_id", "email"]
+				"notification_recipient": ["product_id","email"]
 			},
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"notification_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"notification_to_language": {
-					"columns": ["language_code"],
-					"references": {
-						"table": "languages",
-						"columns": ["code"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"notification_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"notification_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		},
 		"products_prices": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true },
-				"campaign_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"customer_group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"min_quantity": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 1 },
-				"price": { "type": "VARCHAR", "length": 512, "default": "'{}'" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"campaign_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"customer_group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"min_quantity": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
+				"price": {"type":"VARCHAR","length":512,"default":"'{}'"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1177,42 +982,10 @@
 				"min_quantity": ["min_quantity"]
 			},
 			"foreign_keys": {
-				"product_price_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_customer_group": {
-					"columns": ["customer_group_id"],
-					"references": {
-						"table": "customer_groups",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_campaign": {
-					"columns": ["campaign_id"],
-					"references": {
-						"table": "campaigns",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_price_to_geo_zone": {
-					"columns": ["geo_zone_id"],
-					"references": {
-						"table": "geo_zones",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_price_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_customer_group": {"columns":["customer_group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_campaign": {"columns":["campaign_id"],"references":{"table":"campaigns","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"product_price_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			},
 			"check_constraints": {
 				"products_prices_chk_min_quantity": "min_quantity > 0",
@@ -1221,78 +994,46 @@
 		},
 		"products_stock_options": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true },
-				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
-				"price_modifier": { "type": "ENUM('+','%','*','=')", "default": "'+'" },
-				"price_adjustment": { "type": "VARCHAR(512)", "default": "'+'" },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"price_modifier": {"type":"ENUM('+','%','*','=')","default":"'+'"},
+				"price_adjustment": {"type":"VARCHAR(512)","default":"'+'"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"stock_option": ["product_id", "stock_item_id"]
+				"stock_option": ["product_id","stock_item_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_stock_option_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_stock_option_to_stock_item": {
-					"columns": ["stock_item_id"],
-					"references": {
-						"table": "stock_items",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_stock_option_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_stock_option_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"products_to_categories": {
 			"columns": {
-				"product_id": { "type": "INT", "length": 10, "unsigned": true },
-				"category_id": { "type": "INT", "length": 10, "unsigned": true }
+				"product_id": {"type":"INT","length":10,"unsigned":true},
+				"category_id": {"type":"INT","length":10,"unsigned":true}
 			},
-			"primary_key": ["product_id", "category_id"],
+			"primary_key": ["product_id","category_id"],
 			"foreign_keys": {
-				"product_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"product_to_category": {
-					"columns": ["category_id"],
-					"references": {
-						"table": "categories",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"product_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"product_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"quantity_units": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"name": { "type": "TEXT", "nullable": true },
-				"description": { "type": "TEXT", "nullable": true },
-				"decimals": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 2 },
-				"separate": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
+				"separate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"check_constraints": {
@@ -1302,18 +1043,18 @@
 		},
 		"redirects": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"immediate": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"pattern": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"destination": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"http_response_code": { "type": "ENUM('301','302')", "default": "'301'" },
-				"redirects": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"last_redirected": { "type": "TIMESTAMP", "nullable": true },
-				"valid_from": { "type": "TIMESTAMP", "nullable": true },
-				"valid_to": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"immediate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"pattern": {"type":"VARCHAR","length":248,"default":"''"},
+				"destination": {"type":"VARCHAR","length":248,"default":"''"},
+				"http_response_code": {"type":"ENUM('301','302')","default":"'301'"},
+				"redirects": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"last_redirected": {"type":"TIMESTAMP","nullable":true},
+				"valid_from": {"type":"TIMESTAMP","nullable":true},
+				"valid_to": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1326,25 +1067,25 @@
 		},
 		"sessions": {
 			"columns": {
-				"id": { "type": "VARCHAR", "length": 128 },
-				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"data": { "type": "TEXT" },
-				"language_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"country_code": { "type": "CHAR", "length": 2, "default": "''" },
-				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
-				"ip_address": { "type": "VARCHAR", "length": 45 },
-				"ip_country": { "type": "CHAR", "length": 2, "default": "''" },
-				"fingerprint": { "type": "VARCHAR", "length": 128 },
-				"hostname": { "type": "VARCHAR", "length": 128 },
-				"user_agent": { "type": "VARCHAR", "length": 256, "default": "''" },
-				"referrer": { "type": "VARCHAR", "length": 256, "default": "''" },
-				"page_views": { "type": "INT", "length": 11, "default": 0 },
-				"last_url": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"last_request": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"last_active": { "type": "TIMESTAMP", "nullable": true },
-				"expires_at": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"VARCHAR","length":128},
+				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"data": {"type":"TEXT"},
+				"language_code": {"type":"CHAR","length":2,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"default":"''"},
+				"currency_code": {"type":"CHAR","length":3,"default":"''"},
+				"ip_address": {"type":"VARCHAR","length":45},
+				"ip_country": {"type":"CHAR","length":2,"default":"''"},
+				"fingerprint": {"type":"VARCHAR","length":128},
+				"hostname": {"type":"VARCHAR","length":128},
+				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
+				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
+				"page_views": {"type":"INT","length":11,"default":0},
+				"last_url": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_request": {"type":"VARCHAR","length":255,"default":"''"},
+				"last_active": {"type":"TIMESTAMP","nullable":true},
+				"expires_at": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1356,48 +1097,24 @@
 				"fingerprint": ["fingerprint"]
 			},
 			"foreign_keys": {
-				"session_to_customer": {
-					"columns": ["customer_id"],
-					"references": {
-						"table": "customers",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"session_to_language": {
-					"columns": ["language_code"],
-					"references": {
-						"table": "languages",
-						"columns": ["code"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"session_to_currency": {
-					"columns": ["currency_code"],
-					"references": {
-						"table": "currencies",
-						"columns": ["code"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"session_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"session_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"session_to_currency": {"columns":["currency_code"],"references":{"table":"currencies","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"settings": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"group_key": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"key": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"value": { "type": "VARCHAR", "length": 2048, "default": "''" },
-				"title": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"required": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"function": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"group_key": {"type":"VARCHAR","length":64,"nullable":true},
+				"key": {"type":"VARCHAR","length":64,"default":"''"},
+				"value": {"type":"VARCHAR","length":2048,"default":"''"},
+				"title": {"type":"VARCHAR","length":128,"default":"''"},
+				"description": {"type":"VARCHAR","length":512,"default":"''"},
+				"required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"function": {"type":"VARCHAR","length":128,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1409,11 +1126,11 @@
 		},
 		"settings_groups": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"key": { "type": "VARCHAR", "length": 32 },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"priority": { "type": "INT", "length": 11, "default": 0 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"key": {"type":"VARCHAR","length":32},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":255,"default":"''"},
+				"priority": {"type":"INT","length":11,"default":0}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1422,15 +1139,15 @@
 		},
 		"site_tags": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "default": 0 },
-				"position": { "type": "ENUM('head','body')", "default": "'head'" },
-				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"content": { "type": "TEXT" },
-				"require_consent": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"priority": { "type": "TINYINT", "length": 4, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"default":0},
+				"position": {"type":"ENUM('head','body')","default":"'head'"},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"content": {"type":"TEXT"},
+				"require_consent": {"type":"VARCHAR","length":64,"nullable":true},
+				"priority": {"type":"TINYINT","length":4,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1441,13 +1158,13 @@
 		},
 		"sold_out_statuses": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"orderable": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"name": { "type": "TEXT", "nullable": true },
-				"description": { "type": "TEXT", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"orderable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"name": {"type":"TEXT","nullable":true},
+				"description": {"type":"TEXT","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1461,18 +1178,18 @@
 		},
 		"statistics": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"type": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"entity_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"entity_type": { "type": "VARCHAR", "length": 32, "nullable": true },
-				"measure_group_type": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"measure_group_value": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"count": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP"}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"type": {"type":"VARCHAR","length":32,"default":"''"},
+				"entity_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"entity_type": {"type":"VARCHAR","length":32,"nullable":true},
+				"measure_group_type": {"type":"VARCHAR","length":32,"default":"''"},
+				"measure_group_value": {"type":"VARCHAR","length":64,"default":"''"},
+				"count": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"measure": ["type", "entity_id", "entity_type", "measure_group_type", "measure_group_value"]
+				"measure": ["type","entity_id","entity_type","measure_group_type","measure_group_value"]
 			},
 			"keys": {
 				"entity_id": ["entity_id"],
@@ -1483,35 +1200,35 @@
 		},
 		"stock_items": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"brand_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"supplier_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"name": { "type": "TEXT", "nullable": true },
-				"attributes": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"mpn": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"shelf": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"taric": { "type": "VARCHAR", "length": 16, "default": "''" },
-				"image": { "type": "VARCHAR", "length": 512, "default": "''" },
-				"weight": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"length": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"width": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"height": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"length_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"quantity": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"quantity_unit_id": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"backordered": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"purchase_price": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"purchase_price_currency_code": { "type": "VARCHAR", "length": 3, "default": "''" },
-				"file": { "type": "VARCHAR", "length": 248, "nullable": true },
-				"filename": { "type": "VARCHAR", "length": 64, "nullable": true },
-				"mime_type": { "type": "VARCHAR", "length": 32, "nullable": true },
-				"downloads": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"priority": { "type": "INT", "length": 11, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"name": {"type":"TEXT","nullable":true},
+				"attributes": {"type":"VARCHAR","length":32,"default":"''"},
+				"sku": {"type":"VARCHAR","length":32,"default":"''"},
+				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
+				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
+				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
+				"taric": {"type":"VARCHAR","length":16,"default":"''"},
+				"image": {"type":"VARCHAR","length":512,"default":"''"},
+				"weight": {"type":"DECIMAL","length":"10,4","default":0},
+				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"length": {"type":"DECIMAL","length":"10,4","default":0},
+				"width": {"type":"DECIMAL","length":"10,4","default":0},
+				"height": {"type":"DECIMAL","length":"10,4","default":0},
+				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
+				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
+				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"backordered": {"type":"DECIMAL","length":"10,4","default":0},
+				"purchase_price": {"type":"DECIMAL","length":"10,4","default":0},
+				"purchase_price_currency_code": {"type":"VARCHAR","length":3,"default":"''"},
+				"file": {"type":"VARCHAR","length":248,"nullable":true},
+				"filename": {"type":"VARCHAR","length":64,"nullable":true},
+				"mime_type": {"type":"VARCHAR","length":32,"nullable":true},
+				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"priority": {"type":"INT","length":11,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1527,54 +1244,38 @@
 		},
 		"stock_items_references": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
-				"supplier_id": { "type": "INT", "length": 10, "unsigned": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''"}
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
+				"supplier_id": {"type":"INT","length":10,"unsigned":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"}
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_item": {
-					"columns": ["stock_item_id"],
-					"references": {
-						"table": "stock_items",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"supplier": {
-					"columns": ["supplier_id"],
-					"references": {
-						"table": "suppliers",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"supplier": {"columns":["supplier_id"],"references":{"table":"suppliers","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"stock_transactions": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"description": { "type": "MEDIUMTEXT" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"name": {"type":"VARCHAR","length":128,"default":"''"},
+				"description": {"type":"MEDIUMTEXT"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"]
 		},
 		"stock_transactions_contents": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"transaction_id": { "type": "INT", "length": 10, "unsigned": true },
-				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
-				"quantity_adjustment": { "type": "DECIMAL", "length": "10,4", "default": 0 },
-				"sku": { "type": "VARCHAR", "length": 32 }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"transaction_id": {"type":"INT","length":10,"unsigned":true},
+				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"stock_item_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
+				"quantity_adjustment": {"type":"DECIMAL","length":"10,4","default":0},
+				"sku": {"type":"VARCHAR","length":32}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1583,46 +1284,22 @@
 				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_transaction_content_to_transaction": {
-					"columns": ["transaction_id"],
-					"references": {
-						"table": "stock_transactions",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				},
-				"stock_transaction_content_to_product": {
-					"columns": ["product_id"],
-					"references": {
-						"table": "products",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				},
-				"stock_transaction_content_to_stock_item": {
-					"columns": ["stock_item_id"],
-					"references": {
-						"table": "stock_items",
-						"columns": ["id"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"stock_transaction_content_to_transaction": {"columns":["transaction_id"],"references":{"table":"stock_transactions","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
+				"stock_transaction_content_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
+				"stock_transaction_content_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			}
 		},
 		"suppliers": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"code": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "TEXT" },
-				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"phone": { "type": "VARCHAR", "length": 24, "default": "''" },
-				"link": { "type": "VARCHAR", "length": 255, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"TEXT"},
+				"email": {"type":"VARCHAR","length":128,"default":"''"},
+				"phone": {"type":"VARCHAR","length":24,"default":"''"},
+				"link": {"type":"VARCHAR","length":255,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1631,31 +1308,31 @@
 		},
 		"tax_classes": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":64,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"]
 		},
 		"tax_rates": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true },
-				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true },
-				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"rate": { "type": "DECIMAL", "length": "6,4", "unsigned": true, "default": 0 },
-				"address_type": { "type": "ENUM('shipping','payment')", "default": "'shipping'" },
-				"rule_companies_with_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"rule_companies_without_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"rule_individuals_with_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"rule_individuals_without_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"tax_class_id": {"type":"INT","length":10,"unsigned":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
+				"code": {"type":"VARCHAR","length":32,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"VARCHAR","length":128,"default":"''"},
+				"rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
+				"address_type": {"type":"ENUM('shipping','payment')","default":"'shipping'"},
+				"rule_companies_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_companies_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_individuals_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"rule_individuals_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1663,44 +1340,28 @@
 				"geo_zone_id": ["geo_zone_id"]
 			},
 			"foreign_keys": {
-				"tax_rate_to_tax_class": {
-					"columns": ["tax_class_id"],
-					"references": {
-						"table": "tax_classes",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"tax_rate_to_geo_zone": {
-					"columns": ["geo_zone_id"],
-					"references": {
-						"table": "geo_zones",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "RESTRICT"
-					}
-				}
+				"tax_rate_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"tax_rate_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"RESTRICT"}}
 			}
 		},
 		"third_parties": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"privacy_classes": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"category": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"description": { "type": "MEDIUMTEXT", "nullable": true },
-				"collected_data": { "type": "TEXT", "nullable": true },
-				"purposes": { "type": "TEXT", "nullable": true },
-				"homepage": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"cookie_policy_url": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"privacy_policy_url": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"opt_out_url": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"do_not_sell_url": { "type": "VARCHAR", "length": 248, "default": "''" },
-				"country_code": { "type": "CHAR", "length": 2, "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "current_timestamp()" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"privacy_classes": {"type":"VARCHAR","length":64,"default":"''"},
+				"category": {"type":"VARCHAR","length":64,"default":"''"},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"description": {"type":"MEDIUMTEXT","nullable":true},
+				"collected_data": {"type":"TEXT","nullable":true},
+				"purposes": {"type":"TEXT","nullable":true},
+				"homepage": {"type":"VARCHAR","length":248,"default":"''"},
+				"cookie_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"privacy_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"opt_out_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"do_not_sell_url": {"type":"VARCHAR","length":248,"default":"''"},
+				"country_code": {"type":"CHAR","length":2,"nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"current_timestamp()"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1708,15 +1369,7 @@
 				"country_code": ["country_code"]
 			},
 			"foreign_keys": {
-				"third_party_to_country": {
-					"columns": ["country_code"],
-					"references": {
-						"table": "countries",
-						"columns": ["iso_code_2"],
-						"on_update": "CASCADE",
-						"on_delete": "SET NULL"
-					}
-				}
+				"third_party_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"CASCADE","on_delete":"SET NULL"}}
 			},
 			"check_constraints": {
 				"third_parties_chk_description": "description IS NULL OR description = '' OR JSON_VALID(description)",
@@ -1726,15 +1379,15 @@
 		},
 		"translations": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"code": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"text_en": { "type": "TEXT" },
-				"html": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"frontend": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"backend": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
-				"last_accessed": { "type": "TIMESTAMP", "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"code": {"type":"VARCHAR","length":128,"default":"''"},
+				"text_en": {"type":"TEXT"},
+				"html": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"frontend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"backend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
+				"last_accessed": {"type":"TIMESTAMP","nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1748,19 +1401,19 @@
 		},
 		"visitors": {
 			"columns": {
-				"id": { "type": "BIGINT", "length": 20, "unsigned": true, "auto_increment": true },
-				"session_id": { "type": "VARCHAR", "length": 13, "default": "''" },
-				"cart_uid": { "type": "VARCHAR", "length": 13, "default": "''" },
-				"referrer": { "type": "VARCHAR", "length": 256, "default": "''" },
-				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
-				"hostname": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"user_agent": { "type": "VARCHAR", "length": 256, "default": "''" },
-				"language": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"country_code": { "type": "VARCHAR", "length": 2, "default": "''" },
-				"pageviews": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
-				"last_page": { "type": "VARCHAR", "length": 128, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
+				"session_id": {"type":"VARCHAR","length":13,"default":"''"},
+				"cart_uid": {"type":"VARCHAR","length":13,"default":"''"},
+				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
+				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
+				"hostname": {"type":"VARCHAR","length":64,"default":"''"},
+				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
+				"language": {"type":"VARCHAR","length":2,"default":"''"},
+				"country_code": {"type":"VARCHAR","length":2,"default":"''"},
+				"pageviews": {"type":"INT","length":10,"unsigned":true,"default":0},
+				"last_page": {"type":"VARCHAR","length":128,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1773,12 +1426,12 @@
 		},
 		"zones": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"country_code": { "type": "CHAR", "length": 2 },
-				"code": { "type": "VARCHAR", "length": 8 },
-				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"country_code": {"type":"CHAR","length":2},
+				"code": {"type":"VARCHAR","length":8},
+				"name": {"type":"VARCHAR","length":64,"default":"''"},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1786,30 +1439,22 @@
 				"code": ["code"]
 			},
 			"foreign_keys": {
-				"zone_to_country": {
-					"columns": ["country_code"],
-					"references": {
-						"table": "countries",
-						"columns": ["iso_code_2"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				}
+				"zone_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
 			}
 		},
 		"zones_to_geo_zones": {
 			"columns": {
-				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
-				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true },
-				"country_code": { "type": "CHAR", "length": 2 },
-				"zone_code": { "type": "VARCHAR", "length": 8, "nullable": true },
-				"city": { "type": "VARCHAR", "length": 32, "nullable": true },
-				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
-				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
+				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
+				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
+				"country_code": {"type":"CHAR","length":2},
+				"zone_code": {"type":"VARCHAR","length":8,"nullable":true},
+				"city": {"type":"VARCHAR","length":32,"nullable":true},
+				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
+				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"region": ["geo_zone_id", "country_code", "zone_code", "city"]
+				"region": ["geo_zone_id","country_code","zone_code","city"]
 			},
 			"keys": {
 				"geo_zone_id": ["geo_zone_id"],
@@ -1818,33 +1463,9 @@
 				"city": ["city"]
 			},
 			"foreign_keys": {
-				"zone_entry_to_geo_zone": {
-					"columns": ["geo_zone_id"],
-					"references": {
-						"table": "geo_zones",
-						"columns": ["id"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"zone_entry_to_country": {
-					"columns": ["country_code"],
-					"references": {
-						"table": "countries",
-						"columns": ["iso_code_2"],
-						"on_update": "NO ACTION",
-						"on_delete": "CASCADE"
-					}
-				},
-				"zone_entry_to_zone": {
-					"columns": ["zone_code"],
-					"references": {
-						"table": "zones",
-						"columns": ["code"],
-						"on_update": "CASCADE",
-						"on_delete": "CASCADE"
-					}
-				}
+				"zone_entry_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"zone_entry_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
+				"zone_entry_to_zone": {"columns":["zone_code"],"references":{"table":"zones","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
 			}
 		}
 	}

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -2,30 +2,30 @@
 	"tables": {
 		"administrators": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"username": {"type":"VARCHAR","length":32,"default":"''"},
-				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
-				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
-				"email": {"type":"VARCHAR","length":128,"default":"''"},
-				"apps": {"type":"VARCHAR","length":4096,"default":"''"},
-				"widgets": {"type":"VARCHAR","length":512,"default":"''"},
-				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
-				"two_factor_auth": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"login_attempts": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
-				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
-				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
-				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
-				"last_active": {"type":"TIMESTAMP","nullable":true},
-				"last_login": {"type":"TIMESTAMP","nullable":true},
-				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
-				"blocked_until": {"type":"TIMESTAMP","nullable":true},
-				"valid_from": {"type":"TIMESTAMP","nullable":true},
-				"valid_to": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"username": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"apps": { "type": "VARCHAR", "length": 4096, "default": "''" },
+				"widgets": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"password_hash": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"two_factor_auth": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"login_attempts": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"total_logins": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"known_ips": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"last_ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
+				"last_hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"last_user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"last_active": { "type": "TIMESTAMP", "nullable": true },
+				"last_login": { "type": "TIMESTAMP", "nullable": true },
+				"sessions_expiry": { "type": "TIMESTAMP", "nullable": true },
+				"blocked_until": { "type": "TIMESTAMP", "nullable": true },
+				"valid_from": { "type": "TIMESTAMP", "nullable": true },
+				"valid_to": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -36,12 +36,12 @@
 		},
 		"attribute_groups": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"TEXT","nullable":true},
-				"sort": {"type":"ENUM('alphabetical','priority')","default":"'alphabetical'"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "TEXT", "nullable": true },
+				"sort": { "type": "ENUM('alphabetical','priority')", "default": "'alphabetical'" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -53,12 +53,12 @@
 		},
 		"attribute_values": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"group_id": {"type":"INT","length":10,"unsigned":true},
-				"name": {"type":"TEXT","nullable":true},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"group_id": { "type": "INT", "length": 10, "unsigned": true },
+				"name": { "type": "TEXT", "nullable": true },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -70,40 +70,40 @@
 		},
 		"banners": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"languages": {"type":"VARCHAR","length":64,"default":"''"},
-				"html": {"type":"TEXT"},
-				"image": {"type":"VARCHAR","length":64,"default":"''"},
-				"link": {"type":"VARCHAR","length":255,"default":"''"},
-				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
-				"total_views": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"total_clicks": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"valid_from": {"type":"TIMESTAMP","nullable":true},
-				"valid_to": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"languages": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"html": { "type": "TEXT" },
+				"image": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"link": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"total_views": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"total_clicks": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"valid_from": { "type": "TIMESTAMP", "nullable": true },
+				"valid_to": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"]
 		},
 		"brands": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"short_description": {"type":"TEXT","nullable":true},
-				"description": {"type":"MEDIUMTEXT","nullable":true},
-				"h1_title": {"type":"TEXT","nullable":true},
-				"head_title": {"type":"TEXT","nullable":true},
-				"meta_description": {"type":"TEXT","nullable":true},
-				"link": {"type":"TEXT","nullable":true},
-				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
-				"image": {"type":"VARCHAR","length":128,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"featured": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"short_description": { "type": "TEXT", "nullable": true },
+				"description": { "type": "MEDIUMTEXT", "nullable": true },
+				"h1_title": { "type": "TEXT", "nullable": true },
+				"head_title": { "type": "TEXT", "nullable": true },
+				"meta_description": { "type": "TEXT", "nullable": true },
+				"link": { "type": "TEXT", "nullable": true },
+				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"image": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -123,15 +123,15 @@
 		},
 		"campaigns": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
-				"name": {"type":"VARCHAR","length":50,"default":"''"},
-				"discount_mode": {"type":"VARCHAR","length":16,"default":"'fixed'"},
-				"discount_percent": {"type":"DECIMAL","length":"5,2","default":0},
-				"valid_from": {"type":"TIMESTAMP","nullable":true},
-				"valid_to": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
+				"name": { "type": "VARCHAR", "length": 50, "default": "''" },
+				"discount_mode": { "type": "VARCHAR", "length": 16, "default": "'fixed'" },
+				"discount_percent": { "type": "DECIMAL", "length": "5,2", "default": 0 },
+				"valid_from": { "type": "TIMESTAMP", "nullable": true },
+				"valid_to": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -142,36 +142,43 @@
 		},
 		"campaigns_scopes": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"campaign_id": {"type":"INT","length":10,"unsigned":true},
-				"scope_type": {"type":"VARCHAR","length":16,"default":"''"},
-				"scope_id": {"type":"INT","length":10,"unsigned":true}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"campaign_id": { "type": "INT", "length": 10, "unsigned": true },
+				"scope_type": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"scope_id": { "type": "INT", "length": 10, "unsigned": true }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"campaign_scope": ["campaign_id","scope_type","scope_id"]
+				"campaign_scope": ["campaign_id", "scope_type", "scope_id"]
 			},
 			"keys": {
 				"campaign_id": ["campaign_id"],
-				"scope_type": ["scope_type","scope_id"]
+				"scope_type": ["scope_type", "scope_id"]
 			},
 			"foreign_keys": {
-				"campaign_id": {"columns":["campaign_id"],"references":{"table":"campaigns","columns":["id"]},"on_delete":"CASCADE"}
+				"campaign_id": {
+					"columns": ["campaign_id"],
+					"references": {
+						"table": "campaigns",
+						"columns": ["id"]
+					},
+					"on_delete": "CASCADE"
+				}
 			}
 		},
 		"cart_items": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"cart_uid": {"type":"VARCHAR","length":13},
-				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"key": {"type":"VARCHAR","length":32},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"userdata": {"type":"VARCHAR","length":2048,"default":"''"},
-				"image": {"type":"VARCHAR","length":255,"default":"''"},
-				"quantity": {"type":"DECIMAL","length":"11,4","default":1},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"cart_uid": { "type": "VARCHAR", "length": 13 },
+				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"key": { "type": "VARCHAR", "length": 32 },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"stock_option_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"userdata": { "type": "VARCHAR", "length": 2048, "default": "''" },
+				"image": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"quantity": { "type": "DECIMAL", "length": "11,4", "default": 1 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -179,30 +186,54 @@
 				"cart_uid": ["cart_uid"]
 			},
 			"foreign_keys": {
-				"cart_item_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"cart_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"cart_item_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"cart_item_to_customer": {
+					"columns": ["customer_id"],
+					"references": {
+						"table": "customers",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"cart_item_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"cart_item_to_stock_option": {
+					"columns": ["stock_option_id"],
+					"references": {
+						"table": "products_stock_options",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"categories": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"google_taxonomy_id": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"code": {"type":"VARCHAR","length":64,"default":"''"},
-				"name": {"type":"TEXT","nullable":true},
-				"short_description": {"type":"TEXT","nullable":true},
-				"description": {"type":"MEDIUMTEXT","nullable":true},
-				"synonyms": {"type":"TEXT"},
-				"head_title": {"type":"TEXT","nullable":true},
-				"h1_title": {"type":"TEXT","nullable":true},
-				"meta_description": {"type":"TEXT","nullable":true},
-				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
-				"image": {"type":"VARCHAR","length":255,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"parent_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"google_taxonomy_id": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"code": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"name": { "type": "TEXT", "nullable": true },
+				"short_description": { "type": "TEXT", "nullable": true },
+				"description": { "type": "MEDIUMTEXT", "nullable": true },
+				"synonyms": { "type": "TEXT" },
+				"head_title": { "type": "TEXT", "nullable": true },
+				"h1_title": { "type": "TEXT", "nullable": true },
+				"meta_description": { "type": "TEXT", "nullable": true },
+				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"image": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -211,7 +242,15 @@
 				"status": ["status"]
 			},
 			"foreign_keys": {
-				"category_to_parent": {"columns":["parent_id"],"references":{"table":"categories","columns":["id"],"on_update":"CASCADE","on_delete":"RESTRICT"}}
+				"category_to_parent": {
+					"columns": ["parent_id"],
+					"references": {
+					"table": "categories",
+					"columns": ["id"],
+					"on_update": "CASCADE",
+					"on_delete": "RESTRICT"
+					}
+				}
 			},
 			"check_constraints": {
 				"categories_chk_name": "name IS NULL OR name = '' OR JSON_VALID(name)",
@@ -224,42 +263,58 @@
 		},
 		"categories_filters": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"category_id": {"type":"INT","length":10,"unsigned":true},
-				"attribute_group_id": {"type":"INT","length":10,"unsigned":true},
-				"select_multiple": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"category_id": { "type": "INT", "length": 10, "unsigned": true },
+				"attribute_group_id": { "type": "INT", "length": 10, "unsigned": true },
+				"select_multiple": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"attribute_filter": ["category_id","attribute_group_id"]
+				"attribute_filter": ["category_id", "attribute_group_id"]
 			},
 			"keys": {
 				"category_id": ["category_id"]
 			},
 			"foreign_keys": {
-				"category_filter_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"category_filter_to_attribute_group": {"columns":["attribute_group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"category_filter_to_category": {
+					"columns": ["category_id"],
+					"references": {
+						"table": "categories",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"category_filter_to_attribute_group": {
+					"columns": ["attribute_group_id"],
+					"references": {
+						"table": "attribute_groups",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"countries": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"iso_code_1": {"type":"CHAR","length":3,"default":"''"},
-				"iso_code_2": {"type":"CHAR","length":2,"default":"''"},
-				"iso_code_3": {"type":"CHAR","length":3,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"domestic_name": {"type":"VARCHAR","length":64,"default":"''"},
-				"tax_id_format": {"type":"VARCHAR","length":64,"default":"''"},
-				"address_format": {"type":"VARCHAR","length":128,"default":"''"},
-				"postcode_format": {"type":"VARCHAR","length":255,"default":"''"},
-				"postcode_required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"language_code": {"type":"CHAR","length":2},
-				"currency_code": {"type":"CHAR","length":3,"default":"''"},
-				"phone_code": {"type":"VARCHAR","length":3,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"iso_code_1": { "type": "CHAR", "length": 3, "default": "''" },
+				"iso_code_2": { "type": "CHAR", "length": 2, "default": "''" },
+				"iso_code_3": { "type": "CHAR", "length": 3, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"domestic_name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"tax_id_format": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"address_format": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"postcode_format": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"postcode_required": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"language_code": { "type": "CHAR", "length": 2 },
+				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
+				"phone_code": { "type": "VARCHAR", "length": 3, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -273,18 +328,18 @@
 		},
 		"currencies": {
 			"columns": {
-				"id": {"type":"TINYINT","length":3,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"default":0},
-				"code": {"type":"CHAR","length":3,"default":"''"},
-				"number": {"type":"CHAR","length":3,"default":"''"},
-				"name": {"type":"VARCHAR","length":32,"default":"''"},
-				"value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":1},
-				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
-				"prefix": {"type":"VARCHAR","length":8,"default":"''"},
-				"suffix": {"type":"VARCHAR","length":8,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "TINYINT", "length": 3, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "default": 0 },
+				"code": { "type": "CHAR", "length": 3, "default": "''" },
+				"number": { "type": "CHAR", "length": 3, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"value": { "type": "DECIMAL", "length": "11,6", "unsigned": true, "default": 1 },
+				"decimals": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 2 },
+				"prefix": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"suffix": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -295,61 +350,61 @@
 		},
 		"customer_groups": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"type": {"type":"ENUM('retail', 'wholesale')","default":"'retail'"},
-				"name": {"type":"VARCHAR","length":32,"default":"''"},
-				"description": {"type":"VARCHAR","length":248,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"type": { "type": "ENUM('retail', 'wholesale')", "default": "'retail'" },
+				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"]
 		},
 		"customers": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"email": {"type":"VARCHAR","length":64,"default":"''"},
-				"tax_id": {"type":"VARCHAR","length":24,"default":"''"},
-				"company": {"type":"VARCHAR","length":32,"default":"''"},
-				"firstname": {"type":"VARCHAR","length":32,"default":"''"},
-				"lastname": {"type":"VARCHAR","length":32,"default":"''"},
-				"address1": {"type":"VARCHAR","length":32,"default":"''"},
-				"address2": {"type":"VARCHAR","length":32,"default":"''"},
-				"postcode": {"type":"VARCHAR","length":16,"default":"''"},
-				"city": {"type":"VARCHAR","length":32,"default":"''"},
-				"country_code": {"type":"CHAR","length":2,"default":"''"},
-				"zone_code": {"type":"VARCHAR","length":8,"default":"''"},
-				"phone": {"type":"VARCHAR","length":16,"default":"''"},
-				"different_shipping_address": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
-				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
-				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
-				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
-				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
-				"language_code": {"type":"CHAR","length":2,"nullable":true},
-				"notes": {"type":"TEXT"},
-				"password_hash": {"type":"VARCHAR","length":255,"default":"''"},
-				"password_reset_token": {"type":"VARCHAR","length":128,"default":"''"},
-				"login_attempts": {"type":"INT","length":11,"default":0},
-				"total_logins": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"known_ips": {"type":"VARCHAR","length":512,"default":"''"},
-				"last_ip_address": {"type":"VARCHAR","length":39,"default":"''"},
-				"last_hostname": {"type":"VARCHAR","length":128,"default":"''"},
-				"last_user_agent": {"type":"VARCHAR","length":255,"default":"''"},
-				"last_login": {"type":"TIMESTAMP","nullable":true},
-				"last_active": {"type":"TIMESTAMP","nullable":true},
-				"blocked_until": {"type":"TIMESTAMP","nullable":true},
-				"sessions_expiry": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"email": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"tax_id": { "type": "VARCHAR", "length": 24, "default": "''" },
+				"company": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"address1": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"address2": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"city": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"country_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"phone": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"different_shipping_address": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"shipping_company": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"shipping_city": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_country_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"shipping_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"shipping_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"shipping_email": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
+				"notes": { "type": "TEXT" },
+				"password_hash": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"password_reset_token": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"login_attempts": { "type": "INT", "length": 11, "default": 0 },
+				"total_logins": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"known_ips": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"last_ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
+				"last_hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"last_user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"last_login": { "type": "TIMESTAMP", "nullable": true },
+				"last_active": { "type": "TIMESTAMP", "nullable": true },
+				"blocked_until": { "type": "TIMESTAMP", "nullable": true },
+				"sessions_expiry": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -359,16 +414,24 @@
 				"group_id": ["group_id"]
 			},
 			"foreign_keys": {
-				"customer_to_customer_group": {"columns":["group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"customer_to_customer_group": {
+					"columns": ["group_id"],
+					"references": {
+						"table": "customer_groups",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			}
 		},
 		"delivery_statuses": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"name": {"type":"TEXT","nullable":true},
-				"description": {"type":"TEXT","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"name": { "type": "TEXT", "nullable": true },
+				"description": { "type": "TEXT", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"check_constraints": {
@@ -378,24 +441,24 @@
 		},
 		"emails": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"ENUM('draft','scheduled','sent','error')","default":"'draft'"},
-				"code": {"type":"VARCHAR","length":255,"default":"''"},
-				"reference": {"type":"VARCHAR","length":255,"default":"''"},
-				"language_code": {"type":"VARCHAR","length":2,"default":"''"},
-				"sender": {"type":"VARCHAR","length":255,"default":"''"},
-				"recipients": {"type":"TEXT"},
-				"ccs": {"type":"TEXT"},
-				"bccs": {"type":"TEXT"},
-				"subject": {"type":"VARCHAR","length":255,"default":"''"},
-				"multiparts": {"type":"MEDIUMTEXT"},
-				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
-				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
-				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
-				"scheduled_at": {"type":"TIMESTAMP","nullable":true},
-				"sent_at": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "ENUM('draft','scheduled','sent','error')", "default": "'draft'" },
+				"code": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"reference": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"language_code": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"sender": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"recipients": { "type": "TEXT" },
+				"ccs": { "type": "TEXT" },
+				"bccs": { "type": "TEXT" },
+				"subject": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"multiparts": { "type": "MEDIUMTEXT" },
+				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
+				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"scheduled_at": { "type": "TIMESTAMP", "nullable": true },
+				"sent_at": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -407,22 +470,22 @@
 		},
 		"event_logs": {
 			"columns": {
-				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
-				"session_id": {"type":"VARCHAR","length":64,"nullable":true},
-				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"customer_email": {"type":"VARCHAR","length":64,"nullable":true},
-				"customer_phone": {"type":"VARCHAR","length":16,"nullable":true},
-				"type": {"type":"VARCHAR","length":64,"nullable":true},
-				"description": {"type":"VARCHAR","length":248,"default":"''"},
-				"data": {"type":"VARCHAR","length":1024,"default":"'{}'"},
-				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
-				"url": {"type":"VARCHAR","length":248,"nullable":true},
-				"ip_address": {"type":"VARCHAR","length":47,"nullable":true},
-				"hostname": {"type":"VARCHAR","length":128,"nullable":true},
-				"user_agent": {"type":"VARCHAR","length":248,"nullable":true},
-				"fingerprint": {"type":"VARCHAR","length":32,"nullable":true},
-				"expires_at": {"type":"TIMESTAMP","nullable":true},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "BIGINT", "length": 20, "unsigned": true, "auto_increment": true },
+				"session_id": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"customer_email": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"customer_phone": { "type": "VARCHAR", "length": 16, "nullable": true },
+				"type": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"description": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"data": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
+				"conversions": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
+				"url": { "type": "VARCHAR", "length": 248, "nullable": true },
+				"ip_address": { "type": "VARCHAR", "length": 47, "nullable": true },
+				"hostname": { "type": "VARCHAR", "length": 128, "nullable": true },
+				"user_agent": { "type": "VARCHAR", "length": 248, "nullable": true },
+				"fingerprint": { "type": "VARCHAR", "length": 32, "nullable": true },
+				"expires_at": { "type": "TIMESTAMP", "nullable": true },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -438,7 +501,15 @@
 				"expires_at": ["expires_at"]
 			},
 			"foreign_keys": {
-				"event_log_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"event_log_to_customer": {
+					"columns": ["customer_id"],
+					"references": {
+						"table": "customers",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			},
 			"check_constraints": {
 				"event_logs_chk_data": "data IS NULL OR data = '' OR JSON_VALID(data)",
@@ -447,39 +518,39 @@
 		},
 		"geo_zones": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"VARCHAR","length":255,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"]
 		},
 		"languages": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"default":0},
-				"code": {"type":"CHAR","length":2,"default":"''"},
-				"code2": {"type":"CHAR","length":3,"default":"''"},
-				"name": {"type":"VARCHAR","length":32,"default":"''"},
-				"direction": {"type":"ENUM('ltr','rtl')","default":"'ltr'"},
-				"locale": {"type":"VARCHAR","length":64,"default":"''"},
-				"locale_intl": {"type":"VARCHAR","length":16,"default":"''"},
-				"mysql_collation": {"type":"VARCHAR","length":32,"default":"''"},
-				"url_type": {"type":"ENUM('','none','root','path','domain')","default":"''"},
-				"domain_name": {"type":"VARCHAR","length":64,"default":"''"},
-				"raw_date": {"type":"VARCHAR","length":32,"default":"''"},
-				"raw_time": {"type":"VARCHAR","length":32,"default":"''"},
-				"raw_datetime": {"type":"VARCHAR","length":32,"default":"''"},
-				"format_date": {"type":"VARCHAR","length":32,"default":"''"},
-				"format_time": {"type":"VARCHAR","length":32,"default":"''"},
-				"format_datetime": {"type":"VARCHAR","length":32,"default":"''"},
-				"decimal_point": {"type":"VARCHAR","length":1,"default":"''"},
-				"thousands_sep": {"type":"VARCHAR","length":1,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "default": 0 },
+				"code": { "type": "CHAR", "length": 2, "default": "''" },
+				"code2": { "type": "CHAR", "length": 3, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"direction": { "type": "ENUM('ltr','rtl')", "default": "'ltr'" },
+				"locale": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"locale_intl": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"mysql_collation": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"url_type": { "type": "ENUM('','none','root','path','domain')", "default": "''" },
+				"domain_name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"raw_date": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"raw_time": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"raw_datetime": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"format_date": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"format_time": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"format_datetime": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"decimal_point": { "type": "VARCHAR", "length": 1, "default": "''" },
+				"thousands_sep": { "type": "VARCHAR", "length": 1, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -488,17 +559,17 @@
 		},
 		"modules": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"module_id": {"type":"VARCHAR","length":64,"default":"''"},
-				"type": {"type":"VARCHAR","length":16,"default":"''"},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0},
-				"settings": {"type":"TEXT"},
-				"last_log": {"type":"TEXT"},
-				"last_pushed": {"type":"TIMESTAMP","nullable":true},
-				"last_processed": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"module_id": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"type": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"settings": { "type": "TEXT" },
+				"last_log": { "type": "TEXT" },
+				"last_pushed": { "type": "TIMESTAMP", "nullable": true },
+				"last_processed": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -511,17 +582,17 @@
 		},
 		"newsletter_recipients": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"subscribed": {"type":"TINYINT","length":1,"unsigned":true,"default":1},
-				"lastname": {"type":"VARCHAR","length":64,"default":"''"},
-				"firstname": {"type":"VARCHAR","length":64,"default":"''"},
-				"email": {"type":"VARCHAR","length":128,"default":"''"},
-				"language_code": {"type":"CHAR","length":2,"nullable":true},
-				"country_code": {"type":"CHAR","length":2,"nullable":true},
-				"ip_address": {"type":"VARCHAR","length":64,"default":"''"},
-				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
-				"user_agent": {"type":"VARCHAR","length":248,"default":"''"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"subscribed": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 1 },
+				"lastname": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"firstname": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
+				"country_code": { "type": "CHAR", "length": 2, "nullable": true },
+				"ip_address": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"user_agent": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -533,81 +604,81 @@
 		},
 		"orders": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"no": {"type":"VARCHAR","length":16,"nullable":true},
-				"starred": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"unread": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"order_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"customer_tax_id": {"type":"VARCHAR","length":24,"default":"''"},
-				"customer_company": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_firstname": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_lastname": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_address1": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_address2": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_city": {"type":"VARCHAR","length":32,"default":"''"},
-				"customer_postcode": {"type":"VARCHAR","length":16,"default":"''"},
-				"customer_country_code": {"type":"CHAR","length":2,"default":"''"},
-				"customer_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
-				"customer_phone": {"type":"VARCHAR","length":16,"default":"''"},
-				"customer_email": {"type":"VARCHAR","length":64,"default":"''"},
-				"shipping_tax_id": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_company": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_firstname": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_lastname": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_address1": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_address2": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_city": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_postcode": {"type":"VARCHAR","length":16,"default":"''"},
-				"shipping_country_code": {"type":"CHAR","length":2,"default":"''"},
-				"shipping_zone_code": {"type":"VARCHAR","length":8,"default":"''"},
-				"shipping_phone": {"type":"VARCHAR","length":16,"default":"''"},
-				"shipping_email": {"type":"VARCHAR","length":64,"default":"''"},
-				"shipping_option_id": {"type":"VARCHAR","length":32,"default":"''"},
-				"shipping_option_name": {"type":"VARCHAR","length":64,"default":"''"},
-				"shipping_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
-				"shipping_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
-				"shipping_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"shipping_purchase_cost": {"type":"DECIMAL","length":"10,4","default":0},
-				"shipping_tracking_id": {"type":"VARCHAR","length":128,"default":"''"},
-				"shipping_tracking_url": {"type":"VARCHAR","length":255,"default":"''"},
-				"shipping_progress": {"type":"TINYINT","length":3,"default":0},
-				"shipping_current_status": {"type":"VARCHAR","length":64,"default":"''"},
-				"shipping_current_location": {"type":"VARCHAR","length":128,"default":"''"},
-				"payment_option_id": {"type":"VARCHAR","length":32,"default":"''"},
-				"payment_option_name": {"type":"VARCHAR","length":64,"default":"''"},
-				"payment_option_userdata": {"type":"VARCHAR","length":512,"default":"''"},
-				"payment_option_fee": {"type":"DECIMAL","length":"10,4","default":0},
-				"payment_option_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"payment_transaction_id": {"type":"VARCHAR","length":128,"default":"''"},
-				"payment_transaction_fee": {"type":"DECIMAL","length":"10,4","nullable":true},
-				"payment_receipt_url": {"type":"VARCHAR","length":255,"default":"''"},
-				"payment_terms": {"type":"VARCHAR","length":8,"default":"''"},
-				"incoterm": {"type":"VARCHAR","length":3,"default":"''"},
-				"reference": {"type":"VARCHAR","length":128,"default":"''"},
-				"language_code": {"type":"CHAR","length":2,"nullable":true},
-				"weight_total": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"currency_code": {"type":"CHAR","length":3,"default":"''"},
-				"currency_value": {"type":"DECIMAL","length":"11,6","unsigned":true,"default":0},
-				"display_prices_including_tax": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"subtotal": {"type":"DECIMAL","length":"10,4","default":0},
-				"subtotal_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"discount": {"type":"DECIMAL","length":"10,4","default":0},
-				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"total": {"type":"DECIMAL","length":"10,4","default":0},
-				"total_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"notes": {"type":"VARCHAR","length":1024,"default":"''"},
-				"conversions": {"type":"VARCHAR","length":1024,"default":"'{}'"},
-				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
-				"hostname": {"type":"VARCHAR","length":128,"default":"''"},
-				"user_agent": {"type":"VARCHAR","length":255,"default":"''"},
-				"domain": {"type":"VARCHAR","length":64,"nullable":true},
-				"public_key": {"type":"VARCHAR","length":32,"default":"''"},
-				"date_paid": {"type":"TIMESTAMP","nullable":true},
-				"date_dispatched": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"no": { "type": "VARCHAR", "length": 16, "nullable": true },
+				"starred": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"unread": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"order_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"customer_tax_id": { "type": "VARCHAR", "length": 24, "default": "''" },
+				"customer_company": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_city": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"customer_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"customer_country_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"customer_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"customer_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"customer_email": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"shipping_tax_id": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_company": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_firstname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_lastname": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_address1": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_address2": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_city": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_postcode": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"shipping_country_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"shipping_zone_code": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"shipping_phone": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"shipping_email": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"shipping_option_id": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shipping_option_name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"shipping_option_userdata": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"shipping_option_fee": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"shipping_option_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"shipping_purchase_cost": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"shipping_tracking_id": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"shipping_tracking_url": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"shipping_progress": { "type": "TINYINT", "length": 3, "default": 0 },
+				"shipping_current_status": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"shipping_current_location": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"payment_option_id": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"payment_option_name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"payment_option_userdata": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"payment_option_fee": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"payment_option_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"payment_transaction_id": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"payment_transaction_fee": { "type": "DECIMAL", "length": "10,4", "nullable": true },
+				"payment_receipt_url": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"payment_terms": { "type": "VARCHAR", "length": 8, "default": "''" },
+				"incoterm": { "type": "VARCHAR", "length": 3, "default": "''" },
+				"reference": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"language_code": { "type": "CHAR", "length": 2, "nullable": true },
+				"weight_total": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
+				"currency_value": { "type": "DECIMAL", "length": "11,6", "unsigned": true, "default": 0 },
+				"display_prices_including_tax": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"subtotal": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"subtotal_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"discount": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"discount_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"total": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"total_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"notes": { "type": "VARCHAR", "length": 1024, "default": "''" },
+				"conversions": { "type": "VARCHAR", "length": 1024, "default": "'{}'" },
+				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
+				"hostname": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"user_agent": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"domain": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"public_key": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"date_paid": { "type": "TIMESTAMP", "nullable": true },
+				"date_dispatched": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -620,8 +691,24 @@
 				"unread": ["unread"]
 			},
 			"foreign_keys": {
-				"order_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
-				"order_to_order_status": {"columns":["order_status_id"],"references":{"table":"order_statuses","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"order_to_customer": {
+					"columns": ["customer_id"],
+					"references": {
+						"table": "customers",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				},
+				"order_to_order_status": {
+					"columns": ["order_status_id"],
+					"references": {
+						"table": "order_statuses",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			},
 			"check_constraints": {
 				"orders_chk_conversions": "conversions IS NULL OR conversions = '' OR JSON_VALID(conversions)"
@@ -629,82 +716,106 @@
 		},
 		"orders_comments": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"order_id": {"type":"INT","length":10,"unsigned":true},
-				"author_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"author": {"type":"ENUM('system','staff','customer')","default":"'system'"},
-				"text": {"type":"VARCHAR","length":512,"default":"''"},
-				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"order_id": { "type": "INT", "length": 10, "unsigned": true },
+				"author_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"author": { "type": "ENUM('system','staff','customer')", "default": "'system'" },
+				"text": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_comment_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"order_comment_to_order": {
+					"columns": ["order_id"],
+					"references": {
+						"table": "orders",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"orders_items": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"order_id": {"type":"INT","length":10,"unsigned":true},
-				"line_id": {"type":"INT","length":10,"unsigned":true},
-				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
-				"name": {"type":"VARCHAR","length":128,"default":"''"},
-				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
-				"sku": {"type":"VARCHAR","length":32,"default":"''"},
-				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
-				"taric": {"type":"VARCHAR","length":32,"default":"''"},
-				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
-				"price": {"type":"DECIMAL","length":"10,4","default":0},
-				"tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"tax_rate": {"type":"DECIMAL","length":"4,2","unsigned":true,"default":0},
-				"tax_class_id": {"type":"INT","length":"10","unsigned":true,"nullable":true},
-				"discount": {"type":"DECIMAL","length":"10,4","default":0},
-				"discount_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"sum": {"type":"DECIMAL","length":"10,4","default":0},
-				"sum_tax": {"type":"DECIMAL","length":"10,4","default":0},
-				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"length": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"width": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"height": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"order_id": { "type": "INT", "length": 10, "unsigned": true },
+				"line_id": { "type": "INT", "length": 10, "unsigned": true },
+				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
+				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"serial_number": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"taric": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"quantity": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"price": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"tax_rate": { "type": "DECIMAL", "length": "4,2", "unsigned": true, "default": 0 },
+				"tax_class_id": { "type": "INT", "length": "10", "unsigned": true, "nullable": true },
+				"discount": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"discount_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"sum": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"sum_tax": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"weight": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"length": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"width": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"height": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"length_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"downloads": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"order_id": ["order_id"]
 			},
 			"foreign_keys": {
-				"order_item_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"order_item_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"order_item_to_order": {
+					"columns": ["order_id"],
+					"references": {
+						"table": "orders",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"order_item_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			}
 		},
 		"orders_lines": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"order_id": {"type":"INT","length":10,"unsigned":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"stock_option_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"code": {"type":"VARCHAR","length":32,"nullable":true},
-				"name": {"type":"VARCHAR","length":128,"default":"''"},
-				"serial_number": {"type":"VARCHAR","length":32,"default":"''"},
-				"userdata": {"type":"VARCHAR","length":2048,"default":"'{}'"},
-				"quantity": {"type":"DECIMAL","length":"11,4","default":0},
-				"price": {"type":"DECIMAL","length":"11,4","default":0},
-				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"tax_rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
-				"tax": {"type":"DECIMAL","length":"11,4","default":0},
-				"discount": {"type":"DECIMAL","length":"11,4","default":0},
-				"discount_tax": {"type":"DECIMAL","length":"11,4","default":0},
-				"sum": {"type":"DECIMAL","length":"11,4","default":0},
-				"sum_tax": {"type":"DECIMAL","length":"11,4","default":0},
-				"weight": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"order_id": { "type": "INT", "length": 10, "unsigned": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"stock_option_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"code": { "type": "VARCHAR", "length": 32, "nullable": true },
+				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"serial_number": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"userdata": { "type": "VARCHAR", "length": 2048, "default": "'{}'" },
+				"quantity": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"price": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"tax_rate": { "type": "DECIMAL", "length": "6,4", "unsigned": true, "default": 0 },
+				"tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"discount": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"discount_tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"sum": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"sum_tax": { "type": "DECIMAL", "length": "11,4", "default": 0 },
+				"weight": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -715,9 +826,33 @@
 				"code": ["code"]
 			},
 			"foreign_keys": {
-				"order_line_to_order": {"columns":["order_id"],"references":{"table":"orders","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
-				"order_line_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"RESTRICT","on_delete":"RESTRICT"}},
-				"order_line_to_stock_option": {"columns":["stock_option_id"],"references":{"table":"products_stock_options","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"order_line_to_order": {
+					"columns": ["order_id"],
+					"references": {
+						"table": "orders",
+						"columns": ["id"],
+						"on_update": "RESTRICT",
+						"on_delete": "RESTRICT"
+					}
+				},
+				"order_line_to_tax_class": {
+					"columns": ["tax_class_id"],
+					"references": {
+						"table": "tax_classes",
+						"columns": ["id"],
+						"on_update": "RESTRICT",
+						"on_delete": "RESTRICT"
+					}
+				},
+				"order_line_to_stock_option": {
+					"columns": ["stock_option_id"],
+					"references": {
+						"table": "products_stock_options",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			},
 			"check_constraints": {
 				"orders_lines_chk_userdata": "userdata IS NULL OR userdata = '' OR JSON_VALID(userdata)"
@@ -725,23 +860,23 @@
 		},
 		"order_statuses": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"state": {"type":"ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')","default":"''"},
-				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"icon": {"type":"VARCHAR","length":24,"default":"''"},
-				"color": {"type":"VARCHAR","length":7,"default":"''"},
-				"name": {"type":"TEXT","length":64,"nullable":true},
-				"description": {"type":"TEXT","nullable":true},
-				"email_subject": {"type":"TEXT","nullable":true},
-				"email_message": {"type":"MEDIUMTEXT","nullable":true},
-				"is_sale": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"is_archived": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"is_trackable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"stock_action": {"type":"ENUM('none','reserve','commit')","default":"'none'"},
-				"notify": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"state": { "type": "ENUM('','created','on_hold','ready','delayed','processing','completed','dispatched','in_transit','delivered','returning','returned','cancelled','fraud','other')", "default": "''" },
+				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"icon": { "type": "VARCHAR", "length": 24, "default": "''" },
+				"color": { "type": "VARCHAR", "length": 7, "default": "''" },
+				"name": { "type": "TEXT", "length": 64, "nullable": true },
+				"description": { "type": "TEXT", "nullable": true },
+				"email_subject": { "type": "TEXT", "nullable": true },
+				"email_message": { "type": "MEDIUMTEXT", "nullable": true },
+				"is_sale": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"is_archived": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"is_trackable": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"stock_action": { "type": "ENUM('none','reserve','commit')", "default": "'none'" },
+				"notify": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -759,17 +894,17 @@
 		},
 		"pages": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"parent_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"dock": {"type":"VARCHAR","length":64,"default":"''"},
-				"status": {"type":"TINYINT","length":1,"default":0},
-				"title": {"type":"TEXT","nullable":true},
-				"content": {"type":"MEDIUMTEXT","nullable":true},
-				"head_title": {"type":"TEXT","nullable":true},
-				"meta_description": {"type":"TEXT","nullable":true},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"parent_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"dock": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"status": { "type": "TINYINT", "length": 1, "default": 0 },
+				"title": { "type": "TEXT", "nullable": true },
+				"content": { "type": "MEDIUMTEXT", "nullable": true },
+				"head_title": { "type": "TEXT", "nullable": true },
+				"meta_description": { "type": "TEXT", "nullable": true },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -786,45 +921,45 @@
 		},
 		"products": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"type": {"type":"ENUM('virtual','physical','digital','variable','bundle')","default":"'virtual'"},
-				"featured": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"pinned": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"delivery_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"sold_out_status_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"default_category_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"sku": {"type":"VARCHAR","length":32,"default":"''"},
-				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
-				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
-				"taric": {"type":"VARCHAR","length":16,"default":"''"},
-				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"TEXT","nullable":true},
-				"short_description": {"type":"TEXT","nullable":true},
-				"description": {"type":"MEDIUMTEXT","nullable":true},
-				"technical_data": {"type":"TEXT","nullable":true},
-				"autofill_technical_data": {"type":"TINYINT","length":1,"default":0},
-				"head_title": {"type":"TEXT","nullable":true},
-				"meta_description": {"type":"TEXT","nullable":true},
-				"synonyms": {"type":"TEXT","nullable":true},
-				"keywords": {"type":"VARCHAR","length":255,"default":"''"},
-				"stock_option_type": {"type":"ENUM('variants','bundle')","default":"'variants'"},
-				"quantity_min": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
-				"quantity_max": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"quantity_step": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"recommended_price": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":0},
-				"tax_class_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"default_image": {"type":"VARCHAR","length":255,"default":"''"},
-				"video_url": {"type":"VARCHAR","length":255,"default":"''"},
-				"replaced_by": {"type":"VARCHAR","length":24},
-				"valid_from": {"type":"TIMESTAMP","nullable":true},
-				"valid_to": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"type": { "type": "ENUM('virtual','physical','digital','variable','bundle')", "default": "'virtual'" },
+				"featured": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"pinned": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"brand_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"supplier_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"delivery_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"sold_out_status_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"default_category_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"mpn": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"taric": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"shelf": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "TEXT", "nullable": true },
+				"short_description": { "type": "TEXT", "nullable": true },
+				"description": { "type": "MEDIUMTEXT", "nullable": true },
+				"technical_data": { "type": "TEXT", "nullable": true },
+				"autofill_technical_data": { "type": "TINYINT", "length": 1, "default": 0 },
+				"head_title": { "type": "TEXT", "nullable": true },
+				"meta_description": { "type": "TEXT", "nullable": true },
+				"synonyms": { "type": "TEXT", "nullable": true },
+				"keywords": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"stock_option_type": { "type": "ENUM('variants','bundle')", "default": "'variants'" },
+				"quantity_min": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 1 },
+				"quantity_max": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"quantity_step": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"quantity_unit_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"recommended_price": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 0 },
+				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"default_image": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"video_url": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"replaced_by": { "type": "VARCHAR", "length": 24 },
+				"valid_from": { "type": "TIMESTAMP", "nullable": true },
+				"valid_to": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -857,16 +992,16 @@
 		},
 		"products_attributes": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true},
-				"group_id": {"type":"INT","length":10,"unsigned":true},
-				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"custom_value": {"type":"VARCHAR","length":215,"default":"''"},
-				"priority": {"type":"INT","length":10,"unsigned":true,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true },
+				"group_id": { "type": "INT", "length": 10, "unsigned": true },
+				"value_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"custom_value": { "type": "VARCHAR", "length": 215, "default": "''" },
+				"priority": { "type": "INT", "length": 10, "unsigned": true, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"id": ["id","product_id","group_id","value_id"]
+				"id": ["id", "product_id", "group_id", "value_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
@@ -874,104 +1009,192 @@
 				"value_id": ["value_id"]
 			},
 			"foreign_keys": {
-				"product_attribute_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"product_attribute_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"product_attribute_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"product_attribute_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_attribute_to_attribute_group": {
+					"columns": ["group_id"],
+					"references": {
+						"table": "attribute_groups",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_attribute_to_attribute_value": {
+					"columns": ["value_id"],
+					"references": {
+						"table": "attribute_values",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"products_customizations": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"function": {"type":"VARCHAR","length":32,"default":"''"},
-				"required": {"type":"TINYINT","length":1,"default":0},
-				"sort": {"type":"VARCHAR","length":16,"default":"''"},
-				"priority": {"type":"TINYINT","length":2,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"function": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"required": { "type": "TINYINT", "length": 1, "default": 0 },
+				"sort": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"priority": { "type": "TINYINT", "length": 2, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option": ["product_id","group_id"]
+				"product_option": ["product_id", "group_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
 				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_customization_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"product_customization_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_customization_to_attribute_group": {
+					"columns": ["group_id"],
+					"references": {
+						"table": "attribute_groups",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"products_customizations_values": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"value_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"custom_value": {"type":"VARCHAR","length":64,"default":"''"},
-				"price_modifier": {"type":"CHAR","length":1,"default":"'+'"},
-				"price_adjustment": {"type":"VARCHAR","length":1,"default":"''"},
-				"priority": {"type":"TINYINT","length":2,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"value_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"custom_value": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"price_modifier": { "type": "CHAR", "length": 1, "default": "'+'" },
+				"price_adjustment": { "type": "VARCHAR", "length": 1, "default": "''" },
+				"priority": { "type": "TINYINT", "length": 2, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"product_option_value": ["product_id","group_id","value_id"]
+				"product_option_value": ["product_id", "group_id", "value_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"],
 				"priority": ["priority"]
 			},
 			"foreign_keys": {
-				"product_customization_value_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_customization_value_to_attribute_group": {"columns":["group_id"],"references":{"table":"attribute_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_customization_value_to_attribute_value": {"columns":["value_id"],"references":{"table":"attribute_values","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"product_customization_value_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_customization_value_to_attribute_group": {
+					"columns": ["group_id"],
+					"references": {
+						"table": "attribute_groups",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_customization_value_to_attribute_value": {
+					"columns": ["value_id"],
+					"references": {
+						"table": "attribute_values",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"products_images": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true},
-				"filename": {"type":"VARCHAR","length":255,"default":"''"},
-				"checksum": {"type":"CHAR","length":32,"nullable":true},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true },
+				"filename": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"checksum": { "type": "CHAR", "length": 32, "nullable": true },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_image_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"product_image_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"product_notification_recipients": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"email": {"type":"VARCHAR","length":64,"default":"''"},
-				"language_code": {"type":"CHAR","length":2,"default":"''"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"email": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"language_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"notification_recipient": ["product_id","email"]
+				"notification_recipient": ["product_id", "email"]
 			},
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"notification_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"notification_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"notification_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"notification_to_language": {
+					"columns": ["language_code"],
+					"references": {
+						"table": "languages",
+						"columns": ["code"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"products_prices": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true},
-				"campaign_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"customer_group_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"geo_zone_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"min_quantity": {"type":"DECIMAL","length":"10,4","unsigned":true,"default":1},
-				"price": {"type":"VARCHAR","length":512,"default":"'{}'"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true },
+				"campaign_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"customer_group_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"min_quantity": { "type": "DECIMAL", "length": "10,4", "unsigned": true, "default": 1 },
+				"price": { "type": "VARCHAR", "length": 512, "default": "'{}'" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -982,10 +1205,42 @@
 				"min_quantity": ["min_quantity"]
 			},
 			"foreign_keys": {
-				"product_price_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_price_to_customer_group": {"columns":["customer_group_id"],"references":{"table":"customer_groups","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_price_to_campaign": {"columns":["campaign_id"],"references":{"table":"campaigns","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"product_price_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"product_price_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_price_to_customer_group": {
+					"columns": ["customer_group_id"],
+					"references": {
+						"table": "customer_groups",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_price_to_campaign": {
+					"columns": ["campaign_id"],
+					"references": {
+						"table": "campaigns",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_price_to_geo_zone": {
+					"columns": ["geo_zone_id"],
+					"references": {
+						"table": "geo_zones",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			},
 			"check_constraints": {
 				"products_prices_chk_min_quantity": "min_quantity > 0",
@@ -994,46 +1249,78 @@
 		},
 		"products_stock_options": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true},
-				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
-				"price_modifier": {"type":"ENUM('+','%','*','=')","default":"'+'"},
-				"price_adjustment": {"type":"VARCHAR(512)","default":"'+'"},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true },
+				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
+				"price_modifier": { "type": "ENUM('+','%','*','=')", "default": "'+'" },
+				"price_adjustment": { "type": "VARCHAR(512)", "default": "'+'" },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"stock_option": ["product_id","stock_item_id"]
+				"stock_option": ["product_id", "stock_item_id"]
 			},
 			"keys": {
 				"product_id": ["product_id"]
 			},
 			"foreign_keys": {
-				"product_stock_option_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"product_stock_option_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"product_stock_option_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_stock_option_to_stock_item": {
+					"columns": ["stock_item_id"],
+					"references": {
+						"table": "stock_items",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"products_to_categories": {
 			"columns": {
-				"product_id": {"type":"INT","length":10,"unsigned":true},
-				"category_id": {"type":"INT","length":10,"unsigned":true}
+				"product_id": { "type": "INT", "length": 10, "unsigned": true },
+				"category_id": { "type": "INT", "length": 10, "unsigned": true }
 			},
-			"primary_key": ["product_id","category_id"],
+			"primary_key": ["product_id", "category_id"],
 			"foreign_keys": {
-				"product_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"product_to_category": {"columns":["category_id"],"references":{"table":"categories","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"product_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"product_to_category": {
+					"columns": ["category_id"],
+					"references": {
+						"table": "categories",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"quantity_units": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"name": {"type":"TEXT","nullable":true},
-				"description": {"type":"TEXT","nullable":true},
-				"decimals": {"type":"TINYINT","length":1,"unsigned":true,"default":2},
-				"separate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"name": { "type": "TEXT", "nullable": true },
+				"description": { "type": "TEXT", "nullable": true },
+				"decimals": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 2 },
+				"separate": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"check_constraints": {
@@ -1043,18 +1330,18 @@
 		},
 		"redirects": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"immediate": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"pattern": {"type":"VARCHAR","length":248,"default":"''"},
-				"destination": {"type":"VARCHAR","length":248,"default":"''"},
-				"http_response_code": {"type":"ENUM('301','302')","default":"'301'"},
-				"redirects": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"last_redirected": {"type":"TIMESTAMP","nullable":true},
-				"valid_from": {"type":"TIMESTAMP","nullable":true},
-				"valid_to": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"immediate": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"pattern": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"destination": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"http_response_code": { "type": "ENUM('301','302')", "default": "'301'" },
+				"redirects": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"last_redirected": { "type": "TIMESTAMP", "nullable": true },
+				"valid_from": { "type": "TIMESTAMP", "nullable": true },
+				"valid_to": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1067,25 +1354,25 @@
 		},
 		"sessions": {
 			"columns": {
-				"id": {"type":"VARCHAR","length":128},
-				"customer_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"data": {"type":"TEXT"},
-				"language_code": {"type":"CHAR","length":2,"default":"''"},
-				"country_code": {"type":"CHAR","length":2,"default":"''"},
-				"currency_code": {"type":"CHAR","length":3,"default":"''"},
-				"ip_address": {"type":"VARCHAR","length":45},
-				"ip_country": {"type":"CHAR","length":2,"default":"''"},
-				"fingerprint": {"type":"VARCHAR","length":128},
-				"hostname": {"type":"VARCHAR","length":128},
-				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
-				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
-				"page_views": {"type":"INT","length":11,"default":0},
-				"last_url": {"type":"VARCHAR","length":255,"default":"''"},
-				"last_request": {"type":"VARCHAR","length":255,"default":"''"},
-				"last_active": {"type":"TIMESTAMP","nullable":true},
-				"expires_at": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "VARCHAR", "length": 128 },
+				"customer_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"data": { "type": "TEXT" },
+				"language_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"country_code": { "type": "CHAR", "length": 2, "default": "''" },
+				"currency_code": { "type": "CHAR", "length": 3, "default": "''" },
+				"ip_address": { "type": "VARCHAR", "length": 45 },
+				"ip_country": { "type": "CHAR", "length": 2, "default": "''" },
+				"fingerprint": { "type": "VARCHAR", "length": 128 },
+				"hostname": { "type": "VARCHAR", "length": 128 },
+				"user_agent": { "type": "VARCHAR", "length": 256, "default": "''" },
+				"referrer": { "type": "VARCHAR", "length": 256, "default": "''" },
+				"page_views": { "type": "INT", "length": 11, "default": 0 },
+				"last_url": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"last_request": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"last_active": { "type": "TIMESTAMP", "nullable": true },
+				"expires_at": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1097,24 +1384,48 @@
 				"fingerprint": ["fingerprint"]
 			},
 			"foreign_keys": {
-				"session_to_customer": {"columns":["customer_id"],"references":{"table":"customers","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
-				"session_to_language": {"columns":["language_code"],"references":{"table":"languages","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}},
-				"session_to_currency": {"columns":["currency_code"],"references":{"table":"currencies","columns":["code"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"session_to_customer": {
+					"columns": ["customer_id"],
+					"references": {
+						"table": "customers",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				},
+				"session_to_language": {
+					"columns": ["language_code"],
+					"references": {
+						"table": "languages",
+						"columns": ["code"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				},
+				"session_to_currency": {
+					"columns": ["currency_code"],
+					"references": {
+						"table": "currencies",
+						"columns": ["code"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			}
 		},
 		"settings": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"group_key": {"type":"VARCHAR","length":64,"nullable":true},
-				"key": {"type":"VARCHAR","length":64,"default":"''"},
-				"value": {"type":"VARCHAR","length":2048,"default":"''"},
-				"title": {"type":"VARCHAR","length":128,"default":"''"},
-				"description": {"type":"VARCHAR","length":512,"default":"''"},
-				"required": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"function": {"type":"VARCHAR","length":128,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"group_key": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"key": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"value": { "type": "VARCHAR", "length": 2048, "default": "''" },
+				"title": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"required": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"function": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1126,11 +1437,11 @@
 		},
 		"settings_groups": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"key": {"type":"VARCHAR","length":32},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"VARCHAR","length":255,"default":"''"},
-				"priority": {"type":"INT","length":11,"default":0}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"key": { "type": "VARCHAR", "length": 32 },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"priority": { "type": "INT", "length": 11, "default": 0 }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1139,15 +1450,15 @@
 		},
 		"site_tags": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"default":0},
-				"position": {"type":"ENUM('head','body')","default":"'head'"},
-				"name": {"type":"VARCHAR","length":128,"default":"''"},
-				"content": {"type":"TEXT"},
-				"require_consent": {"type":"VARCHAR","length":64,"nullable":true},
-				"priority": {"type":"TINYINT","length":4,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "default": 0 },
+				"position": { "type": "ENUM('head','body')", "default": "'head'" },
+				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"content": { "type": "TEXT" },
+				"require_consent": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"priority": { "type": "TINYINT", "length": 4, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1158,13 +1469,13 @@
 		},
 		"sold_out_statuses": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"hidden": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"orderable": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"name": {"type":"TEXT","nullable":true},
-				"description": {"type":"TEXT","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"hidden": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"orderable": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"name": { "type": "TEXT", "nullable": true },
+				"description": { "type": "TEXT", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1178,18 +1489,18 @@
 		},
 		"statistics": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"type": {"type":"VARCHAR","length":32,"default":"''"},
-				"entity_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"entity_type": {"type":"VARCHAR","length":32,"nullable":true},
-				"measure_group_type": {"type":"VARCHAR","length":32,"default":"''"},
-				"measure_group_value": {"type":"VARCHAR","length":64,"default":"''"},
-				"count": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"type": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"entity_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"entity_type": { "type": "VARCHAR", "length": 32, "nullable": true },
+				"measure_group_type": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"measure_group_value": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"count": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP"}
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"measure": ["type","entity_id","entity_type","measure_group_type","measure_group_value"]
+				"measure": ["type", "entity_id", "entity_type", "measure_group_type", "measure_group_value"]
 			},
 			"keys": {
 				"entity_id": ["entity_id"],
@@ -1200,35 +1511,35 @@
 		},
 		"stock_items": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"brand_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"supplier_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"name": {"type":"TEXT","nullable":true},
-				"attributes": {"type":"VARCHAR","length":32,"default":"''"},
-				"sku": {"type":"VARCHAR","length":32,"default":"''"},
-				"mpn": {"type":"VARCHAR","length":32,"default":"''"},
-				"gtin": {"type":"VARCHAR","length":32,"default":"''"},
-				"shelf": {"type":"VARCHAR","length":32,"default":"''"},
-				"taric": {"type":"VARCHAR","length":16,"default":"''"},
-				"image": {"type":"VARCHAR","length":512,"default":"''"},
-				"weight": {"type":"DECIMAL","length":"10,4","default":0},
-				"weight_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"length": {"type":"DECIMAL","length":"10,4","default":0},
-				"width": {"type":"DECIMAL","length":"10,4","default":0},
-				"height": {"type":"DECIMAL","length":"10,4","default":0},
-				"length_unit": {"type":"VARCHAR","length":2,"default":"''"},
-				"quantity": {"type":"DECIMAL","length":"10,4","default":0},
-				"quantity_unit_id": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"backordered": {"type":"DECIMAL","length":"10,4","default":0},
-				"purchase_price": {"type":"DECIMAL","length":"10,4","default":0},
-				"purchase_price_currency_code": {"type":"VARCHAR","length":3,"default":"''"},
-				"file": {"type":"VARCHAR","length":248,"nullable":true},
-				"filename": {"type":"VARCHAR","length":64,"nullable":true},
-				"mime_type": {"type":"VARCHAR","length":32,"nullable":true},
-				"downloads": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"priority": {"type":"INT","length":11,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"brand_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"supplier_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"name": { "type": "TEXT", "nullable": true },
+				"attributes": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"sku": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"mpn": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"gtin": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"shelf": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"taric": { "type": "VARCHAR", "length": 16, "default": "''" },
+				"image": { "type": "VARCHAR", "length": 512, "default": "''" },
+				"weight": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"weight_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"length": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"width": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"height": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"length_unit": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"quantity": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"quantity_unit_id": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"backordered": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"purchase_price": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"purchase_price_currency_code": { "type": "VARCHAR", "length": 3, "default": "''" },
+				"file": { "type": "VARCHAR", "length": 248, "nullable": true },
+				"filename": { "type": "VARCHAR", "length": 64, "nullable": true },
+				"mime_type": { "type": "VARCHAR", "length": 32, "nullable": true },
+				"downloads": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"priority": { "type": "INT", "length": 11, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1244,38 +1555,54 @@
 		},
 		"stock_items_references": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"stock_item_id": {"type":"INT","length":10,"unsigned":true},
-				"supplier_id": {"type":"INT","length":10,"unsigned":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true },
+				"supplier_id": { "type": "INT", "length": 10, "unsigned": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''"}
 			},
 			"primary_key": ["id"],
 			"keys": {
 				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"supplier": {"columns":["supplier_id"],"references":{"table":"suppliers","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"stock_item": {
+					"columns": ["stock_item_id"],
+					"references": {
+						"table": "stock_items",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"supplier": {
+					"columns": ["supplier_id"],
+					"references": {
+						"table": "suppliers",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"stock_transactions": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"name": {"type":"VARCHAR","length":128,"default":"''"},
-				"description": {"type":"MEDIUMTEXT"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"name": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"description": { "type": "MEDIUMTEXT" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"]
 		},
 		"stock_transactions_contents": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"transaction_id": {"type":"INT","length":10,"unsigned":true},
-				"product_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"stock_item_id": {"type":"INT","length":10,"unsigned":true,"nullable":true},
-				"quantity_adjustment": {"type":"DECIMAL","length":"10,4","default":0},
-				"sku": {"type":"VARCHAR","length":32}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"transaction_id": { "type": "INT", "length": 10, "unsigned": true },
+				"product_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"stock_item_id": { "type": "INT", "length": 10, "unsigned": true, "nullable": true },
+				"quantity_adjustment": { "type": "DECIMAL", "length": "10,4", "default": 0 },
+				"sku": { "type": "VARCHAR", "length": 32 }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1284,22 +1611,46 @@
 				"stock_item_id": ["stock_item_id"]
 			},
 			"foreign_keys": {
-				"stock_transaction_content_to_transaction": {"columns":["transaction_id"],"references":{"table":"stock_transactions","columns":["id"],"on_update":"CASCADE","on_delete":"CASCADE"}},
-				"stock_transaction_content_to_product": {"columns":["product_id"],"references":{"table":"products","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}},
-				"stock_transaction_content_to_stock_item": {"columns":["stock_item_id"],"references":{"table":"stock_items","columns":["id"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"stock_transaction_content_to_transaction": {
+					"columns": ["transaction_id"],
+					"references": {
+						"table": "stock_transactions",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				},
+				"stock_transaction_content_to_product": {
+					"columns": ["product_id"],
+					"references": {
+						"table": "products",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				},
+				"stock_transaction_content_to_stock_item": {
+					"columns": ["stock_item_id"],
+					"references": {
+						"table": "stock_items",
+						"columns": ["id"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			}
 		},
 		"suppliers": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"code": {"type":"VARCHAR","length":64,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"TEXT"},
-				"email": {"type":"VARCHAR","length":128,"default":"''"},
-				"phone": {"type":"VARCHAR","length":24,"default":"''"},
-				"link": {"type":"VARCHAR","length":255,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"code": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "TEXT" },
+				"email": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"phone": { "type": "VARCHAR", "length": 24, "default": "''" },
+				"link": { "type": "VARCHAR", "length": 255, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1308,31 +1659,31 @@
 		},
 		"tax_classes": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"VARCHAR","length":64,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"]
 		},
 		"tax_rates": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"tax_class_id": {"type":"INT","length":10,"unsigned":true},
-				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
-				"code": {"type":"VARCHAR","length":32,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"VARCHAR","length":128,"default":"''"},
-				"rate": {"type":"DECIMAL","length":"6,4","unsigned":true,"default":0},
-				"address_type": {"type":"ENUM('shipping','payment')","default":"'shipping'"},
-				"rule_companies_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"rule_companies_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"rule_individuals_with_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"rule_individuals_without_tax_id": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"tax_class_id": { "type": "INT", "length": 10, "unsigned": true },
+				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true },
+				"code": { "type": "VARCHAR", "length": 32, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"rate": { "type": "DECIMAL", "length": "6,4", "unsigned": true, "default": 0 },
+				"address_type": { "type": "ENUM('shipping','payment')", "default": "'shipping'" },
+				"rule_companies_with_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"rule_companies_without_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"rule_individuals_with_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"rule_individuals_without_tax_id": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1340,28 +1691,44 @@
 				"geo_zone_id": ["geo_zone_id"]
 			},
 			"foreign_keys": {
-				"tax_rate_to_tax_class": {"columns":["tax_class_id"],"references":{"table":"tax_classes","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"tax_rate_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"RESTRICT"}}
+				"tax_rate_to_tax_class": {
+					"columns": ["tax_class_id"],
+					"references": {
+						"table": "tax_classes",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"tax_rate_to_geo_zone": {
+					"columns": ["geo_zone_id"],
+					"references": {
+						"table": "geo_zones",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "RESTRICT"
+					}
+				}
 			}
 		},
 		"third_parties": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"status": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"privacy_classes": {"type":"VARCHAR","length":64,"default":"''"},
-				"category": {"type":"VARCHAR","length":64,"default":"''"},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"description": {"type":"MEDIUMTEXT","nullable":true},
-				"collected_data": {"type":"TEXT","nullable":true},
-				"purposes": {"type":"TEXT","nullable":true},
-				"homepage": {"type":"VARCHAR","length":248,"default":"''"},
-				"cookie_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
-				"privacy_policy_url": {"type":"VARCHAR","length":248,"default":"''"},
-				"opt_out_url": {"type":"VARCHAR","length":248,"default":"''"},
-				"do_not_sell_url": {"type":"VARCHAR","length":248,"default":"''"},
-				"country_code": {"type":"CHAR","length":2,"nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"current_timestamp()"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"status": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"privacy_classes": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"category": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"description": { "type": "MEDIUMTEXT", "nullable": true },
+				"collected_data": { "type": "TEXT", "nullable": true },
+				"purposes": { "type": "TEXT", "nullable": true },
+				"homepage": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"cookie_policy_url": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"privacy_policy_url": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"opt_out_url": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"do_not_sell_url": { "type": "VARCHAR", "length": 248, "default": "''" },
+				"country_code": { "type": "CHAR", "length": 2, "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "current_timestamp()" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1369,7 +1736,15 @@
 				"country_code": ["country_code"]
 			},
 			"foreign_keys": {
-				"third_party_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"CASCADE","on_delete":"SET NULL"}}
+				"third_party_to_country": {
+					"columns": ["country_code"],
+					"references": {
+						"table": "countries",
+						"columns": ["iso_code_2"],
+						"on_update": "CASCADE",
+						"on_delete": "SET NULL"
+					}
+				}
 			},
 			"check_constraints": {
 				"third_parties_chk_description": "description IS NULL OR description = '' OR JSON_VALID(description)",
@@ -1379,15 +1754,15 @@
 		},
 		"translations": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"code": {"type":"VARCHAR","length":128,"default":"''"},
-				"text_en": {"type":"TEXT"},
-				"html": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"frontend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"backend": {"type":"TINYINT","length":1,"unsigned":true,"default":0},
-				"last_accessed": {"type":"TIMESTAMP","nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"code": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"text_en": { "type": "TEXT" },
+				"html": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"frontend": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"backend": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"last_accessed": { "type": "TIMESTAMP", "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
@@ -1401,19 +1776,19 @@
 		},
 		"visitors": {
 			"columns": {
-				"id": {"type":"BIGINT","length":20,"unsigned":true,"auto_increment":true},
-				"session_id": {"type":"VARCHAR","length":13,"default":"''"},
-				"cart_uid": {"type":"VARCHAR","length":13,"default":"''"},
-				"referrer": {"type":"VARCHAR","length":256,"default":"''"},
-				"ip_address": {"type":"VARCHAR","length":39,"default":"''"},
-				"hostname": {"type":"VARCHAR","length":64,"default":"''"},
-				"user_agent": {"type":"VARCHAR","length":256,"default":"''"},
-				"language": {"type":"VARCHAR","length":2,"default":"''"},
-				"country_code": {"type":"VARCHAR","length":2,"default":"''"},
-				"pageviews": {"type":"INT","length":10,"unsigned":true,"default":0},
-				"last_page": {"type":"VARCHAR","length":128,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "BIGINT", "length": 20, "unsigned": true, "auto_increment": true },
+				"session_id": { "type": "VARCHAR", "length": 13, "default": "''" },
+				"cart_uid": { "type": "VARCHAR", "length": 13, "default": "''" },
+				"referrer": { "type": "VARCHAR", "length": 256, "default": "''" },
+				"ip_address": { "type": "VARCHAR", "length": 39, "default": "''" },
+				"hostname": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"user_agent": { "type": "VARCHAR", "length": 256, "default": "''" },
+				"language": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"country_code": { "type": "VARCHAR", "length": 2, "default": "''" },
+				"pageviews": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
+				"last_page": { "type": "VARCHAR", "length": 128, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1426,12 +1801,12 @@
 		},
 		"zones": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"country_code": {"type":"CHAR","length":2},
-				"code": {"type":"VARCHAR","length":8},
-				"name": {"type":"VARCHAR","length":64,"default":"''"},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"country_code": { "type": "CHAR", "length": 2 },
+				"code": { "type": "VARCHAR", "length": 8 },
+				"name": { "type": "VARCHAR", "length": 64, "default": "''" },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"keys": {
@@ -1439,22 +1814,30 @@
 				"code": ["code"]
 			},
 			"foreign_keys": {
-				"zone_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}}
+				"zone_to_country": {
+					"columns": ["country_code"],
+					"references": {
+						"table": "countries",
+						"columns": ["iso_code_2"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		},
 		"zones_to_geo_zones": {
 			"columns": {
-				"id": {"type":"INT","length":10,"unsigned":true,"auto_increment":true},
-				"geo_zone_id": {"type":"INT","length":10,"unsigned":true},
-				"country_code": {"type":"CHAR","length":2},
-				"zone_code": {"type":"VARCHAR","length":8,"nullable":true},
-				"city": {"type":"VARCHAR","length":32,"nullable":true},
-				"updated_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP","on_update":"CURRENT_TIMESTAMP"},
-				"created_at": {"type":"TIMESTAMP","default":"CURRENT_TIMESTAMP"}
+				"id": { "type": "INT", "length": 10, "unsigned": true, "auto_increment": true },
+				"geo_zone_id": { "type": "INT", "length": 10, "unsigned": true },
+				"country_code": { "type": "CHAR", "length": 2 },
+				"zone_code": { "type": "VARCHAR", "length": 8, "nullable": true },
+				"city": { "type": "VARCHAR", "length": 32, "nullable": true },
+				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
+				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
 			"primary_key": ["id"],
 			"unique_keys": {
-				"region": ["geo_zone_id","country_code","zone_code","city"]
+				"region": ["geo_zone_id", "country_code", "zone_code", "city"]
 			},
 			"keys": {
 				"geo_zone_id": ["geo_zone_id"],
@@ -1463,9 +1846,33 @@
 				"city": ["city"]
 			},
 			"foreign_keys": {
-				"zone_entry_to_geo_zone": {"columns":["geo_zone_id"],"references":{"table":"geo_zones","columns":["id"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"zone_entry_to_country": {"columns":["country_code"],"references":{"table":"countries","columns":["iso_code_2"],"on_update":"NO ACTION","on_delete":"CASCADE"}},
-				"zone_entry_to_zone": {"columns":["zone_code"],"references":{"table":"zones","columns":["code"],"on_update":"CASCADE","on_delete":"CASCADE"}}
+				"zone_entry_to_geo_zone": {
+					"columns": ["geo_zone_id"],
+					"references": {
+						"table": "geo_zones",
+						"columns": ["id"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"zone_entry_to_country": {
+					"columns": ["country_code"],
+					"references": {
+						"table": "countries",
+						"columns": ["iso_code_2"],
+						"on_update": "NO ACTION",
+						"on_delete": "CASCADE"
+					}
+				},
+				"zone_entry_to_zone": {
+					"columns": ["zone_code"],
+					"references": {
+						"table": "zones",
+						"columns": ["code"],
+						"on_update": "CASCADE",
+						"on_delete": "CASCADE"
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Following up on the discussion in #440 — this moves category discounts into the campaign system, exactly as you suggested. Same mechanism works for brands too.

## Summary

Extends the existing campaign system with a **percentage discount mode** that targets entire categories and/or brands. Existing fixed-price campaigns are completely untouched.

| What | Details |
|------|---------|
| **New column on campaigns** | `discount_mode` (fixed/percentage), `discount_percent` (0-100%) |
| **New table** | `campaigns_scopes` — links campaign to category IDs and/or brand IDs |
| **Admin UI** | Mode toggle on campaign edit: "Fixed Prices" (existing) or "Percentage Discount" (new with category/brand pickers) |
| **Campaign list** | Shows type column ("-20%" or "Fixed Prices") and affected product count |
| **Price pipeline** | Scope percentage applied after regular/campaign-fixed/customer-group pricing. Lowest resulting price wins when both fixed and percentage campaigns apply |
| **Frontend** | "-X%" badge on category and product pages. Strikethrough price via existing draw_price_tag |
| **Migration** | ALTER TABLE + CREATE TABLE (idempotent) |

### How it works

A merchant creates a campaign, selects "Percentage Discount" mode, sets 20%, picks one or more categories and/or brands. All products in those categories or brands automatically get the discount — no need to add products individually. The campaign's existing date range and status controls apply.

### Files changed (9)

| Layer | File | Change |
|-------|------|--------|
| Schema | `structure.json` | 2 new columns on campaigns, new campaigns_scopes table |
| Migration | `migrations/3.0.0.inc.php` | ALTER + CREATE (idempotent) |
| Entity | `ent_campaign.inc.php` | Load/save scopes, discount_mode, discount_percent |
| Reference | `ref_product.inc.php` | Scope discount in campaign property + final_price pipeline |
| Catalog | `func_catalog.inc.php` | UNION-based scope discount JOIN in bulk query |
| Sticker | `func_draw.inc.php` | "-X%" badge for scope campaigns |
| Product page | `frontend/pages/product.inc.php` | Scope sticker on product detail |
| Admin edit | `edit_campaign.inc.php` | Mode toggle, percent field, category/brand pickers |
| Admin list | `campaigns.inc.php` | Type column, scope product count |

### Relationship to #440

This replaces the approach in #440 (discount columns on categories table). The campaign-based approach is cleaner because:
- Categories and brands use the same mechanism
- Campaigns already have date ranges, status, customer groups
- Price management stays centralized in one place

#440 can be closed once this is merged.

## Test plan

- [ ] Create a percentage campaign targeting a category — products show "-X%" badge and discounted price
- [ ] Create a percentage campaign targeting a brand — same behavior
- [ ] Combine category + brand in one campaign — union of both scopes
- [ ] Existing fixed-price campaigns still work unchanged
- [ ] Campaign list shows type and affected product count
- [ ] Expired/disabled campaign — no discount applied
- [ ] Product in multiple scope campaigns — highest percentage wins
- [ ] Product with both fixed campaign price and scope percentage — lower price wins
- [ ] Mode toggle in admin switches between product table and scope pickers