### PR TITLE
Fix CLI installer undefined client_ip warning (#465)

### DIFF
--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -163,6 +163,9 @@
 			$_REQUEST['password'] = '';
 		}
 
+		if (empty($_REQUEST['client_ip'])) {
+			$_REQUEST['client_ip'] = !empty($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '127.0.0.1';
+		}
 
 		if (empty($_REQUEST['timezone']) && !empty($_REQUEST['store_time_zone'])) {
 			$_REQUEST['timezone'] = $_REQUEST['store_time_zone']; // Backwards compatible


### PR DESCRIPTION
The v2 sibling of this just landed in #466 — this is the v3 counterpart, much smaller since the path issues were already fixed here.

## What's broken

`$_REQUEST['client_ip']` is used at line 456 but never set in CLI mode. The `getopt()` options don't include it, and there's no fallback. Results in an `Undefined array key` warning under `display_errors=On`.

## What this PR does

Adds a universal fallback in the defaults section (after `password`, before `timezone`):

| Scenario | Value |
|----------|-------|
| Web installer | Hidden field from `$_SERVER['REMOTE_ADDR']` — unchanged |
| CLI mode | `$_SERVER['REMOTE_ADDR']` which is already set to `127.0.0.1` at line 10 |
| Edge case (no REMOTE_ADDR) | Hardcoded `127.0.0.1` |

The value only controls which IPs get `display_errors` in the generated config — not security-critical.

## Test plan

- [x] `php -l` syntax check passes
- [x] Fallback placement matches v2 pattern and existing defaults style
- [x] Web installer hidden field still takes priority (non-empty skips fallback)
- [ ] Full CLI install on a clean DB