### PR TITLE
[v3] * Fix console errors on fresh install (fixes #448)

### DIFF
--- a/public_html/frontend/pages/ajax/keep_alive.inc.php
+++ b/public_html/frontend/pages/ajax/keep_alive.inc.php
@@ -1,0 +1,9 @@
+<?php
+
+  header('X-Robots-Tag: noindex');
+  header('Content-Type: application/json; charset=UTF-8');
+  header('Cache-Control: no-store');
+
+  echo json_encode(['status' => 'ok']);
+
+  exit;

--- a/public_html/frontend/templates/default/partials/site_privacy_consent.inc.php
+++ b/public_html/frontend/templates/default/partials/site_privacy_consent.inc.php
@@ -76,11 +76,13 @@
 </div>
 
 <script>
-	try {
-		const privacy_classes = <?php echo f::format_json($privacy_classes, ''); ?>;
-		const consents = <?php echo f::format_json($consents, ''); ?>;
-		$('#site-privacy-consent').privacyConsent(privacy_classes, consents);
-	} catch (e) {
-		console.error('Could not initiate privacy consent manager:' + e.message);
-	};
+	waitFor('jQuery', function($) {
+		try {
+			var privacy_classes = <?php echo f::format_json($privacy_classes, ''); ?>;
+			var consents = <?php echo f::format_json($consents, ''); ?>;
+			$('#site-privacy-consent').privacyConsent(privacy_classes, consents);
+		} catch (e) {
+			console.error('Could not initiate privacy consent manager: ' + e.message);
+		}
+	});
 </script>


### PR DESCRIPTION
Fresh install, open console, two red lines staring back at you. Not the best first impression.

## Fixes

| Error | Cause | Fix |
|-------|-------|-----|
| `privacyConsent is not a function` | Inline script in `site_privacy_consent.inc.php` runs before `app.js` is loaded (script order in `default.inc.php`) | Wrap in `waitFor('jQuery')` — same pattern used everywhere else |
| `GET /ajax/keep_alive 404` | LiteCore's `base.js` calls this endpoint every 60s but the route doesn't exist | Add `frontend/pages/ajax/keep_alive.inc.php` — simple JSON response to keep the session alive |

## Test plan

- [ ] Fresh install with demo data — no console errors on homepage
- [ ] Privacy consent banner initializes correctly
- [ ] Network tab shows `/ajax/keep_alive` returning 200 with `{"status":"ok"}`
- [ ] Session stays alive after 60+ seconds of inactivity