### PR TITLE
[v3] * Security hardening: 5 remaining quick fixes from old days

### DIFF
--- a/public_html/backend/pages/verify.inc.php
+++ b/public_html/backend/pages/verify.inc.php
@@ -79,8 +79,11 @@
 
 			notices::add('errors', $e->getMessage());
 
-			if (++session::$data['security_verification']['attempts'] >= 5 || time() > session::$data['security_verification']['expires']) {
-				$send_verification_code();
+			if (++session::$data['security_verification']['attempts'] >= 5) {
+				unset(session::$data['security_verification']);
+				notices::add('errors', t('error_too_many_attempts', 'Too many failed attempts. Please sign in again.'));
+				redirect(document::ilink('login'));
+				exit;
 			}
 		}
 	}

--- a/public_html/frontend/pages/account/sign_in.inc.php
+++ b/public_html/frontend/pages/account/sign_in.inc.php
@@ -48,11 +48,13 @@
 			});
 
 			if (!$customer) {
-				throw new Exception(t('error_email_not_found_in_database', 'The email does not exist in our database'));
+			// Dummy password_verify to prevent timing-based user enumeration
+				password_verify($_POST['password'], '$2y$10$abcdefghijklmnopqrstuuABCDEFGHIJKLMNOPQRSTUVWXYZ01234');
+				throw new Exception(t('error_wrong_email_password_combination', 'Wrong combination of email and password or the account does not exist'));
 			}
 
 			if (!$customer['status']) {
-				throw new Exception(t('error_customer_account_disabled_or_not_activated', 'The customer account is disabled or not activated'));
+				throw new Exception(t('error_wrong_email_password_combination', 'Wrong combination of email and password or the account does not exist'));
 			}
 
 			if ($customer['blocked_until'] && strtotime($customer['blocked_until']) > time()) {

--- a/public_html/includes/clients/http_client.inc.php
+++ b/public_html/includes/clients/http_client.inc.php
@@ -177,10 +177,13 @@
 				'bytes' => strlen($response_headers . "\r\n" . $response_body),
 			];
 
+			// Redact sensitive headers before logging
+			$redacted_request_headers = preg_replace('#^(Authorization:\s*).*$#mi', '$1[REDACTED]', $this->last_request['headers']);
+
 			file_put_contents(f::file_realpath('storage://logs/http_request_last-'. $parts['host'] .'.log'), implode("\r\n", [
 				'##'. str_pad(' ['. date('Y-m-d H:i:s', $this->last_request['timestamp']) .'] Request ', 70, '#', STR_PAD_RIGHT),
 				'',
-				$this->last_request['headers'],
+				$redacted_request_headers,
 				$this->last_request['body'],
 				'',
 				'##'. str_pad(' ['. date('Y-m-d H:i:s', $this->last_response['timestamp']) .'] Response — '. $this->last_response['bytes'] .' bytes transferred in '. $this->last_response['duration'] .' s ', 72, '#', STR_PAD_RIGHT),

--- a/public_html/includes/functions/func_password.inc.php
+++ b/public_html/includes/functions/func_password.inc.php
@@ -45,6 +45,8 @@
 
 	function password_check_strength($password) {
 
+		if (strlen($password) < 12) return false;
+
 		preg_replace('#[a-z]#', '', $password, -1, $lowercases);
 		preg_replace('#[A-Z]#', '', $password, -1, $uppercases);
 		preg_replace('#\d#', '', $password, -1, $numbers);

--- a/public_html/install/index.php
+++ b/public_html/install/index.php
@@ -8,6 +8,13 @@
 
 	define('VMOD_DISABLED', 'true');
 
+	// Block access if installation is already completed
+	if (is_file(FS_DIR_STORAGE . 'install.lock')) {
+		http_response_code(403);
+		echo 'Installation already completed. Remove storage/install.lock to reinstall.';
+		exit;
+	}
+
 	require_once FS_DIR_APP . 'includes/autoloader.inc.php';
 	require_once FS_DIR_APP . 'includes/error_handler.inc.php';
 	require_once FS_DIR_APP . 'includes/functions.inc.php';

--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -895,9 +895,12 @@
 
 		### #############################################################
 
+		// Write lock file to prevent re-installation
+		file_put_contents(FS_DIR_STORAGE . 'install.lock', date('Y-m-d H:i:s'));
+
 		echo implode(PHP_EOL, [
 			'<h2>Complete</h2>',
-			'<p>Installation complete! Please delete the <strong>~/install/</strong> folder.</p>',
+			'<p>Installation complete!</p>',
 			'<p>You may now log in to the <a href="../'. BACKEND_ALIAS .'/">backend</a> and start configuring your store.</p>',
 			'<p>Check out the <a href="https://wiki.litecart.net/" target="_blank">LiteCart Wiki</a> website for some great tips. Turn to our <a href="https://www.litecart.net/forums/" target="_blank">Community Forums</a> if you have questions.</p>',
 		]);


### PR DESCRIPTION
Wrapping up the last 5 items from the security audit — the easy wins are done, these are the stragglers.

## Summary

| Fix | File | Change |
|-----|------|--------|
| B3 | `http_client.inc.php` | Redact `Authorization` header before writing to log files |
| C1 | `verify.inc.php` | Invalidate session after 5 failed 2FA attempts instead of sending a new code (also hardens TOTP add-ons that reuse verify.inc.php) |
| C2 | `sign_in.inc.php` | Unified error message for unknown email and wrong password, plus dummy `password_verify()` to prevent timing-based user enumeration |
| C3 | `func_password.inc.php` | Enforce minimum password length of 12 characters in `password_check_strength()` |
| D2 | `install/index.php` + `install.php` | Write `storage/install.lock` after successful installation, block `/install/` access when lock exists |

## Notes on C1 (2FA brute-force)
The previous behavior sent a new verification code after 5 failed attempts, giving attackers unlimited rounds. The new behavior invalidates the session entirely and forces a fresh login. This also benefits TOTP-based 2FA add-ons that hook into `verify.inc.php` — they inherit the same brute-force protection.

## Test plan
- [ ] B3: Make an HTTP request via `http_client`, check log file — Authorization header shows `[REDACTED]`
- [ ] C1: Enter wrong 2FA code 5 times — session is invalidated, redirected to login
- [ ] C2: Try login with non-existent email — same error message as wrong password
- [ ] C3: Try setting a password shorter than 12 characters — rejected by `password_check_strength()`
- [ ] D2: Complete installation — `storage/install.lock` exists, `/install/` returns 403