### PR TITLE
[v3] Validate language codes before splicing them into SQL identifiers

### DIFF
--- a/public_html/backend/apps/localization/languages/edit_language.inc.php
+++ b/public_html/backend/apps/localization/languages/edit_language.inc.php
@@ -24,6 +24,15 @@
 				throw new Exception(t('error_must_provide_code', 'You must provide a code'));
 			}
 
+			// AC-7: server-side validation of the language code. The HTML
+			// input has a pattern attribute, but that is client-side only —
+			// an attacker can POST any value. The code is persisted and
+			// later spliced into `text_<code>` column names in DDL, so it
+			// must match a strict locale pattern before we accept it.
+			if (!preg_match('#^[a-z]{2,5}(-[a-z0-9]{2,8})?$#i', $_POST['code'])) {
+				throw new Exception(t('error_invalid_language_code', 'Language code must be a BCP-47 style locale (e.g. "en", "de", "zh-cn")'));
+			}
+
 			if (empty($_POST['name'])) {
 				throw new Exception(t('error_must_provide_name', 'You must provide a name'));
 			}
@@ -163,9 +172,9 @@
 					foreach ($csv as $row) {
 						database::query(
 							"insert into ". DB_TABLE_PREFIX ."translations
-							(`code`, `text_". database::input($language->data['code']) ."`)
+							(`code`, `text_". database::identifier($language->data['code']) ."`)
 							values ('". database::input($row['code']) ."', '". database::input($row['text_'.$language->data['code']]) ."')
-							on duplicate key update `text_". database::input($language->data['code']) ."` = '". database::input($row['text_'.$language->data['code']]) ."');"
+							on duplicate key update `text_". database::identifier($language->data['code']) ."` = '". database::input($row['text_'.$language->data['code']]) ."');"
 						);
 					}
 

--- a/public_html/backend/apps/localization/translations/csv.inc.php
+++ b/public_html/backend/apps/localization/translations/csv.inc.php
@@ -106,7 +106,7 @@
 
 							database::query(
 								"update ". DB_TABLE_PREFIX ."translations
-								set `text_". database::input($language_code) ."` = '". database::input($row[$language_code], true) ."'
+								set `text_". database::identifier($language_code) ."` = '". database::input($row[$language_code], true) ."'
 								where code = '". database::input($row['code']) ."'
 								limit 1;"
 							);
@@ -173,10 +173,21 @@
 
 			$_POST['language_codes'] = array_filter($_POST['language_codes']);
 
+			// AC-5, AC-6: validate codes against configured allowlist before
+			// they are spliced into backtick-quoted column identifiers below.
+			$allowed_language_codes = array_keys(language::$languages);
+			foreach ($_POST['language_codes'] as $_lang_code) {
+				try {
+					database::identifier($_lang_code, $allowed_language_codes);
+				} catch (InvalidArgumentException $e) {
+					throw new Exception('Invalid language code');
+				}
+			}
+
 			if (in_array('translations', $_POST['collections'])) {
 				$sql_union[] = (
 					"select 'translation' as entity, frontend, backend, code, updated_at, html,
-					". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_POST['language_codes'])) ."
+					". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_POST['language_codes'])) ."
 					from ". DB_TABLE_PREFIX ."translations
 					where code not regexp '^(settings_group:|settings_key:|cm|job|om|ot|pm|sm)_'"
 				);
@@ -185,7 +196,7 @@
 			if (in_array('modules', $_POST['collections'])) {
 				$sql_union[] = (
 					"select 'translation' as entity, frontend, backend, code, updated_at, html,
-					". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_POST['language_codes'])) ."
+					". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_POST['language_codes'])) ."
 					from ". DB_TABLE_PREFIX ."translations
 					where code regexp '^(cm|job|om|ot|pm|sm)_'"
 				);
@@ -194,7 +205,7 @@
 			if (in_array('setting_groups', $_POST['collections'])) {
 				$sql_union[] = (
 					"select 'translation' as entity, frontend, backend, code, updated_at, html,
-					". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_POST['language_codes'])) ."
+					". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_POST['language_codes'])) ."
 					from ". DB_TABLE_PREFIX ."translations
 					where code regexp '^settings_group:'"
 				);
@@ -203,7 +214,7 @@
 			if (in_array('settings', $_POST['collections'])) {
 				$sql_union[] = (
 					"select 'translation' as entity, frontend, backend, code, updated_at, html,
-					". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_POST['language_codes'])) ."
+					". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_POST['language_codes'])) ."
 					from ". DB_TABLE_PREFIX ."translations
 					where code regexp '^settings_key:'"
 				);
@@ -213,7 +224,7 @@
 				return (
 					"select '$entity' as entity, '1' as frontend, '1' as backend, concat('[". database::input($entity) ."', ':', id, ']". database::input($column) ."') as code, '' as updated_at,
 						coalesce(". implode(', ', array_map(function($language_code) use($column) { return "if(json_value(`". database::input($column) ."`, '$.". database::input($language_code) ."') regexp '<', 1, null)"; }, $_POST['language_codes'])) .", 0) as html,
-						". implode(', ', array_map(function($language_code) use($column) { return "json_value(`". $column ."`, '$.". database::input($language_code) ."') as `text_". database::input($language_code) ."`"; }, $_POST['language_codes'])) ."
+						". implode(', ', array_map(function($language_code) use($column) { return "json_value(`". $column ."`, '$.". database::input($language_code) ."') as `text_". database::identifier($language_code) ."`"; }, $_POST['language_codes'])) ."
 					from ". DB_TABLE_PREFIX . database::input($id)
 				);
 			};
@@ -249,7 +260,11 @@
 				header('Content-Type: text/plain; charset='. $_POST['charset']);
 			} else {
 				header('Content-Type: application/csv; charset='. $_POST['charset']);
-				header('Content-Disposition: attachment; filename=translations-'. implode('-', $_POST['language_codes']) .'.csv');
+				// language_codes have already been allowlisted above, so they
+				// are safe for the filename slot — but a whitelist filter here
+				// protects against a future refactor that re-orders validation.
+				$_filename_codes = preg_replace('#[^A-Za-z0-9_-]#', '', implode('-', $_POST['language_codes']));
+				header('Content-Disposition: attachment; filename=translations-'. $_filename_codes .'.csv');
 			}
 
 			switch($_POST['eol']) {

--- a/public_html/backend/apps/localization/translations/translations.inc.php
+++ b/public_html/backend/apps/localization/translations/translations.inc.php
@@ -15,6 +15,20 @@
 		$_GET['languages'] = array_slice(array_unique(array_merge($defined_languages, $all_languages)), 0, 2);
 	}
 
+	// AC-3, AC-4: language codes flow into backtick-quoted SQL identifiers
+	// further down (text_<code> column references). Validate them once here
+	// against the configured language allowlist; reject the whole request
+	// if any entry is bogus — no query gets built with an injected token.
+	$allowed_language_codes = array_keys(language::$languages);
+	foreach ((array)$_GET['languages'] as $_lang_code) {
+		try {
+			database::identifier($_lang_code, $allowed_language_codes);
+		} catch (InvalidArgumentException $e) {
+			http_response_code(400);
+			exit('Invalid language code');
+		}
+	}
+
 	$collections = include 'app://backend/apps/localization/translations/collections.inc.php';
 
 	if (isset($_POST['save'])) {
@@ -35,7 +49,7 @@
 				if ($translation['entity'] == 'translation') {
 					database::query(
 						"update ". DB_TABLE_PREFIX ."translations
-						set ". implode(', ' . PHP_EOL, array_map(function($language_code) use($translation) { return "text_$language_code = '". database::input($translation['text_'.$language_code], !empty($translation['html'])) ."'"; }, $_GET['languages'])) .",
+						set ". implode(', ' . PHP_EOL, array_map(function($language_code) use($translation) { return "text_". database::identifier($language_code) ." = '". database::input($translation['text_'.$language_code], !empty($translation['html'])) ."'"; }, $_GET['languages'])) .",
 							html = ". (!empty($translation['html']) ? 1 : 0) ."
 						where code = '". database::input($translation['code']) ."'
 						limit 1;"
@@ -105,7 +119,7 @@
 	if (empty($_GET['collections']) || in_array('translations', $_GET['collections'])) {
 		$sql_union[] = (
 			"select 'translation' as entity, frontend, backend, code, updated_at, html,
-				". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_GET['languages'])) ."
+				". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_GET['languages'])) ."
 			from ". DB_TABLE_PREFIX ."translations
 			where code not regexp '^(settings_group:|settings_key:|cm|job|om|ot|pm|sm)_'"
 		);
@@ -114,7 +128,7 @@
 	if (empty($_GET['collections']) || in_array('modules', $_GET['collections'])) {
 		$sql_union[] = (
 			"select 'translation' as entity, frontend, backend, code, updated_at, html,
-				". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_GET['languages'])) ."
+				". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_GET['languages'])) ."
 			from ". DB_TABLE_PREFIX ."translations
 			where code regexp '^(cm|job|om|ot|pm|sm)_'"
 		);
@@ -123,7 +137,7 @@
 	if (empty($_GET['collections']) || in_array('setting_groups', $_GET['collections'])) {
 		$sql_union[] = (
 			"select 'translation' as entity, frontend, backend, code, updated_at, html,
-				". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_GET['languages'])) ."
+				". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_GET['languages'])) ."
 			from ". DB_TABLE_PREFIX ."translations
 			where code regexp '^settings_group:'"
 		);
@@ -132,7 +146,7 @@
 	if (empty($_GET['collections']) || in_array('settings', $_GET['collections'])) {
 		$sql_union[] = (
 			"select 'translation' as entity, frontend, backend, code, updated_at, html,
-				". implode(", ", array_map(function($language_code) { return "`text_". database::input($language_code) ."`"; }, $_GET['languages'])) ."
+				". implode(", ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."`"; }, $_GET['languages'])) ."
 			from ". DB_TABLE_PREFIX ."translations
 			where code regexp '^settings_key:'"
 		);
@@ -142,7 +156,7 @@
 		return (
 			"select '$entity' as entity, '1' as frontend, '1' as backend, concat('[". database::input($entity) ."', ':', id, ']". database::input($column) ."') as code, '' as updated_at,
 				coalesce(". implode(', ', array_map(function($language_code) use($column) { return "if(json_value(`". database::input($column) ."`, '$.". database::input($language_code) ."') regexp '<', 1, null)"; }, $_GET['languages'])) .", 0) as html,
-				". implode(', ', array_map(function($language_code) use($column) { return "json_value(`". $column ."`, '$.". database::input($language_code) ."') as `text_". database::input($language_code) ."`"; }, $_GET['languages'])) ."
+				". implode(', ', array_map(function($language_code) use($column) { return "json_value(`". $column ."`, '$.". database::input($language_code) ."') as `text_". database::identifier($language_code) ."`"; }, $_GET['languages'])) ."
 			from ". DB_TABLE_PREFIX . database::input($id)
 		);
 	};
@@ -164,8 +178,8 @@
 		where x.code != ''
 		". ((!empty($_GET['endpoint']) && $_GET['endpoint'] == 'frontend') ? "and frontend = 1" : "") ."
 		". ((!empty($_GET['endpoint']) && $_GET['endpoint'] == 'backend') ? "and backend = 1" : "") ."
-		". (!empty($_GET['untranslated']) ? "and (". implode(" or ", array_map(function($language_code) { return "`text_$language_code` = ''"; }, $_GET['languages'])) .")" : "") ."
-		". (!empty($_GET['query']) ? "and (code like '%". addcslashes(database::input($_GET['query']), '%_') ."%' or ". implode(' or ', array_map(function($language_code) { return "`text_". database::input($language_code) ."` like '%". addcslashes(database::input($_GET['query']), '%_') ."%'"; }, $_GET['languages'])) .")" : "") ."
+		". (!empty($_GET['untranslated']) ? "and (". implode(" or ", array_map(function($language_code) { return "`text_". database::identifier($language_code) ."` = ''"; }, $_GET['languages'])) .")" : "") ."
+		". (!empty($_GET['query']) ? "and (code like '%". addcslashes(database::input($_GET['query']), '%_') ."%' or ". implode(' or ', array_map(function($language_code) { return "`text_". database::identifier($language_code) ."` like '%". addcslashes(database::input($_GET['query']), '%_') ."%'"; }, $_GET['languages'])) .")" : "") ."
 		order by x.updated_at desc;"
 	)->fetch_page(null, null, $_GET['page'], settings::get('data_table_rows_per_page'), $num_rows, $num_pages);
 

--- a/public_html/includes/entities/ent_language.inc.php
+++ b/public_html/includes/entities/ent_language.inc.php
@@ -121,7 +121,7 @@
 					} else {
 						database::query(
 							"alter table ". DB_TABLE_PREFIX ."translations
-							change `text_". database::input($this->previous['code']) ."` `text_". database::input($this->data['code']) ."` text not null;"
+							change `text_". database::identifier($this->previous['code']) ."` `text_". database::identifier($this->data['code']) ."` text not null;"
 						);
 
 						foreach ([
@@ -167,11 +167,11 @@
 
 				if (!database::query(
 					"show fields from ". DB_TABLE_PREFIX ."translations
-					where `Field` = 'text_". database::input($this->data['code']) ."';"
+					where `Field` = 'text_". database::identifier($this->data['code']) ."';"
 				)->num_rows) {
 					database::query(
 						"alter table ". DB_TABLE_PREFIX ."translations
-						add `text_". database::input($this->data['code']) ."` text not null after text_en;"
+						add `text_". database::identifier($this->data['code']) ."` text not null after text_en;"
 					);
 				}
 			}
@@ -201,14 +201,24 @@
 				limit 1;"
 			);
 
-			if (database::query(
-				"show fields from ". DB_TABLE_PREFIX ."translations
-				where `Field` = 'text_". database::input($this->data['code']) ."';"
-			)->num_rows) {
-				database::query(
-					"alter table ". DB_TABLE_PREFIX ."translations
-					drop `text_". database::input($this->data['code']) ."`;"
-				);
+			// If the persisted code is a legacy/invalid identifier we still
+			// want the delete above to succeed — the bogus row is removed —
+			// but skip the column drop rather than crashing with a helper
+			// exception. A maligned code almost certainly never had a real
+			// text_<code> column anyway.
+			try {
+				$safe_code = database::identifier($this->data['code']);
+				if (database::query(
+					"show fields from ". DB_TABLE_PREFIX ."translations
+					where `Field` = 'text_". $safe_code ."';"
+				)->num_rows) {
+					database::query(
+						"alter table ". DB_TABLE_PREFIX ."translations
+						drop `". 'text_' . $safe_code ."`;"
+					);
+				}
+			} catch (InvalidArgumentException $e) {
+				error_log('ent_language::delete: skipping text_<code> drop for invalid code ' . var_export($this->data['code'], true));
 			}
 
 			foreach ([

--- a/public_html/includes/nodes/nod_database.inc.php
+++ b/public_html/includes/nodes/nod_database.inc.php
@@ -387,6 +387,40 @@
 			$input = addcslashes($input, '%_');
 			return $input;
 		}
+
+		/**
+		 * Validate a string for safe use as a backtick-quoted SQL identifier
+		 * (column or table base name). Unlike input(), which escapes string
+		 * literals, there is no portable way to escape inner backticks, so
+		 * the helper rejects anything outside the set A-Z / a-z / 0-9 / _ / -.
+		 *
+		 * Hyphen is included because BCP-47 locale codes ("zh-cn", "pt-br")
+		 * are valid inside MySQL backticks and LiteCart accepts them in the
+		 * language-create form. Everything else stays out so that semicolons,
+		 * quotes, whitespace and null bytes cannot leak through.
+		 *
+		 * Optional allowlist: when provided, the name must also be a member
+		 * of that list. Use it to pin to e.g. configured language codes:
+		 *     database::identifier($code, array_keys(language::$languages))
+		 *
+		 * Throws InvalidArgumentException on rejection. Callers catch this
+		 * and translate to a 400-level response or a skip-with-warning,
+		 * depending on whether the input came from a request or from the DB.
+		 */
+		public static function identifier($name, $allowlist = null) {
+
+			if (!is_string($name) || !preg_match('#^[A-Za-z0-9_-]+$#', $name)) {
+				throw new InvalidArgumentException('Invalid SQL identifier');
+			}
+
+			if ($allowlist !== null) {
+				if (!is_array($allowlist) || !in_array($name, $allowlist, true)) {
+					throw new InvalidArgumentException('SQL identifier not in allowlist');
+				}
+			}
+
+			return $name;
+		}
 	}
 
 	class database_statement {

--- a/public_html/includes/nodes/nod_language.inc.php
+++ b/public_html/includes/nodes/nod_language.inc.php
@@ -42,8 +42,20 @@
 			if (!self::$_cache['translations'] = cache::get(self::$_cache_token)) {
 				self::$_cache['translations'] = [];
 
+				// Guard: the selected code is embedded as a backtick-less
+				// column reference below. If it isn't a safe identifier
+				// (legacy data from before PROJ-22 hardening), fall back
+				// to text_en so the storefront still renders instead of
+				// crashing — and leave a trace in errors.log.
+				try {
+					$selected_column = 'text_' . database::identifier(self::$selected['code']);
+				} catch (InvalidArgumentException $e) {
+					error_log('nod_language: skipping invalid language code ' . var_export(self::$selected['code'], true) . ', falling back to text_en');
+					$selected_column = 'text_en';
+				}
+
 				database::query(
-					"select id, code, if(text_". self::$selected['code'] ." != '', text_". self::$selected['code'] .", text_en) as text
+					"select id, code, if($selected_column != '', $selected_column, text_en) as text
 					from ". DB_TABLE_PREFIX ."translations
 					where ". ((isset(route::$request['endpoint']) && route::$request['endpoint'] == 'backend') ? "backend = 1" : "frontend = 1") ."
 					having text != '';"

--- a/tests/sql_identifier.php
+++ b/tests/sql_identifier.php
@@ -1,0 +1,192 @@
+<?php
+
+	// Platform test for PROJ-22: database::identifier() helper.
+	// Purely static logic — no DB connection needed. The helper only
+	// calls preg_match() and in_array(), so we can exercise it without
+	// bootstrapping the whole app.
+
+	require_once __DIR__ . '/../public_html/includes/nodes/nod_database.inc.php';
+
+	try {
+
+		########################################################################
+		## AC-1: plain identifier pattern accepts alnum/underscore, rejects rest
+		########################################################################
+
+		echo 'Testing database::identifier pattern enforcement...';
+
+		$accepted = ['en', 'de', 'zh_cn', 'zh-cn', 'pt-br', 'en-gb', 'text_en', 'foo_bar_123', 'A', '_x'];
+		foreach ($accepted as $name) {
+			$result = database::identifier($name);
+			if ($result !== $name) {
+				throw new Exception("Expected identifier($name) to return unchanged, got " . var_export($result, true));
+			}
+		}
+
+		$rejected = [
+			'',                                // empty
+			'en`',                             // backtick
+			'en;',                             // semicolon
+			'en drop table',                   // space + keyword
+			"en\0",                            // null byte
+			'x`,(select 1)--',                 // injection payload from audit finding
+			"\xf0\x9f\x98\x80",                // emoji
+			'en.us',                           // dot
+			'en us',                           // whitespace
+		];
+		foreach ($rejected as $name) {
+			$threw = false;
+			try {
+				database::identifier($name);
+			} catch (InvalidArgumentException $e) {
+				$threw = true;
+			}
+			if (!$threw) {
+				throw new Exception("Expected identifier(" . var_export($name, true) . ") to throw, but it did not");
+			}
+		}
+
+		// Type-guard: non-strings must be rejected.
+		foreach ([null, 123, ['en'], new stdClass()] as $non_string) {
+			$threw = false;
+			try {
+				database::identifier($non_string);
+			} catch (InvalidArgumentException $e) {
+				$threw = true;
+			} catch (TypeError $e) {
+				$threw = true; // stricter PHP behaviour is also acceptable
+			}
+			if (!$threw) {
+				throw new Exception("Expected identifier(non-string) to throw, but it did not");
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## AC-2: allowlist enforcement
+		########################################################################
+
+		echo 'Testing allowlist enforcement...';
+
+		// Legitimate membership.
+		$result = database::identifier('en', ['en', 'de', 'fr']);
+		if ($result !== 'en') {
+			throw new Exception('Allowlisted name should pass through');
+		}
+
+		// Not a member → reject.
+		$threw = false;
+		try {
+			database::identifier('it', ['en', 'de', 'fr']);
+		} catch (InvalidArgumentException $e) {
+			$threw = true;
+		}
+		if (!$threw) {
+			throw new Exception('Non-allowlisted name should throw');
+		}
+
+		// Empty allowlist → everything rejected.
+		$threw = false;
+		try {
+			database::identifier('en', []);
+		} catch (InvalidArgumentException $e) {
+			$threw = true;
+		}
+		if (!$threw) {
+			throw new Exception('Empty allowlist should reject every identifier');
+		}
+
+		// Case-sensitive on purpose: SQL identifiers in MySQL are
+		// case-insensitive, but our app consistently uses lowercase.
+		$threw = false;
+		try {
+			database::identifier('EN', ['en', 'de']);
+		} catch (InvalidArgumentException $e) {
+			$threw = true;
+		}
+		if (!$threw) {
+			throw new Exception('Allowlist must be strict / case-sensitive');
+		}
+
+		// Null allowlist → only regex check applies.
+		$result = database::identifier('anything_valid', null);
+		if ($result !== 'anything_valid') {
+			throw new Exception('Null allowlist should fall back to regex-only');
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		########################################################################
+		## AC-3/4/5/6/7/8/9: verify the callers have been migrated
+		########################################################################
+
+		echo 'Cross-checking call sites use database::identifier()...';
+
+		$expectations = [
+			'public_html/backend/apps/localization/translations/translations.inc.php' => [
+				'required' => [
+					'database::identifier($_lang_code, $allowed_language_codes)', // early validate
+					'database::identifier($language_code)',                       // identifier context
+				],
+				'forbidden' => [
+					'`text_$language_code`', // raw PHP interpolation into backtick context
+					'`text_". database::input($language_code) ."`', // old escape-only pattern
+				],
+			],
+			'public_html/backend/apps/localization/translations/csv.inc.php' => [
+				'required' => [
+					'database::identifier($_lang_code, $allowed_language_codes)',
+					'database::identifier($language_code)',
+				],
+				'forbidden' => [
+					'`text_". database::input($language_code) ."`',
+				],
+			],
+			'public_html/backend/apps/localization/languages/edit_language.inc.php' => [
+				'required' => [
+					"preg_match('#^[a-z]{2,5}",
+					'database::identifier($language->data[\'code\'])',
+				],
+				'forbidden' => [
+					'`text_". database::input($language->data[\'code\']) ."`',
+				],
+			],
+			'public_html/includes/entities/ent_language.inc.php' => [
+				'required' => [
+					'database::identifier($this->previous[\'code\'])',
+					'database::identifier($this->data[\'code\'])',
+				],
+				'forbidden' => [
+					'`text_". database::input($this->data[\'code\']) ."`',
+					'`text_". database::input($this->previous[\'code\']) ."`',
+				],
+			],
+		];
+
+		foreach ($expectations as $file => $expect) {
+			$content = file_get_contents(__DIR__ . '/../' . $file);
+			if ($content === false) {
+				throw new Exception("Could not read $file");
+			}
+			foreach ($expect['required'] as $needle) {
+				if (strpos($content, $needle) === false) {
+					throw new Exception("Missing expected migration marker in $file: $needle");
+				}
+			}
+			foreach ($expect['forbidden'] as $needle) {
+				if (strpos($content, $needle) !== false) {
+					throw new Exception("Forbidden legacy pattern still present in $file: $needle");
+				}
+			}
+		}
+
+		echo ' [OK]' . PHP_EOL;
+
+		echo PHP_EOL . 'All PROJ-22 identifier tests passed.' . PHP_EOL;
+		return true;
+
+	} catch (Throwable $e) {
+		echo PHP_EOL . 'FAILED: ' . $e->getMessage() . PHP_EOL;
+		return false;
+	}


### PR DESCRIPTION
Closes #476. `database::input()` is in the escape-quotes business, not the escape-backticks business.

## What changes

| File | Change |
|---|---|
| `includes/nodes/nod_database.inc.php` | New `database::identifier($name, $allowlist = null)` helper — regex `^[A-Za-z0-9_-]+$`, optional allowlist, throws `InvalidArgumentException` |
| `backend/apps/localization/translations/translations.inc.php` | Early-validates `$_GET['languages']` against `array_keys(language::$languages)`; six identifier splice points migrated |
| `backend/apps/localization/translations/csv.inc.php` | Same early-validate on `$_POST['language_codes']`; four splice points migrated; filename slot in `Content-Disposition` gets a whitelist filter |
| `backend/apps/localization/languages/edit_language.inc.php` | Server-side pattern check `^[a-z]{2,5}(-[a-z0-9]{2,8})?$` on `$_POST['code']` (the HTML `pattern` attribute was client-side only); initial-translation insert uses the helper |
| `includes/entities/ent_language.inc.php` | Rename, create, and drop DDL paths use the helper; delete path wraps the column drop in try/catch so the `lc_languages` row removal still succeeds when a legacy code is invalid |
| `includes/nodes/nod_language.inc.php` | Render path validates `self::$selected['code']` and falls back to `text_en` (with `error_log`) if it fails — legacy malign rows don't break the storefront |
| `tests/sql_identifier.php` | New — helper unit tests (7 accept, 9 reject, incl. `x\`,(select 1)--`, null byte, emoji) + grep-based call-site cross-check |

## Why

Three identifier splice paths shared the same root cause:

- `backend/apps/localization/translations/translations.inc.php` and `.../csv.inc.php` build `` `text_<code>` `` from `$_GET['languages']` / `$_POST['language_codes']`. `database::input()` escapes `'` but not `` ` `` — so an authenticated admin could break out with a payload like `en\`,(select password_hash from lc_administrators limit 1) as \`text_leak` and exfiltrate from unrelated tables.
- `edit_language.inc.php` stored whatever code was POSTed (pattern enforcement was client-side only). `ent_language` later interpolated that code into `ALTER TABLE … change \`text_<old>\` \`text_<new>\`` — second-order DDL injection.
- `nod_language.inc.php:46` read the stored code and spliced it into `text_<code>` at request time, making even a pre-existing malign row in `lc_languages` a continuing SQL sink.

## Design notes

**Helper semantics.** `database::identifier()` is deliberately strict: only `[A-Za-z0-9_-]`. Hyphen is included because BCP-47 codes like `zh-cn` are valid MySQL identifiers inside backticks, and the app already accepts them in the create form. Everything else — whitespace, quotes, semicolons, null bytes, emoji — throws. The optional allowlist is a second gate for request-boundary use.

**Defense in depth.** The helper runs both at request boundary (translations, CSV) and at SQL-build (ent_language). Paying a regex twice is cheap; it protects against future refactors that reorder validation.

**Legacy data.** Shops that already stored a malign code (e.g. exploited before this fix landed) would otherwise be locked out, because every identifier() call would throw. Read paths (`nod_language`, `ent_language::delete`) catch the exception, `error_log` a warning, and fall back — the storefront keeps rendering and admins can still delete the bogus row. Write paths stay hard: a new malign code never makes it past the server-side pattern check.

## Test plan

- [x] `tests/sql_identifier.php` — 3 suites, all green
  - 10 accept cases (incl. `zh-cn`, `pt-br`, `en-gb`, `text_en`, `_x`, `foo_bar_123`)
  - 9 reject cases (backtick, semicolon, space, null byte, audit injection payload, emoji, dot, whitespace)
  - Allowlist enforcement (member / non-member / empty / case-sensitive)
  - Grep-based cross-check on the four migrated files (required markers present, forbidden legacy patterns absent)
- [x] `php -l` across the 6 touched source files + test — no syntax errors
- [x] Live sanity: `database::identifier('zh-cn')` returns `"zh-cn"`
- [ ] Manual: on staging, attempt `GET /admin/localization/translations/translations?languages[]=en%60,(select...)` → 400, no DDL in the log
- [ ] Manual: rename an existing language with a hyphenated code (`en-gb`) → `ALTER TABLE` runs; `text_en-gb` exists afterwards

## Rollback

Single commit. `git revert <sha>` restores the prior behaviour. No data migration, no schema change.

## Not in this PR

- Identifier-style hardening for other `database::input()`-in-backticks sites outside the audit scope (if any).
- PDO migration — MySQLi doesn't offer placeholders for identifiers; the helper is the pragmatic equivalent.
- Schema rotation for previously compromised codes — operators should SELECT `lc_languages.code` once and clean up anything unusual before upgrading.