### PR TITLE
[v3] Fix tests/database.php never returning true on pass

### DIFF
--- a/tests/database.php
+++ b/tests/database.php
@@ -56,6 +56,8 @@
 			throw new Exception('Expected 2 pages, got '. $num_pages);
 		}
 
+		return true;
+
 	} catch (Exception $e) {
 
 		echo ' [FAILED]' . PHP_EOL . 'Error: '. $e->getMessage();


### PR DESCRIPTION
Noticed this while triaging the platform-test suite — the database test itself is broken in a way that only shows because `continue-on-error` on the runner step masks it.

## Summary
| Change | File |
|---|---|
| Add the missing `return true;` after the last assertion so a successful run actually returns truthy to the runner | `tests/database.php` |

## Why
The test body has `return false` inside the `catch` block but no matching `return true` at the end of the `try` block. A successful run falls through and returns `null`. The runner checks `=== true` and flags the test as `[FAIL]`, even though every assertion passed.

## CI side-effect
Because `platform_tests.php` exits with code 1 on the first failing test, and `database.php` is alphabetically near the top, every test after it never runs. The CI step has `continue-on-error: true` so the job still shows green, but subsequent tests contribute zero signal. With this fix the runner gets past `database.php` and actually starts exercising later tests again.

There are other preexisting failures surfaced by that progression (`func_catalog`, `nod_database`, `nod_settings`, `checkout`/`order` under strict `sql_mode`) — separate issue, not in this PR.

## Test plan
- [ ] `php .git-hooks/pre-commit.d/platform_tests.php` — `database.php` reports `[OK]` and the runner continues past it
- [ ] CI shows `database.php` passing in the Platform Tests job log