### PR TITLE
[v3] Fix undefined paths variable in phplint gulp task

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -161,7 +161,7 @@ gulp.task('scss-trumbowyg', function() {
 // Lint PHP files
 gulp.task('phplint', function() {
 	return gulp
-		.src(paths.php)
+		.src('public_html/**/*.php')
 		.pipe(phplint())
 		.pipe(phplint.reporter('fail'));
 });


### PR DESCRIPTION
Quick one — `npm run phplint` has been broken since the Gulp migration. The `phplint` task references `paths.php` which was never defined, so it crashes with a `ReferenceError`.

| Before | After |
|--------|-------|
| `paths.php` (undefined) | `'public_html/**/*.php'` (inline glob) |

CI was unaffected since it runs `php -l` directly, so this went unnoticed.

## Test plan
- [x] `npm run phplint` completes without errors
- [x] Verify glob catches all relevant PHP files