### PR TITLE
[v3] Fix undefined $field blocking email update in account edit

### DIFF
--- a/public_html/frontend/pages/account/edit.inc.php
+++ b/public_html/frontend/pages/account/edit.inc.php
@@ -73,7 +73,7 @@
 				}
 			}
 
-			if (isset($_POST[$field])) {
+			if (isset($_POST['email'])) {
 				$customer->data['email'] = $_POST['email'];
 			}
 


### PR DESCRIPTION
Tiny one while I had the file open — the email update in the frontend account edit has been silently broken.

## Summary
| Change | File |
|---|---|
| Replace undefined `$field` with the literal `'email'` in the `save_account` branch so the email address is actually copied into the customer object | `public_html/frontend/pages/account/edit.inc.php:76` |

## Why it matters
The `save_account` branch uses `isset($_POST[$field])` but `$field` is only initialised in the later `foreach` loop that belongs to `save_details`. In the `save_account` path the variable is undefined, the guard is always false, and `$customer->data['email']` never receives the posted value. Existing customers cannot change their email address through the frontend account edit at the moment.

## Test plan
- [ ] Sign in as a customer, open account edit, change the email, enter current password, submit
- [ ] Verify the stored email is updated and subsequent sign-in works with the new email