### PR TITLE
[v3] * Use JSON encoding in console_dump()

### DIFF
--- a/public_html/includes/functions.inc.php
+++ b/public_html/includes/functions.inc.php
@@ -3,9 +3,9 @@
 	// Output any variable to the browser console
 	function console_dump(...$vars) { // ... as of PHP 5.6
 
-		$output = var_export($vars, true);
-
-		echo '<script>console.log("'. addcslashes($output, "\"\r\n") .'");</script>';
+		foreach ($vars as $var) {
+			echo '<script>console.log('. json_encode($var, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) .');</script>';
+		}
 	}
 
 	// Return the first non-nil variable


### PR DESCRIPTION
Follow-up to #452 — as suggested, this switches console_dump() from var_export to JSON encoding, so the browser console can natively decode and display interactive, navigable objects instead of a plain text dump.

## Summary
- Replace `var_export()` with `json_encode()` in `console_dump()`
- Each variable gets its own `console.log()` call for cleaner output
- Browser devtools now show clickable, expandable objects and arrays

## Test plan
- [ ] Call `console_dump(['foo' => 'bar'], 42, true)` and verify three interactive entries in the browser console
- [ ] Verify nested arrays/objects are expandable in devtools