### PR TITLE
[v3] Fix catalog_products_search_query reading query from $_GET

### DIFF
--- a/public_html/includes/functions/func_catalog.inc.php
+++ b/public_html/includes/functions/func_catalog.inc.php
@@ -410,8 +410,7 @@
 
 		if (!empty($filter['query'])) {
 
-			$code_regex = f::format_regex_code($_GET['query']);
-			$query_fulltext = f::escape_mysql_fulltext($_GET['query']);
+			$code_regex = f::format_regex_code($filter['query']);
 
 			$sql_select_relevance[] = (
 				"if(p.code regexp '". database::input($code_regex) ."', 5, 0)"
@@ -430,15 +429,15 @@
 			);
 
 			$sql_select_relevance[] = (
-				"if(json_value(p.name, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($_GET['query']), '%_') ."%', 3, 0)"
+				"if(json_value(p.name, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($filter['query']), '%_') ."%', 3, 0)"
 			);
 
 			$sql_select_relevance[] = (
-				"if(json_value(p.short_description, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($_GET['query']), '%_') ."%', 2, 0)"
+				"if(json_value(p.short_description, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($filter['query']), '%_') ."%', 2, 0)"
 			);
 
 			$sql_select_relevance[] = (
-				"if(json_value(p.description, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($_GET['query']), '%_') ."%', 1, 0)"
+				"if(json_value(p.description, '$.". database::input(language::$selected['code']) ."') collate utf8mb4_unicode_ci like '%". addcslashes(database::input($filter['query']), '%_') ."%', 1, 0)"
 			);
 		}
 


### PR DESCRIPTION
Closes #473.

Small one — the function reads from the wrong variable, so the relevance scoring for product search silently degrades to empty strings when called with a direct `\$filter` argument (including the platform test).

## Summary
| Change | File |
|---|---|
| Use `\$filter['query']` instead of `\$_GET['query']` in the five relevance expressions; drop the now-unused `\$query_fulltext` local | `public_html/includes/functions/func_catalog.inc.php` |

## Why
`catalog_products_search_query(\$filter)` guards on `!empty(\$filter['query'])` but the five `\$sql_select_relevance` expressions inside that branch read from `\$_GET['query']`. Any caller that passes `\$filter` without also populating `\$_GET` — including `tests/func_catalog.php` — lands in that branch with `\$_GET['query']` undefined, which means:

- PHP emits `Undefined array key 'query'` warnings for every one of the five accesses
- `database::input(\$_GET['query'])` feeds empty strings into the `regexp` and `like` expressions, so `p.code regexp ''`, `json_value(... like '%%')`, etc. all match everything, ruining the relevance scoring

The sister function `catalog_categories_query()` above does it correctly (reads from `\$filter`), so this is just a copy-paste slip. Fixed. Also dropped `\$query_fulltext` which was set but never read anywhere in the function body.

## Test plan
- [x] `tests/func_catalog.php` now gets past the warnings in CI — verified on this branch's run (`func_catalog.php… [OK]`)
- [x] `php -l` clean
- [ ] Manual: frontend product search still returns relevant hits — no behavioural change, same inputs reach the SQL via `\$filter` now