### PR TITLE
[v3] Harden session expiry and password reset flow (PROJ-23)

### DIFF
--- a/public_html/frontend/pages/account/edit.inc.php
+++ b/public_html/frontend/pages/account/edit.inc.php
@@ -68,7 +68,7 @@
 					throw new Exception(t('error_passwords_missmatch', 'The passwords did not match.'));
 				}
 
-				if (!f::password_check_strength($_POST['password'])) {
+				if (!f::password_check_strength($_POST['new_password'])) {
 					throw new Exception(t('error_password_not_strong_enough', 'The password is not strong enough'));
 				}
 			}

--- a/public_html/frontend/pages/account/reset_password.inc.php
+++ b/public_html/frontend/pages/account/reset_password.inc.php
@@ -28,15 +28,13 @@
 				limit 1;"
 			)->fetch();
 
-			if (!$customer) {
-				throw new Exception(t('error_email_not_in_database', 'The email address does not exist in our database.'));
-			}
-
-			if (empty($customer['status'])) {
-				throw new Exception(t('error_account_inactive', 'Your account is inactive, contact customer support'));
-			}
-
 			if (!empty($_REQUEST['reset_token'])) {
+
+				// Reset-token branch: the token itself is the secret, so unknown or
+				// inactive accounts surface as a generic "invalid reset token" error.
+				if (!$customer || empty($customer['status'])) {
+					throw new Exception(t('error_invalid_reset_token', 'Invalid reset token'));
+				}
 
 				if (!$reset_token = json_decode($customer['password_reset_token'], true)) {
 					throw new Exception(t('error_invalid_reset_token', 'Invalid reset token'));
@@ -75,43 +73,52 @@
 
 			if (empty($_REQUEST['reset_token'])) {
 
-				$reset_token = [
-					'token' => bin2hex(random_bytes(24)),
-					'expires' => date('Y-m-d H:i:s', strtotime('+15 minutes')),
-				];
+				// Uniform-response branch: never leak whether the email belongs to a known or active account.
+				if ($customer && !empty($customer['status'])) {
 
-				database::query(
-					"update ". DB_TABLE_PREFIX ."customers
-					set password_reset_token = '". database::input(f::format_json($reset_token, false)) ."'
-					where id = ". (int)$customer['id'] ."
-					limit 1;"
-				);
+					$reset_token = [
+						'token' => bin2hex(random_bytes(24)),
+						'expires' => date('Y-m-d H:i:s', strtotime('+15 minutes')),
+					];
 
-				$aliases = [
-					'{email}' => $customer['email'],
-					'{store_name}' => settings::get('store_name'),
-					'{token}' => $reset_token['token'],
-					'{link}' => document::ilink('account/reset_password', ['email' => $customer['email'], 'reset_token' => $reset_token['token']]),
-				];
+					database::query(
+						"update ". DB_TABLE_PREFIX ."customers
+						set password_reset_token = '". database::input(f::format_json($reset_token, false)) ."'
+						where id = ". (int)$customer['id'] ."
+						limit 1;"
+					);
 
-				$subject = t('title_reset_password', 'Reset Password');
-				$message = strtr(implode("\r\n", [
-					t('email_body_reset_password_intro', "You recently requested to reset your password for {store_name}."),
-					t('email_body_reset_password_ignore', "If you did not request a password reset, please ignore this email."),
-					t('email_body_reset_password_instruction', "Visit the link below to reset your password:"),
-					"",
-					"{link}",
-					"",
-					t('email_body_reset_password_token', "Reset Token: {token}")
-				]), $aliases);
+					$aliases = [
+						'{email}' => $customer['email'],
+						'{store_name}' => settings::get('store_name'),
+						'{token}' => $reset_token['token'],
+						'{link}' => document::ilink('account/reset_password', ['email' => $customer['email'], 'reset_token' => $reset_token['token']]),
+					];
 
-				(new ent_email())
-					->add_recipient($customer['email'], $customer['firstname'] .' '. $customer['lastname'])
-					->set_subject($subject)
-					->add_body($message)
-					->send();
+					$subject = t('title_reset_password', 'Reset Password');
+					$message = strtr(implode("\r\n", [
+						t('email_body_reset_password_intro', "You recently requested to reset your password for {store_name}."),
+						t('email_body_reset_password_ignore', "If you did not request a password reset, please ignore this email."),
+						t('email_body_reset_password_instruction', "Visit the link below to reset your password:"),
+						"",
+						"{link}",
+						"",
+						t('email_body_reset_password_token', "Reset Token: {token}")
+					]), $aliases);
 
-				notices::add('success', t('success_reset_password_email_sent', 'An email with instructions has been sent to your email address.'));
+					(new ent_email())
+						->add_recipient($customer['email'], $customer['firstname'] .' '. $customer['lastname'])
+						->set_subject($subject)
+						->add_body($message)
+						->send();
+
+				} else {
+
+					// Timing-neutral dummy path so unknown/inactive accounts respond in the same ballpark as real sends.
+					usleep(random_int(200000, 500000));
+				}
+
+				notices::add('success', t('success_reset_password_email_sent_uniform', 'If an account exists for this email, instructions have been sent.'));
 				redirect(document::ilink('account/reset_password', ['email' => $_REQUEST['email'], 'reset_token' => '']), 303);
 				exit;
 
@@ -119,7 +126,8 @@
 
 				$customer = new ent_customer($customer['id']);
 				$customer->set_password($_POST['new_password']);
-				$customer->data['password_reset_token'] = '';
+				$customer->data['sessions_expiry'] = date('Y-m-d H:i:s');
+				$customer->save();
 
 				notices::add('success', t('success_new_password_set', 'Your new password has been set. You may now sign in.'));
 				redirect(document::ilink('account/sign_in', ['email' => $customer->data['email']]), 303);

--- a/public_html/includes/entities/ent_customer.inc.php
+++ b/public_html/includes/entities/ent_customer.inc.php
@@ -183,12 +183,17 @@
 
 			database::query(
 				"update ". DB_TABLE_PREFIX ."customers
-				set password_hash = '". database::input($this->data['password_hash'] = password_hash($password, PASSWORD_DEFAULT)) ."'
+				set password_hash = '". database::input($this->data['password_hash'] = password_hash($password, PASSWORD_DEFAULT)) ."',
+					password_reset_token = ''
 				where id = ". (int)$this->data['id'] ."
 				limit 1;"
 			);
 
-			$this->previous['password_hash'] = $this->data['password_hash'];
+			$this->data['password_reset_token'] = '';
+
+			// Re-sync the full snapshot so a later save() does not roll back values that were changed
+			// between set_password() and save() (e.g. sessions_expiry during the reset flow).
+			$this->previous = $this->data;
 		}
 
 		public function send_email($type='account_created') {

--- a/public_html/includes/nodes/nod_customer.inc.php
+++ b/public_html/includes/nodes/nod_customer.inc.php
@@ -106,10 +106,8 @@
 						throw new Exception(t('error_your_account_is_disabled', 'Your account is disabled'));
 					}
 
-					if (!empty($customer['sessions_expiry'])) {
-						if (!isset(session::$data['customer_security_timestamp']) || session::$data['customer_security_timestamp'] < strtotime($customer['sessions_expiry'])) {
-							throw new Exception(t('error_session_expired_due_to_account_changes', 'Session expired due to changes in the account'));
-						}
+					if (self::is_session_expired($customer)) {
+						throw new Exception(t('error_session_expired_due_to_account_changes', 'Session expired due to changes in the account'));
 					}
 
 					session::$data['customer'] = array_replace(session::$data['customer'], array_intersect_key($customer, session::$data['customer']));
@@ -374,6 +372,22 @@
 
 		public static function check_login() {
 			if (!empty(self::$data['id'])) return true;
+		}
+
+		// Returns true when the current session's customer_security_timestamp is older than
+		// the customer's sessions_expiry (or missing entirely). Used by init() to revoke
+		// sessions after a password reset or similar security event.
+		public static function is_session_expired($customer_row) {
+
+			if (empty($customer_row['sessions_expiry'])) {
+				return false;
+			}
+
+			if (!isset(session::$data['customer_security_timestamp'])) {
+				return true;
+			}
+
+			return session::$data['customer_security_timestamp'] < strtotime($customer_row['sessions_expiry']);
 		}
 
 		public static function log($event) {

--- a/public_html/includes/nodes/nod_session.inc.php
+++ b/public_html/includes/nodes/nod_session.inc.php
@@ -187,12 +187,14 @@
 			$session = database::query(
 				"select * from ". DB_TABLE_PREFIX ."sessions
 				where id = '". database::input($session_id) ."'
+				and expires_at > '". database::input(date('Y-m-d H:i:s')) ."'
 				limit 1;"
 			)->fetch(function(&$row){
 				$row['data'] = $row['data'] ? json_decode($row['data'], true) : [];
 			});
 
 			if (!$session) {
+				self::generate_id();
 				return false;
 			}
 
@@ -214,18 +216,21 @@
 			}
 
 			// Save only the payload without pretty printing to reduce storage
+			$expires_at = date('Y-m-d H:i:s', strtotime('+1 hour'));
+
 			database::query(
 				"insert into ". DB_TABLE_PREFIX ."sessions
-				(id, data, updated_at, created_at)
+				(id, data, expires_at, updated_at, created_at)
 				values (
 					'". database::input(self::$data['id']) ."',
 					'". database::input(f::format_json(self::$data)) ."',
+					'". database::input($expires_at) ."',
 					'". database::input(date('Y-m-d H:i:s')) ."',
 					'". database::input(date('Y-m-d H:i:s')) ."'
 				)
 				on duplicate key update
 					data = '". database::input(f::format_json(self::$data)) ."',
-					expires_at = '". database::input(date('Y-m-d H:i:s', strtotime('+1 hour'))) ."',
+					expires_at = '". database::input($expires_at) ."',
 					updated_at = '". database::input(date('Y-m-d H:i:s')) ."';"
 			);
 

--- a/tests/password_strength_new.php
+++ b/tests/password_strength_new.php
@@ -1,0 +1,46 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		########################################################################
+		## edit.inc.php must run password_check_strength on new_password,
+		## never on the current-password field.
+		########################################################################
+
+		$path = f::file_resolve_path(__DIR__.'/../public_html/frontend/pages/account/edit.inc.php');
+		$content = file_get_contents($path);
+
+		if ($content === false) {
+			throw new Exception('Could not read edit.inc.php');
+		}
+
+		if (!preg_match('/password_check_strength\(\s*\$_POST\[\s*\'new_password\'\s*\]/', $content)) {
+			throw new Exception('edit.inc.php does not call password_check_strength on $_POST[new_password]');
+		}
+
+		if (preg_match('/password_check_strength\(\s*\$_POST\[\s*\'password\'\s*\]/', $content)) {
+			throw new Exception('edit.inc.php still calls password_check_strength on $_POST[password] (typo regression)');
+		}
+
+		########################################################################
+		## Behavioural contract: weak new password must be rejected,
+		## strong new password must be accepted by the helper.
+		########################################################################
+
+		if (f::password_check_strength('weak')) {
+			throw new Exception('password_check_strength accepted a weak password');
+		}
+
+		if (!f::password_check_strength('Str0ng!Pass99')) {
+			throw new Exception('password_check_strength rejected a strong password');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+	}

--- a/tests/reset_session_revoke.php
+++ b/tests/reset_session_revoke.php
@@ -1,0 +1,105 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$auto_increment_id = database::query(
+			"SHOW TABLE STATUS LIKE '". DB_TABLE_PREFIX ."customers';"
+		)->fetch('Auto_increment');
+
+		database::query("start transaction;");
+
+		########################################################################
+		## Create a customer
+		########################################################################
+
+		$customer = new ent_customer();
+		$customer->data = f::array_update($customer->data, [
+			'status' => 1,
+			'firstname' => 'Revoke',
+			'lastname' => 'Target',
+			'email' => 'revoke.target@example.com',
+			'phone' => '555-0102',
+			'password' => 'InitialPass!2',
+		]);
+		$customer->save();
+
+		$customer_id = $customer->data['id'];
+
+		if (!$customer_id) {
+			throw new Exception('Failed to create test customer');
+		}
+
+		########################################################################
+		## Simulate the reset flow: set_password + sessions_expiry = now + save
+		########################################################################
+
+		$customer = new ent_customer($customer_id);
+		$customer->set_password('BrandNew!Pass43');
+		$customer->data['sessions_expiry'] = date('Y-m-d H:i:s');
+		$customer->save();
+
+		$row = database::query(
+			"select * from ". DB_TABLE_PREFIX ."customers
+			where id = ". (int)$customer_id ."
+			limit 1;"
+		)->fetch();
+
+		if (empty($row['sessions_expiry'])) {
+			throw new Exception('sessions_expiry was not persisted after save()');
+		}
+
+		if (abs(strtotime($row['sessions_expiry']) - time()) > 5) {
+			throw new Exception('sessions_expiry is not near current time (got '. $row['sessions_expiry'] .')');
+		}
+
+		########################################################################
+		## Verify the live enforcement helper (customer::is_session_expired)
+		## — same code path that nod_customer::init() uses to revoke stale sessions.
+		########################################################################
+
+		// Older session timestamp → expired (another device still holding an old session).
+		session::$data['customer_security_timestamp'] = strtotime($row['sessions_expiry']) - 3600;
+		if (customer::is_session_expired($row) !== true) {
+			throw new Exception('is_session_expired() accepted an older customer_security_timestamp');
+		}
+
+		// Newer session timestamp → still valid (the device that actually performed the reset).
+		session::$data['customer_security_timestamp'] = strtotime($row['sessions_expiry']) + 3600;
+		if (customer::is_session_expired($row) !== false) {
+			throw new Exception('is_session_expired() rejected a newer customer_security_timestamp');
+		}
+
+		// Missing timestamp (legacy / never initialised) → expired.
+		unset(session::$data['customer_security_timestamp']);
+		if (customer::is_session_expired($row) !== true) {
+			throw new Exception('is_session_expired() accepted a missing customer_security_timestamp');
+		}
+
+		########################################################################
+		## Baseline: a customer without sessions_expiry must not be flagged,
+		## regardless of session state.
+		########################################################################
+
+		$baseline = ['sessions_expiry' => null];
+		unset(session::$data['customer_security_timestamp']);
+		if (customer::is_session_expired($baseline) !== false) {
+			throw new Exception('is_session_expired() incorrectly flagged a customer without sessions_expiry');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+
+		database::query('rollback;');
+
+		database::query(
+			"ALTER TABLE ". DB_TABLE_PREFIX ."customers AUTO_INCREMENT = ". (int)$auto_increment_id .";"
+		);
+	}

--- a/tests/reset_token_invalidation.php
+++ b/tests/reset_token_invalidation.php
@@ -1,0 +1,114 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$auto_increment_id = database::query(
+			"SHOW TABLE STATUS LIKE '". DB_TABLE_PREFIX ."customers';"
+		)->fetch('Auto_increment');
+
+		database::query("start transaction;");
+
+		########################################################################
+		## Create a customer carrying an active reset token
+		########################################################################
+
+		$customer = new ent_customer();
+		$customer->data = f::array_update($customer->data, [
+			'status' => 1,
+			'firstname' => 'Reset',
+			'lastname' => 'Target',
+			'email' => 'reset.target@example.com',
+			'phone' => '555-0101',
+			'password' => 'InitialPass!1',
+		]);
+		$customer->save();
+
+		$customer_id = $customer->data['id'];
+
+		if (!$customer_id) {
+			throw new Exception('Failed to create test customer');
+		}
+
+		$reset_token_payload = f::format_json([
+			'token' => bin2hex(random_bytes(24)),
+			'expires' => date('Y-m-d H:i:s', strtotime('+15 minutes')),
+		], false);
+
+		database::query(
+			"update ". DB_TABLE_PREFIX ."customers
+			set password_reset_token = '". database::input($reset_token_payload) ."'
+			where id = ". (int)$customer_id ."
+			limit 1;"
+		);
+
+		$before = database::query(
+			"select password_hash, password_reset_token
+			from ". DB_TABLE_PREFIX ."customers
+			where id = ". (int)$customer_id ."
+			limit 1;"
+		)->fetch();
+
+		if (empty($before['password_reset_token'])) {
+			throw new Exception('Pre-condition failed: reset token was not persisted');
+		}
+
+		########################################################################
+		## set_password() must invalidate the reset token in the same update
+		########################################################################
+
+		$customer = new ent_customer($customer_id);
+		$customer->set_password('BrandNew!Pass42');
+
+		$after = database::query(
+			"select password_hash, password_reset_token
+			from ". DB_TABLE_PREFIX ."customers
+			where id = ". (int)$customer_id ."
+			limit 1;"
+		)->fetch();
+
+		if ($after['password_hash'] === $before['password_hash']) {
+			throw new Exception('set_password() did not update password_hash');
+		}
+
+		if (!empty($after['password_reset_token'])) {
+			throw new Exception('set_password() did not clear password_reset_token (got: '. var_export($after['password_reset_token'], true) .')');
+		}
+
+		if (!password_verify('BrandNew!Pass42', $after['password_hash'])) {
+			throw new Exception('set_password() stored an unverifiable hash');
+		}
+
+		########################################################################
+		## Reset token must not be reusable after password change
+		########################################################################
+
+		$stored = json_decode($reset_token_payload, true);
+
+		$row = database::query(
+			"select id from ". DB_TABLE_PREFIX ."customers
+			where id = ". (int)$customer_id ."
+			and password_reset_token = '". database::input($reset_token_payload) ."'
+			limit 1;"
+		)->fetch();
+
+		if ($row) {
+			throw new Exception('The old reset token is still resolvable after password change');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+
+		database::query('rollback;');
+
+		database::query(
+			"ALTER TABLE ". DB_TABLE_PREFIX ."customers AUTO_INCREMENT = ". (int)$auto_increment_id .";"
+		);
+	}

--- a/tests/session_expiry.php
+++ b/tests/session_expiry.php
@@ -1,0 +1,142 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		database::query("start transaction;");
+
+		########################################################################
+		## Expired session row must be rejected by session::load()
+		########################################################################
+
+		$session_id = bin2hex(random_bytes(24));
+		$payload = f::format_json([
+			'id' => $session_id,
+			'customer' => ['id' => 999999, 'email' => 'ghost@example.com'],
+			'administrator' => ['id' => 888888, 'username' => 'ghostadmin'],
+		]);
+
+		database::query(
+			"insert into ". DB_TABLE_PREFIX ."sessions
+			(id, data, expires_at, updated_at, created_at)
+			values (
+				'". database::input($session_id) ."',
+				'". database::input($payload) ."',
+				'". database::input(date('Y-m-d H:i:s', strtotime('-1 hour'))) ."',
+				'". database::input(date('Y-m-d H:i:s', strtotime('-2 hours'))) ."',
+				'". database::input(date('Y-m-d H:i:s', strtotime('-2 hours'))) ."'
+			);"
+		);
+
+		$loaded = session::load($session_id);
+
+		if ($loaded !== false) {
+			throw new Exception('session::load() accepted an expired session row');
+		}
+
+		if (!empty(session::$data['customer']['id'])) {
+			throw new Exception('Expired session payload leaked into session::$data');
+		}
+
+		if (empty(session::$data['id']) || session::$data['id'] === $session_id) {
+			throw new Exception('Expired session load did not rotate the session id');
+		}
+
+		// Rebind the session-backed references the same way customer::init() / administrator::init()
+		// would — session::reset() replaced the underlying array, so any earlier references are stale.
+		if (!isset(session::$data['customer']) || !is_array(session::$data['customer'])) {
+			session::$data['customer'] = [];
+		}
+		if (!isset(session::$data['administrator']) || !is_array(session::$data['administrator'])) {
+			session::$data['administrator'] = [];
+		}
+		customer::$data = &session::$data['customer'];
+		administrator::$data = &session::$data['administrator'];
+
+		if (customer::check_login() === true) {
+			throw new Exception('customer::check_login() returned true after expired session rejection');
+		}
+
+		if (administrator::check_login() === true) {
+			throw new Exception('administrator::check_login() returned true after expired session rejection');
+		}
+
+		########################################################################
+		## Fresh (non-expired) session row must still load correctly
+		########################################################################
+
+		$fresh_id = bin2hex(random_bytes(24));
+		$fresh_payload = f::format_json([
+			'id' => $fresh_id,
+			'customer' => ['id' => 42, 'email' => 'alive@example.com'],
+		]);
+
+		database::query(
+			"insert into ". DB_TABLE_PREFIX ."sessions
+			(id, data, expires_at, updated_at, created_at)
+			values (
+				'". database::input($fresh_id) ."',
+				'". database::input($fresh_payload) ."',
+				'". database::input(date('Y-m-d H:i:s', strtotime('+1 hour'))) ."',
+				'". database::input(date('Y-m-d H:i:s')) ."',
+				'". database::input(date('Y-m-d H:i:s')) ."'
+			);"
+		);
+
+		$loaded = session::load($fresh_id);
+
+		if ($loaded !== true) {
+			throw new Exception('session::load() rejected a non-expired session row');
+		}
+
+		if (empty(session::$data['customer']['id']) || session::$data['customer']['id'] !== 42) {
+			throw new Exception('Fresh session payload did not restore correctly');
+		}
+
+		########################################################################
+		## session::save() must populate expires_at on INSERT, not just UPDATE
+		########################################################################
+
+		$save_id = bin2hex(random_bytes(24));
+		session::reset();
+		session::$data['id'] = $save_id;
+		session::$data['probe'] = 'insert-sets-expiry';
+		session::save();
+
+		$row = database::query(
+			"select expires_at from ". DB_TABLE_PREFIX ."sessions
+			where id = '". database::input($save_id) ."'
+			limit 1;"
+		)->fetch();
+
+		if (empty($row['expires_at'])) {
+			throw new Exception('session::save() did not populate expires_at on INSERT');
+		}
+
+		if (strtotime($row['expires_at']) <= time()) {
+			throw new Exception('session::save() populated expires_at in the past');
+		}
+
+		session::reset();
+		$loaded = session::load($save_id);
+
+		if ($loaded !== true) {
+			throw new Exception('session::load() could not reload a freshly saved session');
+		}
+
+		if (empty(session::$data['probe']) || session::$data['probe'] !== 'insert-sets-expiry') {
+			throw new Exception('Freshly saved session payload did not round-trip');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+
+		database::query('rollback;');
+	}


### PR DESCRIPTION
Small one — three tiny auth gaps that add up to a decent attack chain in the customer flow.

## Summary
| Area | Change |
|---|---|
| Session expiry | `nod_session::load()` now rejects rows with `expires_at <= now()` and rotates the session id on miss; `save()` populates `expires_at` on INSERT too, so fresh sessions are not immediately treated as expired |
| Reset token | `ent_customer::set_password()` clears `password_reset_token` in the same update as the new hash and resyncs `$this->previous`; the reset branch in `account/reset_password` now calls `$customer->save()` with `sessions_expiry = now` to revoke parallel sessions |
| Enumeration oracle | The request branch collapses the three distinct error messages (unknown / inactive / normal) into a single uniform success notice; unknown or inactive accounts run a randomized `usleep(200–500ms)` dummy to keep response time in the same ballpark as the real send path |
| Edit strength check | `edit.inc.php` now runs `password_check_strength()` against `new_password` instead of the current password (one-character typo) |
| Testability | New `customer::is_session_expired($row)` extracted from `init()` so the revoke check is directly testable instead of reproduced in test logic |

## Why
The customer session and password-reset chain had four related gaps from an internal audit:
- expired session rows stayed authoritative because `load()` never checked `expires_at`
- `password_reset_token` was cleared in memory but not persisted after `set_password()`
- the forgot-password form returned three distinct error messages, so it worked as an email-verification oracle
- `account/edit` ran the strength check against the old password, so a strong current password let a weak new one through

All four hang off the customer-session-and-reset chain; fixing only some leaves the chain alive.

## Tests
New platform tests (`tests/*.php`, run via `php .git-hooks/pre-commit.d/platform_tests.php`):
| Test | Covers |
|---|---|
| `session_expiry.php` | Expired row rejected, new id rotated, `customer::check_login()` / `administrator::check_login()` stay not-true; `save()`→`load()` round-trip for fresh sessions |
| `reset_token_invalidation.php` | `password_reset_token` cleared in the same update as the new hash, and no longer resolvable |
| `reset_session_revoke.php` | `customer::is_session_expired()` flags older / missing `customer_security_timestamp`, accepts newer, passes through for accounts without `sessions_expiry` |
| `password_strength_new.php` | `edit.inc.php` checks `new_password` (static + behavioural assertion) |

Regression spot-checks: `customer.php`, `administrator.php`, `cart.php`, `func_password.php` all green.

## Notes
- The uniform-response message uses a new translation key `success_reset_password_email_sent_uniform` with an English fallback; it lazy-seeds into `lc_translations` on first render (existing v3 convention).
- The original "≤ 100 ms timing delta" target is not reachable with synchronous SMTP — the important part is that the message is uniform and the dummy path stays in the same order of magnitude as the real send. A truly constant-time response would need an async mail queue, which is post-3.0.
- I kept the preexisting `$_POST[$field]` bug in `edit.inc.php:76` out of this PR; it's in Wachhund:fix/edit-account-email-field → #483 as its own one-liner.
- Heads-up on CI: the Platform Tests job prints green but `continue-on-error: true` masks a preexisting `tests/database.php` failure that stops the runner before my new tests run. Wachhund:fix/platform-tests-database → #484 fixes that (one-liner).

## Test plan
- [ ] Apply #484 first (or run the suite locally) so the four new tests actually execute
- [ ] `php .git-hooks/pre-commit.d/platform_tests.php` — the four new tests report `[OK]`
- [ ] Manually: reset-password form for known / unknown / inactive account all return the same success notice
- [ ] Manually: account/edit with strong current + weak new password is rejected
- [ ] Manually: after a reset, a previously authenticated session on another browser is invalidated on the next request