### PR TITLE
Fix compact_category_tree selectors missing .card-body (#362)

### DIFF
--- a/public_html/includes/templates/default.catalog/views/box_category_tree.inc.php
+++ b/public_html/includes/templates/default.catalog/views/box_category_tree.inc.php
@@ -18,10 +18,10 @@
 
 <?php if (!empty(document::$settings['compact_category_tree'])) { ?>
 <style>
-  #box-category-tree > ul.compact > li:not(.opened) {
+  #box-category-tree > .card-body > ul.compact > li:not(.opened) {
     display: none;
   }
-  #box-category-tree > ul.compact > li.toggle {
+  #box-category-tree > .card-body > ul.compact > li.toggle {
     display: block !important;
   }
 </style>
@@ -41,16 +41,16 @@
 
 <?php if (!empty(document::$settings['compact_category_tree'])) { ?>
 <script>
-  $('#box-category-tree > ul.compact').prepend(
+  $('#box-category-tree > .card-body > ul.compact').prepend(
     '<li class="toggle"><a href="#" data-toggle="showall"><?php echo functions::draw_fonticon(((language::$selected['direction'] == 'rtl') ? 'fa-angle-right' : 'fa-angle-left') .' fa-fw'); ?> <?php echo language::translate('title_show_all', 'Show All'); ?></a></li>'
   );
 
-  $('#box-category-tree > ul.compact').on('click', 'a[data-toggle="showall"]', function(e){
+  $('#box-category-tree > .card-body > ul.compact').on('click', 'a[data-toggle="showall"]', function(e){
     e.preventDefault();
     $(this).parent().slideUp(function(){
       $(this).remove();
     });
-    $('#box-category-tree > ul > li:hidden').slideDown();
+    $('#box-category-tree > .card-body > ul > li:hidden').slideDown();
   });
 </script>
 <?php } ?>


### PR DESCRIPTION
The `compact_category_tree` setting has been quietly broken since the template got its `.card-body` wrapper — CSS and JS selectors target `#box-category-tree > ul.compact` but the actual DOM is `#box-category-tree > .card-body > ul.compact`.

## The fix

Added the missing `.card-body` level to all 5 selectors (2 CSS, 3 JS):

| Before | After |
|--------|-------|
| `#box-category-tree > ul.compact` | `#box-category-tree > .card-body > ul.compact` |
| `#box-category-tree > ul > li:hidden` | `#box-category-tree > .card-body > ul > li:hidden` |

One file, 5 lines changed. The fix is minimal — alternatively this feature could be removed entirely since it was already dropped in 3.0, but that's a bigger change. Up to you.

## Test plan

- [x] `phplint` passes
- [x] CSS selectors match actual DOM structure
- [x] JS selectors match actual DOM structure
- [ ] Visual test: enable `compact_category_tree` in template settings, navigate category tree