### PR TITLE
[v2] * Update SECURITY.md, STANDARD.md, and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,10 +71,12 @@ If you are new to Git, we recommend SourceTree or GitHub Desktop as a great grap
 
 ```bash
 # Clone the repo
-git clone dev https://github.com/you/litecart.git
+git clone https://github.com/you/litecart.git
+cd litecart
+git checkout dev
 ```
 
-2. Add the official repository as second source, and let's call it `upstream`.
+3. Add the official repository as second source, and let's call it `upstream`.
 
 ```bash
 # Add official repo
@@ -84,30 +86,26 @@ git remote add upstream https://github.com/litecart/litecart.git
 git fetch upstream
 ```
 
-3. Create a new local branch for your new feature or modification, based on the state of the `dev` branch of the official repository (upstream).
+4. Create a new local branch for your new feature or modification, based on the state of the `dev` branch of the official repository (upstream).
 
 ```bash
 git checkout -b mynewfeature upstream/dev
 ```
 
-4. Commit your changes and push the new branch to your forked repository.
+5. Commit your changes and push the new branch to your forked repository.
 
 ```bash
-# Cherry pick a commit made in another branch...
-git cherry-pick <commit-hash>
-
-# ... or stage new files for commit
+# Stage files for commit
 git add path/to/file.ext
-git add path/to/file2.ext
 
 # Commit your new feature locally
-git commit -m "Commit message of new feature, used for changelog"
+git commit -m "+ Commit message of new feature, used for changelog"
 
 # Push commit to your Github repository
 git push -u origin mynewfeature
 ```
 
-5. Go to your forked repository in Github and click **Pull Requests** followed by the button **New Pull Request**.
+6. Go to your forked repository in Github and click **Pull Requests** followed by the button **New Pull Request**.
 
   * Base Repository: `litecart/litecart`, Compare: `dev`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-## Have found a vulnerability?
+## Found a vulnerability?
 
 Reports of vulnerabilities, security threats, or suspicion of breaches can be sent to security@litecart.net.
 
@@ -8,8 +8,9 @@ Do not register a public CVE record until security fixes are released.
 
 ## PGP Public Key
 
-```
+```pgp
 -----BEGIN PGP PUBLIC KEY BLOCK-----
+
 xsBNBGKokEoBCADbGIJthkW5k31YDSjEPMub2NncCEGvqLhRDhvnCvm0tW3P1igJ
 OHiLXAsYmGd+8+9FpkDN3IbX0gkn9wdkiGjUe7qk4HwQ9LZ/+Do0tgfbliru9kw4
 OaSmWUYHe5haQfaGwKv2pjxQcCP/kSZIZhpZJw+znVKwPIrQkC5Ln3ULcKo43WYF

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -77,7 +77,7 @@
 
   Correct:
 
-    echo '<p>Hello World!</br />' . PHP_EOL
+    echo '<p>Hello World!<br />' . PHP_EOL
        . 'This is a new row</p>';
 
   For emails and HTTP headers we always use Windows style Carriage Return + Line Feed (CRLF) \r\n
@@ -273,6 +273,28 @@
   Correct:
 
     $_POST['name'] = strtolower(trim($_POST['name']));  // We most likely will not ever use the unsanitized data
+
+
+## Avoid One-Time Variables
+
+  Creating variables for one-time use should be avoided (unless it serves good purpose).
+
+  Incorrect:
+
+    $array = ['foo', 'bar'];
+
+    foreach ($array as $item) {
+      echo $item;
+    }
+
+  Correct:
+
+    foreach ([
+      'foo',
+      'bar',
+    ] as $item) {
+      echo $item;
+    }
 
 
 ## Naming of CSS IDs and Classes
@@ -514,7 +536,7 @@
       limit 1;"
     );
 
-    echo '<input value="<?php echo htmlspecialchars($_POST['variable']); ?>" />
+    echo '<input value="' . htmlspecialchars($_POST['variable']) . '" />'
 
 
 ## No Sloppy HTML
@@ -530,3 +552,26 @@
 
         <img src="" />
         <br />
+
+
+## Autoloader Conventions
+
+  Class prefixes determine the autoloader directory:
+
+    abs_*    abstracts/           Base classes
+    ent_*    entities/            Data objects (product, order, customer, etc.)
+    ref_*    references/          Read-only factory models
+    cm_*     modules/customer/    Customer modules
+    om_*     modules/order/       Order modules
+    ot_*     modules/order_total/ Order total modules
+    pm_*     modules/payment/     Payment modules
+    sm_*     modules/shipping/    Shipping modules
+    job_*    modules/jobs/        Background job modules
+    mod_*    modules/             Generic modules
+    url_*    routes/              Route handlers
+    wrap_*   wrappers/            Service layers / API clients
+
+  Bare class names (no prefix) resolve to `library/lib_{class}.inc.php` and auto-call
+  `{class}::init()` if it exists. This is how `database`, `session`, `settings`, etc. are loaded.
+
+  All autoloaded files use `.inc.php` extension and pass through the vMod system.


### PR DESCRIPTION
While v3 got its docs polished in #447, v2 was sitting there with a broken `</br />` and a git clone command that never worked. Time to fix that.

## Summary

| File | Changes |
|------|---------|
| **SECURITY.md** | Fix heading grammar, add `pgp` code fence hint, add blank line after PGP header (required for valid block parsing) |
| **STANDARD.md** | Fix `</br />` typo, fix broken `htmlspecialchars` example, add "Avoid One-Time Variables" section, add "Autoloader Conventions" reference |
| **CONTRIBUTING.md** | Fix `git clone dev` syntax, fix step numbering (duplicate "2."), remove cherry-pick example, add commit prefix `+` |

## Test plan

- [ ] PGP key block renders correctly on GitHub
- [ ] Autoloader table matches v2 `autoloader.inc.php`
- [ ] CONTRIBUTING.md git workflow steps work for `dev` branch