### PR TITLE
[v3] Add backend search filters and E2E test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,8 +402,20 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('package.json') }}
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Run E2E tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         run: npm install --no-audit --no-fund
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -421,7 +421,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,3 +276,142 @@ jobs:
       - name: Run platform tests
         continue-on-error: true
         run: php .git-hooks/pre-commit.d/platform_tests.php
+
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: [lint, build]
+
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: litecart_root
+          MARIADB_DATABASE: litecart
+          MARIADB_USER: litecart
+          MARIADB_PASSWORD: litecart
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mysqli, gd, intl, mbstring, zip, xml, curl, simplexml, apcu
+          ini-values: date.timezone=Europe/London, apc.enable_cli=1
+          tools: none
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Create storage directories
+        run: |
+          mkdir -p public_html/storage/{cache,data,logs}
+          mkdir -p public_html/storage/images/products
+          mkdir -p public_html/storage/vmods/.cache
+
+      - name: Generate config file
+        run: |
+          sed \
+            -e 's|{STORAGE_FOLDER}|storage|g' \
+            -e 's|{ADMIN_FOLDER}|admin|g' \
+            -e 's|{DB_SERVER}|127.0.0.1|g' \
+            -e 's|{DB_USERNAME}|litecart|g' \
+            -e 's|{DB_PASSWORD}|litecart|g' \
+            -e 's|{DB_DATABASE}|litecart|g' \
+            -e 's|{DB_TABLE_PREFIX}|lc_|g' \
+            -e 's|{CLIENT_IP}|127.0.0.1|g' \
+            -e 's|{TIMEZONE}|Europe/London|g' \
+            public_html/install/config > public_html/storage/config.inc.php
+          echo "Config file generated"
+
+      - name: Import database schema and seed data
+        run: |
+          php -r "
+            define('DB_SERVER', '127.0.0.1');
+            define('DB_USERNAME', 'litecart');
+            define('DB_PASSWORD', 'litecart');
+            define('DB_DATABASE', 'litecart');
+            define('DB_TABLE_PREFIX', 'lc_');
+
+            \$link = new mysqli(DB_SERVER, DB_USERNAME, DB_PASSWORD, DB_DATABASE);
+            \$link->set_charset('utf8mb4');
+            \$link->query(\"SET SESSION sql_mode = ''\");
+
+            // Load and process structure.json
+            \$structure = file_get_contents('public_html/install/structure.json');
+            \$structure = str_replace('\"table\": \"', '\"table\": \"' . DB_TABLE_PREFIX, \$structure);
+            \$tables = json_decode(\$structure, true)['tables'];
+
+            foreach (\$tables as \$key => \$table) {
+              \$name = DB_TABLE_PREFIX . \$key;
+              \$cols = [];
+              foreach (\$table['columns'] as \$col => \$def) {
+                \$type = \$def['type'];
+                if (!empty(\$def['length'])) \$type .= '(' . \$def['length'] . ')';
+                if (!empty(\$def['unsigned'])) \$type .= ' UNSIGNED';
+                \$null = (!isset(\$def['null']) || \$def['null']) ? '' : ' NOT NULL';
+                \$default = isset(\$def['default']) ? ' DEFAULT ' . \$def['default'] : '';
+                \$auto = !empty(\$def['auto_increment']) ? ' AUTO_INCREMENT' : '';
+                \$cols[] = \"\`\$col\` \$type\$null\$default\$auto\";
+              }
+              if (!empty(\$table['primary_key'])) {
+                \$cols[] = 'PRIMARY KEY (\`' . implode('\`,\`', \$table['primary_key']) . '\`)';
+              }
+              if (!empty(\$table['keys'])) {
+                foreach (\$table['keys'] as \$kname => \$kcols) {
+                  \$unique = !empty(\$kcols['unique']) ? 'UNIQUE ' : '';
+                  \$idx_cols = is_array(\$kcols) && isset(\$kcols['columns']) ? \$kcols['columns'] : (is_array(\$kcols) && !isset(\$kcols['unique']) ? \$kcols : [\$kname]);
+                  if (is_string(\$idx_cols)) \$idx_cols = [\$idx_cols];
+                  \$cols[] = \$unique . \"KEY \`\$kname\` (\`\" . implode('\`,\`', \$idx_cols) . '\`)';
+                }
+              }
+              \$sql = \"CREATE TABLE IF NOT EXISTS \`\$name\` (\" . implode(', ', \$cols) . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
+              if (!\$link->query(\$sql)) {
+                echo \"ERROR creating \$name: \" . \$link->error . PHP_EOL;
+                exit(1);
+              }
+            }
+            echo 'Schema: ' . count(\$tables) . ' tables created' . PHP_EOL;
+
+            // Import seed data
+            \$data = file_get_contents('public_html/install/data.sql');
+            \$data = str_replace('\`lc_', '\`' . DB_TABLE_PREFIX, \$data);
+            \$link->multi_query(\$data);
+            while (\$link->next_result()) {}
+            echo 'Seed data imported' . PHP_EOL;
+
+            // Create admin user
+            \$hash = password_hash('admin123456', PASSWORD_DEFAULT);
+            \$link->query(\"INSERT INTO lc_administrators (status, username, email, password_hash) VALUES (1, 'admin', 'ci@test.com', '\$hash')\");
+            echo 'Admin user created' . PHP_EOL;
+          "
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ BingSiteAuth.xml
 #####################
 
 node_modules/
+playwright/.auth/
+playwright-report/
+test-results/
 
 *.bak
 *.old

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"node": ">=24"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@sequencemedia/gulp-clean-css": "^1.0.285",
 		"@sequencemedia/gulp-sourcemaps": "^1.0.301",
 		"gulp": "^5.0.1",
@@ -46,6 +47,7 @@
 		"hash": "php .git-hooks/pre-commit.d/calculate_checksums.php",
 		"phplint": "gulp phplint",
 		"test": "php .git-hooks/pre-commit.d/platform_tests.php",
+		"test:e2e": "npx playwright test",
 		"uglify": "gulp replace",
 		"watch": "gulp watch",
 		"upgrade": "ncu -u && npm install",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.E2E_PORT || 8080;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : [['html', { open: 'on-failure' }]],
+  timeout: 30_000,
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'auth',
+      testMatch: /auth\.setup\.mjs/,
+    },
+    {
+      name: 'backend',
+      testDir: './tests/e2e/backend',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['auth'],
+    },
+    {
+      name: 'frontend',
+      testDir: './tests/e2e/frontend',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+
+  webServer: {
+    command: `php -S localhost:${PORT} -t public_html router.php`,
+    url: BASE_URL,
+    timeout: 30_000,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/public_html/backend/apps/catalog/brands.inc.php
+++ b/public_html/backend/apps/catalog/brands.inc.php
@@ -32,6 +32,14 @@
 		}
 	}
 
+	// Search Filter
+	if (!empty($_GET['query'])) {
+		$sql_find = [
+			"b.id = '". database::input($_GET['query']) ."'",
+			"b.name like '%". database::input($_GET['query']) ."%'",
+		];
+	}
+
 	// Table Rows, Total Number of Rows, Total Number of Pages
 	$brands = database::query(
 		"select b.*, p.num_products
@@ -41,6 +49,8 @@
 			from ". DB_TABLE_PREFIX ."products
 			group by brand_id
 		) p on (p.brand_id = b.id)
+		where b.id
+		". (!empty($sql_find) ? "and (". implode(" or ", $sql_find) .")" : "") ."
 		order by name asc;"
 	)->fetch_page(null, null, $_GET['page'], null, $num_rows, $num_pages);
 
@@ -55,6 +65,15 @@
 	<div class="card-action">
 		<?php echo f::form_button_link(document::ilink(__APP__.'/edit_brand'), t('title_create_new_brand', 'Create New Brand'), '', 'create'); ?>
 	</div>
+
+	<?php echo f::form_begin('search_form', 'get'); ?>
+
+		<div class="card-filter">
+			<div class="expandable"><?php echo f::form_input_search('query', true, 'placeholder="'. t('text_search_phrase_or_keyword', 'Search phrase or keyword') .'"'); ?></div>
+			<?php echo f::form_button('filter', t('title_search', 'Search'), 'submit'); ?>
+		</div>
+
+	<?php echo f::form_end(); ?>
 
 	<?php echo f::form_begin('brands_form', 'post'); ?>
 

--- a/public_html/backend/apps/catalog/suppliers.inc.php
+++ b/public_html/backend/apps/catalog/suppliers.inc.php
@@ -9,10 +9,20 @@
 		$_GET['page'] = 1;
 	}
 
+	// Search Filter
+	if (!empty($_GET['query'])) {
+		$sql_find = [
+			"id = '". database::input($_GET['query']) ."'",
+			"name like '%". database::input($_GET['query']) ."%'",
+		];
+	}
+
 	// Table Rows, Total Number of Rows, Total Number of Pages
 	$suppliers = database::query(
 		"select id, name
 		from ". DB_TABLE_PREFIX ."suppliers
+		where id
+		". (!empty($sql_find) ? "and (". implode(" or ", $sql_find) .")" : "") ."
 		order by name asc;"
 	)->fetch_page(null, null, $_GET['page'], null, $num_rows, $num_pages);
 
@@ -27,6 +37,15 @@
 	<div class="card-action">
 		<?php echo f::form_button_link(document::ilink(__APP__.'/edit_supplier'), t('title_create_new_supplier', 'Create New Supplier'), '', 'create'); ?>
 	</div>
+
+	<?php echo f::form_begin('search_form', 'get'); ?>
+
+		<div class="card-filter">
+			<div class="expandable"><?php echo f::form_input_search('query', true, 'placeholder="'. t('text_search_phrase_or_keyword', 'Search phrase or keyword') .'"'); ?></div>
+			<?php echo f::form_button('filter', t('title_search', 'Search'), 'submit'); ?>
+		</div>
+
+	<?php echo f::form_end(); ?>
 
 	<?php echo f::form_begin('suppliers_form', 'post'); ?>
 

--- a/public_html/backend/apps/localization/countries/countries.inc.php
+++ b/public_html/backend/apps/localization/countries/countries.inc.php
@@ -61,6 +61,10 @@
 		<?php echo f::form_button_link(document::ilink(__APP__.'/countries/edit_country'), t('title_create_new_country', 'Create New Country'), '', 'create'); ?>
 	</div>
 
+	<div class="card-filter">
+		<div class="expandable"><?php echo f::form_input_search('query', false, 'placeholder="'. t('text_search_phrase_or_keyword', 'Search phrase or keyword') .'"'); ?></div>
+	</div>
+
 	<?php echo f::form_begin('countries_form', 'post'); ?>
 
 		<table class="table data-table">
@@ -125,4 +129,12 @@
 	$('.data-table :checkbox').on('change', function() {
 		$('#actions').prop('disabled', !$('.data-table :checked').length);
 	}).first().trigger('change');
+
+	$('input[name="query"]').on('input', function() {
+		var query = this.value.toLowerCase();
+		$('.data-table tbody tr').each(function() {
+			$(this).toggle(!query || $(this).text().toLowerCase().indexOf(query) > -1);
+		});
+		$('.data-table tfoot td').text('<?php echo t('title_countries', 'Countries'); ?>: ' + $('.data-table tbody tr:visible').length);
+	});
 </script>

--- a/router.php
+++ b/router.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Router script for PHP built-in server.
+ * Replaces .htaccess rewrite rules for E2E testing.
+ *
+ * Usage: php -S localhost:8080 -t public_html router.php
+ */
+
+  $docroot = $_SERVER['DOCUMENT_ROOT'];
+  $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+  $path = $docroot . $uri;
+
+  // Serve physical files directly
+  if ($uri !== '/' && (is_file($path) || is_dir($path))) {
+
+    // Block access to .inc.php files (like .htaccess FilesMatch rule)
+    if (preg_match('#\.inc\.php$#', $uri)) {
+      http_response_code(403);
+      echo '403 Forbidden';
+      return true;
+    }
+
+    return false;
+  }
+
+  // Rewrite /images/ and /cache/ to /storage/
+  if (preg_match('#^/(cache|images)/#', $uri)) {
+    $storage_path = $docroot . '/storage' . $uri;
+    if (is_file($storage_path)) {
+      $mime = mime_content_type($storage_path);
+      header('Content-Type: ' . $mime);
+      readfile($storage_path);
+      return true;
+    }
+  }
+
+  // Favicon fallback
+  if (preg_match('#/favicon\.ico$#', $uri)) {
+    $favicon = $docroot . '/storage/images/favicons/favicon.ico';
+    if (is_file($favicon)) {
+      header('Content-Type: image/x-icon');
+      readfile($favicon);
+      return true;
+    }
+  }
+
+  // Route everything else to index.php
+  require $docroot . '/index.php';
+  return true;

--- a/tests/e2e/auth.setup.mjs
+++ b/tests/e2e/auth.setup.mjs
@@ -1,0 +1,24 @@
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const authFile = path.join(__dirname, '../../playwright/.auth/admin.json');
+
+const ADMIN_USER = process.env.E2E_ADMIN_USER || 'admin';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || 'admin123456';
+
+setup('authenticate as admin', async ({ page }) => {
+  await page.goto('/admin/');
+
+  // Fill login form
+  await page.getByPlaceholder('Username or Email Address').fill(ADMIN_USER);
+  await page.getByPlaceholder('Password').fill(ADMIN_PASS);
+  await page.getByRole('button', { name: 'Login' }).click();
+
+  // Wait for dashboard to load
+  await expect(page).toHaveTitle(/Dashboard/);
+
+  // Save signed-in state
+  await page.context().storageState({ path: authFile });
+});

--- a/tests/e2e/backend/search-filters.spec.mjs
+++ b/tests/e2e/backend/search-filters.spec.mjs
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Backend Search Filters (#470)', () => {
+
+  test.describe('Brands', () => {
+
+    test('search field and button are present', async ({ page }) => {
+      await page.goto('/admin/catalog/brands');
+      await expect(page.getByPlaceholder('Search phrase or keyword')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
+    });
+
+    test('search submits without errors', async ({ page }) => {
+      await page.goto('/admin/catalog/brands?query=test');
+      await expect(page.locator('.data-table')).toBeVisible();
+      // No PHP errors on the page
+      await expect(page.locator('body')).not.toContainText('Fatal error');
+      await expect(page.locator('body')).not.toContainText('Warning:');
+    });
+  });
+
+  test.describe('Suppliers', () => {
+
+    test('search field and button are present', async ({ page }) => {
+      await page.goto('/admin/catalog/suppliers');
+      await expect(page.getByPlaceholder('Search phrase or keyword')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
+    });
+
+    test('search submits without errors', async ({ page }) => {
+      await page.goto('/admin/catalog/suppliers?query=test');
+      await expect(page.locator('.data-table')).toBeVisible();
+      await expect(page.locator('body')).not.toContainText('Fatal error');
+      await expect(page.locator('body')).not.toContainText('Warning:');
+    });
+  });
+
+  test.describe('Countries', () => {
+
+    test('search field is present', async ({ page }) => {
+      await page.goto('/admin/localization/countries/countries');
+      await expect(page.getByPlaceholder('Search phrase or keyword')).toBeVisible();
+    });
+
+    test('client-side filter reduces visible rows', async ({ page }) => {
+      await page.goto('/admin/localization/countries/countries');
+
+      const rows = page.locator('.data-table tbody tr');
+      const totalRows = await rows.count();
+      expect(totalRows).toBeGreaterThan(10);
+
+      // Type a filter term
+      await page.getByPlaceholder('Search phrase or keyword').fill('Germany');
+      await expect(rows.filter({ hasText: 'Germany' })).toBeVisible();
+
+      const visibleRows = await rows.filter({ has: page.locator(':visible') }).count();
+      expect(visibleRows).toBeLessThan(totalRows);
+    });
+
+    test('footer counter updates on filter', async ({ page }) => {
+      await page.goto('/admin/localization/countries/countries');
+
+      const footer = page.locator('.data-table tfoot td');
+      const initialText = await footer.textContent();
+
+      await page.getByPlaceholder('Search phrase or keyword').fill('Germany');
+
+      // Counter should show a smaller number
+      await expect(footer).not.toHaveText(initialText);
+      await expect(footer).toContainText('Countries:');
+    });
+
+    test('clearing filter restores all rows', async ({ page }) => {
+      await page.goto('/admin/localization/countries/countries');
+
+      const rows = page.locator('.data-table tbody tr');
+      const totalBefore = await rows.count();
+
+      // Filter then clear
+      await page.getByPlaceholder('Search phrase or keyword').fill('Germany');
+      await page.getByPlaceholder('Search phrase or keyword').fill('');
+
+      const totalAfter = await rows.count();
+      expect(totalAfter).toBe(totalBefore);
+    });
+  });
+});


### PR DESCRIPTION
Tackles two things in one PR — the search filters from #470 and the E2E test infrastructure to validate them.

## Search Filters (#470)

| App | Approach | Searchable fields |
|-----|----------|-------------------|
| Brands | Server-side `$_GET['query']` | ID, name |
| Suppliers | Server-side `$_GET['query']` | ID, name |
| Countries | Client-side jQuery filter | All visible text (name, ISO codes) |

Brands and suppliers follow the existing `card-filter` + `form_input_search` pattern from customers/products. Countries uses a lightweight JS filter since all rows are already on the page.

## E2E Test Infrastructure (Playwright)

| Component | File |
|-----------|------|
| Router script | `router.php` (project root, not web-accessible) |
| Playwright config | `playwright.config.mjs` |
| Auth setup | `tests/e2e/auth.setup.mjs` |
| Search filter tests | `tests/e2e/backend/search-filters.spec.mjs` |
| CI job | `.github/workflows/ci.yml` |

The E2E setup uses PHP's built-in server with a router script (replaces .htaccess rewrites), Playwright with Chromium, and storageState for shared admin login. The CI job reuses the existing MariaDB service and schema import pattern from platform-tests.

Directory structure is ready for growth: `tests/e2e/backend/` and `tests/e2e/frontend/` with auto-discovery of `*.spec.mjs` files.

## Test plan
- [x] `php -l` passes on all changed PHP files
- [x] 9 E2E tests pass locally (7.5s)
- [x] CI lint job passes
- [x] CI build job passes
- [x] CI e2e-tests job passes
- [x] Verify search filters work in brands, suppliers, countries