### PR TITLE
[v3] * Update STANDARD.md and CONTRIBUTING.md for v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Github Repository: https://www.github.com/litecart/litecart
 Repository URL: https://www.github.com/litecart/litecart.git
-Branch Name: `dev`
+Branch Name: `dev-major`
 
 
 # Changelog / Commit Messages
@@ -30,8 +30,7 @@ Branch Name: `dev`
 
 # How To Install and Run the Build Tools
 
-This project is preconfigured with Grunt for Node.js. Grunt can be used for compiling LESS to CSS along with some other useful tools.
-To install Grunt do the following:
+This project uses Gulp 5 (ESM) for building assets. Requires Node.js 24+.
 
 1. Install Node.js from https://nodejs.org/
 
@@ -47,18 +46,60 @@ npm install
 
 Done!
 
-Node.js should now have installed all necessary libraries.
-
 You can now execute any of the following commands:
 
-    npm run grunt         (Launches all grunt tasks)
-    npm run less          (Compile and minify .min.css from .less)
-    npm run uglify        (Uglify and minify .min.js from .js)
-    npm run replace       (Update version number in scripts from package.js)
-    npm run phplint       (Check PHP scripts for syntax errors)
-    npm run watch         (Watch for changes in .less and .js and update minified versions on the fly)
+    npm run build         (Compile LESS/SCSS to CSS, minify JS — includes watch)
+    npm run watch         (Watch for changes in LESS/JS/SCSS and recompile)
+    npm run phplint       (Check PHP scripts for syntax errors via Gulp)
+    npm test              (Run platform tests — requires a running database)
     npm run hash          (Update checksums.md5 for all tracked files)
-    npm update            (Update your node modules to newer versions)
+    npm run uglify        (Minify JavaScript and update version numbers)
+
+
+# Database Schema
+
+The database schema is defined in `install/structure.json`. This file is the single source of truth — the upgrade script automatically patches the database with any missing tables, columns, and indexes from this file.
+
+**Migrations** (`install/migrations/*.inc.php`) are only needed for operations the auto-patcher cannot handle:
+- Renaming columns or tables
+- Moving data between columns
+- Data transformations
+
+When adding new columns or tables, only update `structure.json`. No migration needed.
+
+**Important:** Keep the existing formatting in `structure.json` — use spaces after `:` and `,` in JSON column definitions (e.g. `{ "type": "INT", "length": 10 }`). Do not run JSON formatters or prettifiers on the file.
+
+
+# JSON File Formatting
+
+Do not use automated JSON formatters (Prettier, VS Code format-on-save, etc.) on JSON files in this project. The existing formatting is intentional for human readability.
+
+For `structure.json`, column definitions use compact single-line objects with spaces:
+
+    "column_name": { "type": "VARCHAR", "length": 128, "default": "''" },
+
+Do NOT expand these into multi-line format:
+
+    "column_name": {
+        "type": "VARCHAR",
+        "length": 128,
+        "default": "''"
+    },
+
+When editing JSON files, make targeted changes and preserve the surrounding format.
+
+
+# CSS and Frontend Assets
+
+Storefront styles are compiled from LESS source files:
+
+    frontend/templates/default/less/variables.less   (CSS custom properties — theme tokens)
+    frontend/templates/default/less/app.less          (main storefront styles)
+    frontend/templates/default/less/checkout.less     (checkout-specific styles)
+
+All color values must use CSS custom properties defined in `variables.less`. Do not hardcode hex/rgb values in component LESS files.
+
+**Important:** Compiled CSS files must be committed alongside LESS source changes. Run `npm run build` before committing.
 
 
 # How To Make a Git Pull Request
@@ -67,14 +108,16 @@ If you are new to Git, we recommend SourceTree or GitHub Desktop as a great grap
 
 1. Fork the official LiteCart repository by going to https://github.com/litecart/litecart and clicking **Fork**.
 
-2. Initiate a copy of the code from your forked repository. Use the `dev` branch as source.
+2. Initiate a copy of the code from your forked repository. Use the `dev-major` branch as source.
 
 ```bash
 # Clone the repo
-git clone dev https://github.com/you/litecart.git
+git clone https://github.com/you/litecart.git
+cd litecart
+git checkout dev-major
 ```
 
-2. Add the official repository as second source, and let's call it `upstream`.
+3. Add the official repository as second source, and let's call it `upstream`.
 
 ```bash
 # Add official repo
@@ -84,32 +127,28 @@ git remote add upstream https://github.com/litecart/litecart.git
 git fetch upstream
 ```
 
-3. Create a new local branch for your new feature or modification, based on the state of the `dev` branch of the official repository (upstream).
+4. Create a new local branch for your new feature or modification, based on the state of the `dev-major` branch of the official repository (upstream).
 
 ```bash
-git checkout -b mynewfeature upstream/dev
+git checkout -b mynewfeature upstream/dev-major
 ```
 
-4. Commit your changes and push the new branch to your forked repository.
+5. Commit your changes and push the new branch to your forked repository.
 
 ```bash
-# Cherry pick a commit made in another branch...
-git cherry-pick <commit-hash>
-
-# ... or stage new files for commit
+# Stage files for commit
 git add path/to/file.ext
-git add path/to/file2.ext
 
 # Commit your new feature locally
-git commit -m "Commit message of new feature, used for changelog"
+git commit -m "+ Commit message of new feature, used for changelog"
 
 # Push commit to your Github repository
 git push -u origin mynewfeature
 ```
 
-5. Go to your forked repository in Github and click **Pull Requests** followed by the button **New Pull Request**.
+6. Go to your forked repository in Github and click **Pull Requests** followed by the button **New Pull Request**.
 
-  * Base Repository: `litecart/litecart`, Compare: `dev`
+  * Base Repository: `litecart/litecart`, Compare: `dev-major`
 
   * Head Repository: `you/litecart`, Compare: `mynewfeature`
 

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -2,11 +2,11 @@
 
 ## Code Compliance
 
- - PHP code must comply with modern PHP standards no earlier than 5.6+.
+ - PHP code must comply with modern PHP standards no earlier than 8.0+ (recommended 8.3+).
 
- - HTML code must comply with HTML 5.
+ - HTML code must comply with HTML 5. Self-closing tags required (`<br />`, `<img ... />`).
 
- - Style definitions must be compliant with CSS 3.
+ - Style definitions must be compliant with CSS 3. All color values must use CSS custom properties defined in `variables.less`.
 
  - Any use of JavaScript should honour the jQuery framework.
 
@@ -560,3 +560,61 @@
 		);
 
 		echo '<input value="<?php echo htmlspecialchars($_POST['variable']); ?>">
+
+
+## Autoloader Conventions
+
+	Class prefixes determine the autoloader directory:
+
+		nod_*    nodes/        Static singletons (core services)
+		ent_*    entities/     Data objects (product, order, customer, etc.)
+		ref_*    references/   Read-only factory models with lazy properties
+		abs_*    abstracts/    Base classes
+		cm_*     modules/customer/    Customer modules
+		om_*     modules/order/       Order modules
+		ot_*     modules/order_total/ Order total modules
+		pm_*     modules/payment/     Payment modules
+		sm_*     modules/shipping/    Shipping modules
+		job_*    modules/jobs/        Background job modules
+		mod_*    modules/             Generic modules
+		url_*    routes/              Route handlers
+		wrap_*   wrappers/            Service layers / API clients
+
+	All autoloaded files use `.inc.php` extension and pass through the vMod system.
+
+
+## Stream Wrappers
+
+	Use stream wrappers for file paths within the application:
+
+		app://       Application files (templates, includes, assets)
+		storage://   User storage (images, config, cache)
+
+	Incorrect:
+
+		include FS_DIR_APP . 'includes/templates/default/layouts/default.inc.php';
+
+	Correct:
+
+		include 'app://frontend/templates/default/layouts/default.inc.php';
+
+
+## CSS Custom Properties
+
+	All color values in storefront LESS files must use CSS custom properties defined in `variables.less`.
+
+	Incorrect:
+
+		.element {
+			color: #cc0000;
+			background: rgba(0, 0, 0, 0.5);
+		}
+
+	Correct:
+
+		.element {
+			color: var(--color-sale-price);
+			background: var(--overlay-dark);
+		}
+
+	Exceptions: `transparent`, `inherit`, `currentColor`.


### PR DESCRIPTION
Imagine a new contributor reading CONTRIBUTING.md and setting up Grunt on Node 12. Figured we should save them the confusion.

## CONTRIBUTING.md

| Updated | From | To |
|---------|------|----|
| Branch | `dev` | `dev-major` |
| Build tools | Grunt | Gulp 5 (Node 24+) |
| npm scripts | `npm run grunt`, `npm run less` | `npm run build`, `npm run watch` |
| PR base branch | `dev` | `dev-major` |

New sections:
- **Database Schema** — explains the auto-patcher and when migrations are needed
- **CSS and Frontend Assets** — CSS custom properties requirement, compiled CSS must be committed
- **JSON File Formatting** — don't run formatters on structure.json (lesson learned)

## STANDARD.md

| Updated | From | To |
|---------|------|----|
| PHP version | 5.6+ | 8.0+ (recommended 8.3+) |

New sections:
- **Autoloader Conventions** — `nod_*`, `ent_*`, `ref_*` prefix → directory mapping
- **Stream Wrappers** — `app://` and `storage://` usage
- **CSS Custom Properties** — all colors via `var(--token)`, no hardcoded values

## Test plan

- [ ] Verify npm scripts match `package.json`
- [ ] Verify branch name matches current workflow
- [ ] Verify autoloader prefixes match codebase conventions