### PR TITLE
[v3] Stop storage/logs/ from leaking credentials and tokens

### DIFF
--- a/public_html/includes/clients/smtp_client.inc.php
+++ b/public_html/includes/clients/smtp_client.inc.php
@@ -8,6 +8,13 @@
 		private $_log_handle;
 		private $_last_response;
 
+		// When an AUTH command is written, this counter is set to the
+		// number of subsequent write()s whose payload is a base64 credential
+		// token. Each following write() decrements the counter and writes
+		// "[REDACTED]" to the transcript instead of the raw bytes. Socket
+		// writes are unaffected.
+		private $_pending_credential_writes = 0;
+
 		function __construct($host, $port=25, $username='', $password='') {
 
 			if ($port == 465) {
@@ -135,7 +142,27 @@
 
 		public function write($data, $expected_response=null) {
 
-			fwrite($this->_log_handle, "> $data");
+			if ($this->_pending_credential_writes > 0) {
+				// Payload is a credential token — never let it hit the log.
+				fwrite($this->_log_handle, "> [REDACTED]\r\n");
+				$this->_pending_credential_writes--;
+			} else {
+				fwrite($this->_log_handle, "> $data");
+
+				// If this is an AUTH command, arm the redaction counter
+				// for the following write() call(s). Counter values are
+				// chosen from the three auth flows in send():
+				//   AUTH LOGIN   → 2 follow-up writes (username-b64, password-b64)
+				//   AUTH PLAIN   → 1 follow-up write  (\0user\0pass-b64)
+				//   AUTH CRAM-MD5 → 1 follow-up write (HMAC response)
+				$trimmed = ltrim($data);
+				if (stripos($trimmed, 'AUTH LOGIN') === 0) {
+					$this->_pending_credential_writes = 2;
+				} else if (stripos($trimmed, 'AUTH PLAIN') === 0 || stripos($trimmed, 'AUTH CRAM-MD5') === 0) {
+					$this->_pending_credential_writes = 1;
+				}
+			}
+
 			$result = fwrite($this->_socket, $data);
 
 			if ($expected_response !== null) {

--- a/public_html/includes/error_handler.inc.php
+++ b/public_html/includes/error_handler.inc.php
@@ -86,13 +86,24 @@
 
 		if (filter_var(ini_get('log_errors'), FILTER_VALIDATE_BOOLEAN)) {
 
+			// Redaction helpers (PROJ-21): sensitive parameter values in
+			// argv / REQUEST_URI / HTTP_REFERER are replaced before the
+			// line hits error_log. The file is loaded defensively —
+			// error_handler may run before the autoloader in some paths.
+			if (!function_exists('redact_query_string')) {
+				$redact_file = __DIR__ . '/functions/func_redact.inc.php';
+				if (is_file($redact_file)) require_once $redact_file;
+			}
+			$_redact_q = function_exists('redact_query_string') ? 'redact_query_string' : function($s) { return $s; };
+			$_redact_a = function_exists('redact_argv_line') ? 'redact_argv_line' : function($a) { return implode(' ', $a); };
+
 			$output = array_merge($output, array_filter([
-				($_SERVER['SERVER_SOFTWARE'] == 'CLI') ? 'Command: '. implode(' ', $GLOBALS['argv']) : '',
-				!empty($_SERVER['REQUEST_URI']) ? 'Request: '. $_SERVER['REQUEST_METHOD'] .' '. $_SERVER['REQUEST_URI'] .' '. $_SERVER['SERVER_PROTOCOL'] : '',
+				($_SERVER['SERVER_SOFTWARE'] == 'CLI') ? 'Command: '. $_redact_a($GLOBALS['argv']) : '',
+				!empty($_SERVER['REQUEST_URI']) ? 'Request: '. $_SERVER['REQUEST_METHOD'] .' '. $_redact_q($_SERVER['REQUEST_URI']) .' '. $_SERVER['SERVER_PROTOCOL'] : '',
 				!empty($_SERVER['HTTP_HOST']) ? 'Host: '. $_SERVER['HTTP_HOST'] : '',
 				!empty($_SERVER['REMOTE_ADDR']) ? 'Client: '. $_SERVER['REMOTE_ADDR'] .' ('. gethostbyaddr($_SERVER['REMOTE_ADDR']) .')' : '',
 				!empty($_SERVER['HTTP_USER_AGENT']) ? 'User Agent: '. $_SERVER['HTTP_USER_AGENT'] : '',
-				!empty($_SERVER['HTTP_REFERER']) ? 'Referer: '. $_SERVER['HTTP_REFERER'] : '',
+				!empty($_SERVER['HTTP_REFERER']) ? 'Referer: '. $_redact_q($_SERVER['HTTP_REFERER']) : '',
 			]));
 
 			if (defined('SCRIPT_TIMESTAMP_START')) {

--- a/public_html/includes/functions/func_redact.inc.php
+++ b/public_html/includes/functions/func_redact.inc.php
@@ -1,0 +1,173 @@
+<?php
+
+	/**
+	 * Redaction helpers for log output.
+	 *
+	 * LiteCart writes request URIs, HTTP referers, CLI argv, and (via callers)
+	 * other free-form strings into storage/logs/errors.log. Any secret
+	 * carried in those strings (reset tokens, order public keys, install
+	 * passwords, API keys) ends up in the log in clear. These helpers
+	 * replace the sensitive values with the literal string [REDACTED]
+	 * before the caller writes to the log.
+	 *
+	 * The helpers are pure string processing — no I/O, no side effects —
+	 * so they are cheap to call on every log line.
+	 */
+
+	/**
+	 * Keys whose value should ALWAYS be redacted when they appear as the
+	 * full key name. Matched case-insensitively against the complete key
+	 * (after url-decode / without the leading dashes). Covers short tokens
+	 * that are meaningful only as complete words — "token" and "auth" in
+	 * particular are too generic to allow as substrings.
+	 */
+	const REDACT_SENSITIVE_EXACT = [
+		'password', 'passwd',
+		'secret', 'credential',
+		'token', 'auth',
+		'api_key', 'apikey',
+		'reset_token', 'public_key',
+	];
+
+	/**
+	 * Additional unambiguous "credential" words that are ALSO checked against
+	 * individual segments of a key (split on `_` and `-`). This allows
+	 * `db_password`, `admin_password`, `smtp_secret` etc. to be redacted
+	 * without maintaining an exhaustive list of compound keys. Kept small
+	 * on purpose — "token" and "key" are deliberately NOT in here, because
+	 * `token_count`, `cache_key`, `foreign_key_id` etc. must pass through.
+	 */
+	const REDACT_SENSITIVE_SEGMENTS = [
+		'password', 'passwd', 'secret', 'credential',
+	];
+
+	const REDACT_PLACEHOLDER = '[REDACTED]';
+
+	/**
+	 * Return true when $key matches a REDACT_SENSITIVE_EXACT entry or when
+	 * any `_` / `-`-separated segment of $key matches a
+	 * REDACT_SENSITIVE_SEGMENTS entry. All comparisons case-insensitive.
+	 */
+	function redact_key_is_sensitive($key) {
+		$needle = strtolower((string)$key);
+		if ($needle === '') return false;
+
+		foreach (REDACT_SENSITIVE_EXACT as $pattern) {
+			if ($needle === $pattern) return true;
+		}
+
+		$segments = preg_split('#[_-]+#', $needle);
+		foreach ($segments as $segment) {
+			foreach (REDACT_SENSITIVE_SEGMENTS as $pattern) {
+				if ($segment === $pattern) return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Redact sensitive parameter values in a URL or a bare query string.
+	 *
+	 * Input forms supported:
+	 *   "/path?a=1&token=secret"   → "/path?a=1&token=[REDACTED]"
+	 *   "token=secret&a=1"         → "token=[REDACTED]&a=1"
+	 *   "https://host/x?token=s"   → "https://host/x?token=[REDACTED]"
+	 *
+	 * Values are matched against REDACT_SENSITIVE_KEYS case-insensitively.
+	 * Unknown parameters pass through unchanged. Fragment (#...) is
+	 * preserved but its contents are not rewritten (browsers never send
+	 * fragments to the server, so they don't appear in REQUEST_URI).
+	 */
+	function redact_query_string($url_or_query) {
+		$input = (string)$url_or_query;
+		if ($input === '') return $input;
+
+		// Split off fragment (kept as-is).
+		$fragment = '';
+		if (($hash_pos = strpos($input, '#')) !== false) {
+			$fragment = substr($input, $hash_pos);
+			$input = substr($input, 0, $hash_pos);
+		}
+
+		// Split off a URL prefix if present — we only rewrite the query part.
+		$prefix = '';
+		$query = $input;
+		if (($q_pos = strpos($input, '?')) !== false) {
+			$prefix = substr($input, 0, $q_pos + 1);
+			$query = substr($input, $q_pos + 1);
+		} else if (!preg_match('#^[^=&]+=#', $input)) {
+			// No query structure and no URL marker → nothing to redact.
+			return $input . $fragment;
+		}
+
+		if ($query === '') return $prefix . $fragment;
+
+		$pairs = explode('&', $query);
+		foreach ($pairs as $i => $pair) {
+			$eq = strpos($pair, '=');
+			if ($eq === false) continue; // bare flag, no value
+			$key = substr($pair, 0, $eq);
+			if (redact_key_is_sensitive(urldecode($key))) {
+				$pairs[$i] = $key . '=' . REDACT_PLACEHOLDER;
+			}
+		}
+
+		return $prefix . implode('&', $pairs) . $fragment;
+	}
+
+	/**
+	 * Redact sensitive values in a CLI argv array.
+	 *
+	 * Supports the three forms getopt() accepts:
+	 *   --name=value    → value replaced
+	 *   --name value    → value in next slot replaced
+	 *   -x value        → value in next slot replaced
+	 *
+	 * Positional arguments (those not preceded by an option flag) pass
+	 * through untouched. Flags without values (e.g. "--cleanup") pass
+	 * through untouched.
+	 *
+	 * Input:  ['install.php', '--db_password=s3cret', '--timezone=UTC', '--password', 'x']
+	 * Output: ['install.php', '--db_password=[REDACTED]', '--timezone=UTC', '--password', '[REDACTED]']
+	 */
+	function redact_argv(array $argv) {
+		$out = [];
+		$redact_next = false;
+		foreach ($argv as $arg) {
+			if ($redact_next) {
+				$out[] = REDACT_PLACEHOLDER;
+				$redact_next = false;
+				continue;
+			}
+			// --name=value  (long option with inline value)
+			if (preg_match('#^--([A-Za-z0-9_-]+)=(.*)$#s', $arg, $m)) {
+				if (redact_key_is_sensitive($m[1])) {
+					$out[] = '--' . $m[1] . '=' . REDACT_PLACEHOLDER;
+				} else {
+					$out[] = $arg;
+				}
+				continue;
+			}
+			// --name  or  -x  (long or short option without inline value)
+			if (preg_match('#^-{1,2}([A-Za-z0-9_-]+)$#', $arg, $m)) {
+				$out[] = $arg;
+				if (redact_key_is_sensitive($m[1])) {
+					$redact_next = true;
+				}
+				continue;
+			}
+			// Positional or unrecognised token
+			$out[] = $arg;
+		}
+		return $out;
+	}
+
+	/**
+	 * Convenience wrapper for error_handler: takes the raw argv-as-string
+	 * that `implode(' ', $argv)` would produce and returns the redacted
+	 * equivalent. Implemented by running redact_argv on the array form.
+	 */
+	function redact_argv_line(array $argv) {
+		return implode(' ', redact_argv($argv));
+	}

--- a/public_html/install/data/default/storage/logs/.htaccess
+++ b/public_html/install/data/default/storage/logs/.htaccess
@@ -1,0 +1,3 @@
+<Files *>
+	Require all denied
+</Files>

--- a/public_html/install/upgrade.php
+++ b/public_html/install/upgrade.php
@@ -808,6 +808,33 @@
 
 			echo '<span class="ok">[OK]</span></p>' . PHP_EOL . PHP_EOL;
 
+			### Storage Skeleton > Ensure ##########################################
+			#
+			# Idempotent copy of small files that MUST exist under storage/
+			# on every install (fresh or upgraded). Currently: the deny-rule
+			# .htaccess on storage/logs/ that older installs (<= 3.0.0) never
+			# shipped. Each entry is copied ONLY if the destination does not
+			# already exist — operator customisations are never overwritten.
+
+			echo '<p>Ensuring storage skeleton files... ';
+
+			$skeleton_files = [
+				'logs/.htaccess',
+			];
+			$copied = 0;
+			foreach ($skeleton_files as $rel) {
+				$dst = FS_DIR_STORAGE . $rel;
+				$src = __DIR__ . '/data/default/storage/' . $rel;
+				if (is_file($dst)) continue;
+				if (!is_file($src)) continue;
+				$dst_dir = dirname($dst);
+				if (!is_dir($dst_dir)) @mkdir($dst_dir, 0755, true);
+				if (@copy($src, $dst)) $copied++;
+			}
+
+			echo ($copied ? "$copied file(s) installed. " : 'Nothing to do. ')
+				 . '<span class="ok">[OK]</span></p>' . PHP_EOL . PHP_EOL;
+
 			########################################################################
 
 			echo '<h2>Complete</h2>' . PHP_EOL . PHP_EOL

--- a/tests/redact.php
+++ b/tests/redact.php
@@ -1,0 +1,204 @@
+<?php
+
+	// Platform test for PROJ-21: redaction helper + SMTP state-machine.
+	// No DB or autoloader dependency — these helpers are pure string
+	// processing and must work even before LiteCart's bootstrap has run
+	// (error_handler may run very early).
+
+	require_once __DIR__ . '/../public_html/includes/functions/func_redact.inc.php';
+
+	try {
+
+		########################################################################
+		## AC-7: redact_query_string blanks sensitive params, keeps rest
+		########################################################################
+
+		echo 'Testing redact_query_string...';
+
+		$cases = [
+			// [input, expected]
+			['/account/reset?reset_token=abc123',        '/account/reset?reset_token=[REDACTED]'],
+			['/order?public_key=deadbeef&id=42',         '/order?public_key=[REDACTED]&id=42'],
+			['token=s3cr3t',                              'token=[REDACTED]'],
+			['foo=1&password=hunter2&bar=2',              'foo=1&password=[REDACTED]&bar=2'],
+			['https://host/x?api_key=X&q=search',         'https://host/x?api_key=[REDACTED]&q=search'],
+			['/path#fragment',                            '/path#fragment'],
+			['/path?token=a#fragment',                    '/path?token=[REDACTED]#fragment'],
+			['',                                          ''],
+			['/no-query-here',                            '/no-query-here'],
+			['TOKEN=upper',                               'TOKEN=[REDACTED]'],    // case-insensitive
+			['Password=mixed',                            'Password=[REDACTED]'], // case-insensitive
+		];
+
+		foreach ($cases as [$input, $expected]) {
+			$actual = redact_query_string($input);
+			if ($actual !== $expected) {
+				throw new Exception('redact_query_string('. var_export($input, true) .') returned '
+					. var_export($actual, true) .', expected ' . var_export($expected, true));
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## AC-9: redact_argv preserves non-sensitive flags and positions
+		########################################################################
+
+		echo 'Testing redact_argv...';
+
+		$argv_cases = [
+			[
+				['install.php', '--db_password=s3cret', '--timezone=UTC', '--password', 'hunter2', '--cleanup'],
+				['install.php', '--db_password=[REDACTED]', '--timezone=UTC', '--password', '[REDACTED]', '--cleanup'],
+			],
+			[
+				['upgrade.php', '--from_version=3.0.0', '--backup=1'],
+				['upgrade.php', '--from_version=3.0.0', '--backup=1'],
+			],
+			[
+				['tool.php', '--api_key', 'secret_abc', '--endpoint', 'https://x'],
+				['tool.php', '--api_key', '[REDACTED]', '--endpoint', 'https://x'],
+			],
+			[
+				['tool.php', '--token=abc', '--TOKEN=xyz'],
+				['tool.php', '--token=[REDACTED]', '--TOKEN=[REDACTED]'],
+			],
+		];
+
+		foreach ($argv_cases as [$input, $expected]) {
+			$actual = redact_argv($input);
+			if ($actual !== $expected) {
+				throw new Exception('redact_argv('. json_encode($input) .') returned '
+					. json_encode($actual) .', expected ' . json_encode($expected));
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## Key-matching is whole-word, not substring
+		########################################################################
+
+		echo 'Testing key-match precision (no false positives)...';
+
+		$false_positive_cases = [
+			// These keys contain sensitive substrings but are not themselves
+			// credentials — they must pass through untouched.
+			['token_count=5&key_id=7',       'token_count=5&key_id=7'],
+			['some_token_like=foo',          'some_token_like=foo'],
+			['authoritative=1',              'authoritative=1'],
+			['passwords_enabled=yes',        'passwords_enabled=yes'],
+		];
+
+		foreach ($false_positive_cases as [$input, $expected]) {
+			$actual = redact_query_string($input);
+			if ($actual !== $expected) {
+				throw new Exception('False positive: redact_query_string('. var_export($input, true) .') redacted a non-sensitive key');
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## AC-4/5/6: SMTP state-machine — simulate AUTH flows
+		########################################################################
+
+		echo 'Testing SMTP AUTH redaction (write-path simulation)...';
+
+		// We cannot instantiate smtp_client without a live socket, so this
+		// is an inline simulation of the same state-machine logic. If the
+		// algorithm below matches the one in smtp_client::write(), both
+		// will behave identically. The test protects against future
+		// regressions — if smtp_client.inc.php changes, update the mirror.
+
+		$simulate_write = function(string $data, int &$pending): string {
+			$transcript_line = '';
+			if ($pending > 0) {
+				$transcript_line = "> [REDACTED]\r\n";
+				$pending--;
+			} else {
+				$transcript_line = "> $data";
+				$trimmed = ltrim($data);
+				if (stripos($trimmed, 'AUTH LOGIN') === 0) {
+					$pending = 2;
+				} else if (stripos($trimmed, 'AUTH PLAIN') === 0 || stripos($trimmed, 'AUTH CRAM-MD5') === 0) {
+					$pending = 1;
+				}
+			}
+			return $transcript_line;
+		};
+
+		// AUTH LOGIN flow: command + 2 credential writes.
+		$pending = 0;
+		$transcript = '';
+		foreach (["AUTH LOGIN\r\n", base64_encode('user') . "\r\n", base64_encode('secretpassword') . "\r\n"] as $w) {
+			$transcript .= $simulate_write($w, $pending);
+		}
+		if (strpos($transcript, 'secretpassword') !== false) {
+			throw new Exception('Plain password leaked into AUTH LOGIN transcript');
+		}
+		if (strpos($transcript, base64_encode('secretpassword')) !== false) {
+			throw new Exception('Base64 password leaked into AUTH LOGIN transcript');
+		}
+		if (substr_count($transcript, '[REDACTED]') !== 2) {
+			throw new Exception('AUTH LOGIN: expected 2 [REDACTED] markers, got: ' . $transcript);
+		}
+
+		// AUTH PLAIN flow: command + 1 credential write.
+		$pending = 0;
+		$transcript = '';
+		foreach (["AUTH PLAIN\r\n", base64_encode("\0user\0mySecret") . "\r\n"] as $w) {
+			$transcript .= $simulate_write($w, $pending);
+		}
+		if (strpos($transcript, 'mySecret') !== false) {
+			throw new Exception('AUTH PLAIN password leaked');
+		}
+		if (substr_count($transcript, '[REDACTED]') !== 1) {
+			throw new Exception('AUTH PLAIN: expected 1 [REDACTED], got: ' . $transcript);
+		}
+
+		// AUTH CRAM-MD5 flow: command + 1 HMAC write.
+		$pending = 0;
+		$transcript = '';
+		foreach (["AUTH CRAM-MD5\r\n", base64_encode('user ' . hash_hmac('md5', 'sensitive', 'challenge')) . "\r\n"] as $w) {
+			$transcript .= $simulate_write($w, $pending);
+		}
+		if (stripos($transcript, hash_hmac('md5', 'sensitive', 'challenge')) !== false) {
+			throw new Exception('CRAM-MD5 HMAC leaked');
+		}
+
+		// Non-AUTH command: no redaction.
+		$pending = 0;
+		$transcript = '';
+		foreach (["EHLO example.com\r\n", "MAIL FROM: <a@b>\r\n", "RCPT TO: <c@d>\r\n"] as $w) {
+			$transcript .= $simulate_write($w, $pending);
+		}
+		if (strpos($transcript, '[REDACTED]') !== false) {
+			throw new Exception('Non-AUTH commands should not be redacted');
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## Cross-check: the state-machine mirror matches smtp_client.inc.php
+		########################################################################
+
+		echo 'Cross-checking smtp_client.inc.php matches simulated state-machine...';
+
+		$smtp_src = file_get_contents(__DIR__ . '/../public_html/includes/clients/smtp_client.inc.php');
+
+		foreach (['_pending_credential_writes', 'AUTH LOGIN', 'AUTH PLAIN', 'AUTH CRAM-MD5', '[REDACTED]'] as $needle) {
+			if (strpos($smtp_src, $needle) === false) {
+				throw new Exception('smtp_client.inc.php is missing expected marker: ' . $needle);
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		echo PHP_EOL . 'All PROJ-21 redaction tests passed.' . PHP_EOL;
+		return true;
+
+	} catch (Throwable $e) {
+		echo PHP_EOL . 'FAILED: ' . $e->getMessage() . PHP_EOL;
+		return false;
+	}


### PR DESCRIPTION
Closes #475. Someone reading `errors.log` shouldn't get a free SMTP password.

## What changes

| File | Change |
|---|---|
| `install/data/default/storage/logs/.htaccess` | New — `Require all denied`, matching the sibling dirs (`backups`, `files`, `vmods`) |
| `install/upgrade.php` | New idempotent post-migration step: copies missing skeleton files (currently `logs/.htaccess`) into existing installs, never overwrites |
| `includes/clients/smtp_client.inc.php` | `write()` now tracks a pending-credential-writes counter; AUTH commands arm it, following writes log `[REDACTED]` instead of the base64 token |
| `includes/functions/func_redact.inc.php` | New — `redact_query_string()`, `redact_argv()`, `redact_argv_line()` with a two-tier key blacklist |
| `includes/error_handler.inc.php` | Lazily loads the redact helper, runs `REQUEST_URI`, `HTTP_REFERER`, and `argv` through it before `error_log()` |
| `tests/redact.php` | New — 5 suites (11 query cases, 4 argv cases, 4 false-positive guards, 3 SMTP auth flows, cross-check against `smtp_client.inc.php`) |

## Why

Three sinks on the same exposure chain:

- `storage/logs/` shipped without a `.htaccess` deny rule, so on default Apache installs `errors.log` and `last_smtp.log` were readable to anyone who could guess the URL. The sibling directories (`backups`, `files`, `vmods`) all shipped the deny rule — logs was the outlier.
- `smtp_client::write()` dumped every byte into `last_smtp.log` before writing to the socket. That included base64-encoded `AUTH LOGIN` / `PLAIN` / `CRAM-MD5` payloads, trivially reversible by anyone with log access.
- `error_handler` logged full `REQUEST_URI`, `HTTP_REFERER`, and CLI `argv` verbatim. Query-string secrets (reset tokens, order `public_key`, installer `--db_password`) went straight into `errors.log`.

Together: unauthenticated read of `/storage/logs/errors.log` → SMTP credentials + active reset tokens.

## Design notes

**SMTP state machine.** Counter starts at 0. `AUTH LOGIN` arms it to 2 (username + password writes); `AUTH PLAIN` and `AUTH CRAM-MD5` arm it to 1. Each subsequent `write()` decrements the counter and logs `> [REDACTED]`; socket gets the real bytes. Counter can't go negative; `disconnect()` closes the handle, so state doesn't leak between sessions.

**Redact blacklist.** Two tiers, to avoid false positives like `token_count` or `cache_key`:

- Exact-match keys: `password`, `passwd`, `secret`, `credential`, `token`, `auth`, `api_key`, `apikey`, `reset_token`, `public_key`.
- Segment-match keys (split on `_` / `-`): only the unambiguous words — `password`, `passwd`, `secret`, `credential`. This redacts `db_password`, `admin_password`, `smtp_secret` without touching `token_count`, `key_id`, `passwords_enabled`, or `authoritative`.

**Idempotent upgrade hook.** Copies ship-new files into existing installs based on an allowlist hardcoded in `upgrade.php`. Each entry is copied only if the destination doesn't exist — operator customisations survive.

## Nginx configuration hint

`.htaccess` is Apache-only. Nginx operators should add an equivalent block after deploying this PR:

```nginx
location ^~ /storage/logs/ {
    deny all;
    return 403;
}
```

## Test plan

- [x] `tests/redact.php` — 5 suites, all green
- [x] `php -l` across the 5 touched/new source files — no syntax errors
- [x] Key-match precision: `token_count`, `key_id`, `authoritative`, `passwords_enabled` pass through; `db_password`, `admin_password`, `reset_token` redacted
- [x] SMTP transcript after simulated `AUTH LOGIN` / `PLAIN` / `CRAM-MD5` — `strpos(transcript, 'secretpassword')` is `false`, `strpos(transcript, base64_encode('secretpassword'))` is `false`
- [x] Non-AUTH commands (`EHLO`, `MAIL FROM`, `RCPT TO`) are **not** redacted
- [x] PROJ-20 platform test (`tests/install_access_control.php`) still green — no regression in the installer paths
- [ ] Manual: on a staging install, `rm storage/logs/.htaccess && php upgrade.php && ls -la storage/logs/.htaccess` → file reappears; second run is a no-op
- [ ] Manual: existing `last_smtp.log` files from before the fix should be rotated/removed by the operator — release note

## Rollback

Single commit; `git revert <sha>` restores the prior behaviour. No DB migrations, no data changes. Log files written after the revert will again contain raw AUTH payloads, so re-rotate if you revert.

## Not in this PR

- http_client Authorization-header redaction — separate follow-up; will use the same `redact_` helper.
- Structured / JSON logging — not in scope.
- Automatic rotation of pre-fix log files — left to the operator.