### PR TITLE
[v3] Fix database::input() null coercion and bind() placeholder swallow

### DIFF
--- a/public_html/includes/nodes/nod_database.inc.php
+++ b/public_html/includes/nodes/nod_database.inc.php
@@ -377,12 +377,15 @@
 				return $input;
 			}
 
-			if ($input == '') {
-				return '';
+			// Pass non-string scalars through unchanged. Must run before the empty-check
+			// below, otherwise `null == ''` (loose compare) would coerce null to ''.
+			// gettype() returns 'NULL' / 'double' (not 'null' / 'float') — use those.
+			if (in_array(gettype($input), ['NULL', 'boolean', 'integer', 'double'], true)) {
+				return $input;
 			}
 
-			if (in_array(gettype($input), ['null', 'boolean', 'double', 'integer', 'float'])) {
-				return $input;
+			if ($input === '') {
+				return '';
 			}
 
 			if ($allowable_tags !== true) {
@@ -606,8 +609,8 @@
 							continue;
 						}
 
-						// Commit replacement
-						$sql = substr($sql, 0, $i) . $value . substr($sql, $n + 1);
+						// Commit replacement (keep the break character at $n — it belongs to the SQL, not the placeholder)
+						$sql = substr($sql, 0, $i) . $value . substr($sql, $n);
 
 						// Move cursor to end of parameter
 						$i = $i + strlen($value);

--- a/tests/nod_database.php
+++ b/tests/nod_database.php
@@ -77,33 +77,27 @@
     }
 
     ########################################################################
-    ## query — parameter substitution (integer)
+    ## prepare / bind — parameter substitution (integer)
     ########################################################################
 
-    $result = database::query(
-      "select :val as result;",
-      [':val' => 42]
-    );
-
-    $row = $result->fetch();
+    $row = database::prepare(
+      "select :val as result;"
+    )->bind(['val' => 42])->fetch();
 
     if ((int)$row['result'] !== 42) {
-      throw new Exception('query: Parameter substitution for integer failed, got '. $row['result']);
+      throw new Exception('prepare/bind: Parameter substitution for integer failed, got '. var_export($row['result'], true));
     }
 
     ########################################################################
-    ## query — parameter substitution (string with escaping)
+    ## prepare / bind — parameter substitution (string with escaping)
     ########################################################################
 
-    $result = database::query(
-      "select :val as result;",
-      [':val' => "test'injection"]
-    );
-
-    $row = $result->fetch();
+    $row = database::prepare(
+      "select :val as result;"
+    )->bind(['val' => "test'injection"])->fetch();
 
     if ($row['result'] !== "test'injection") {
-      throw new Exception('query: String parameter should be escaped and returned correctly');
+      throw new Exception('prepare/bind: String parameter should be escaped and returned correctly, got '. var_export($row['result'], true));
     }
 
     ########################################################################
@@ -143,17 +137,18 @@
     }
 
     ########################################################################
-    ## each — callback iteration
+    ## each — callback is invoked for every row
     ########################################################################
 
-    $values = database::query(
+    $collected = [];
+    database::query(
       "select 1 as n union all select 2 union all select 3;"
-    )->each(function($row) {
-      return (int)$row['n'] * 10;
+    )->each(function($row) use (&$collected) {
+      $collected[] = (int)$row['n'] * 10;
     });
 
-    if ($values !== [10, 20, 30]) {
-      throw new Exception('each: Expected [10, 20, 30], got '. var_export($values, true));
+    if ($collected !== [10, 20, 30]) {
+      throw new Exception('each: Expected [10, 20, 30] collected via callback, got '. var_export($collected, true));
     }
 
     ########################################################################


### PR DESCRIPTION
Two bugs I hit while getting \`tests/nod_database.php\` green — they're small but the second one means \`database::prepare()->bind()\` has been generating invalid SQL for any placeholder followed by a space.

## Summary
| # | Fix | File |
|---|-----|------|
| 1 | \`database::input(null)\` now returns \`null\` instead of being coerced to \`''\` | \`public_html/includes/nodes/nod_database.inc.php\` |
| 2 | \`database_statement::bind()\` no longer swallows the break character after the placeholder | \`public_html/includes/nodes/nod_database.inc.php\` |
| 3 | Rewrite \`tests/nod_database.php\` to use the real \`prepare()->bind()\` API and to test \`each()\` via closure capture | \`tests/nod_database.php\` |

## Details

### 1. Null is coerced to empty string in \`input()\`

\`database::input()\` ran a loose-compare empty-string guard (\`\$input == ''\`) before the scalar passthrough branch. \`null == ''\` is true in PHP, so null returned \`''\`.

The passthrough branch had a second problem: it checked \`gettype(\$input)\` against \`['null', 'boolean', 'double', 'integer', 'float']\`, but \`gettype()\` returns \`'NULL'\` / \`'double'\` (not \`'null'\` / \`'float'\`) — so even if null had reached that line it wouldn't have matched.

Fix: run the scalar passthrough first with the correct type names and strict \`in_array\` compare, then strict \`\$input === ''\` short-circuit.

\`\`\`diff
+ // Pass non-string scalars through unchanged. Must run before the empty-check
+ // below, otherwise \`null == ''\` (loose compare) would coerce null to ''.
+ // gettype() returns 'NULL' / 'double' (not 'null' / 'float') — use those.
+ if (in_array(gettype(\$input), ['NULL', 'boolean', 'integer', 'double'], true)) {
+     return \$input;
+ }
+
- if (\$input == '') {
+ if (\$input === '') {
      return '';
  }
- if (in_array(gettype(\$input), ['null', 'boolean', 'double', 'integer', 'float'])) {
-     return \$input;
- }
\`\`\`

### 2. \`bind()\` eats the character after the placeholder

Given \`select :val as result;\` with \`['val' => 42]\`, the result was \`select 42as result;\` — a broken SQL that MySQL rejects with \`Unknown column '42as'\`. The parser locates the break character that terminates the placeholder (space, \`;\`, \`\r\`, \`\n\`) at offset \`\$n\`, then does:

\`\`\`php
\$sql = substr(\$sql, 0, \$i) . \$value . substr(\$sql, \$n + 1);
\`\`\`

The \`\$n + 1\` skips the break character itself — the space in this example — so the output loses it. Dropping the \`+ 1\` keeps the break character, which belongs to the SQL around the placeholder, not the placeholder itself.

### 3. Test file rewrite

- The two \`database::query(\$sql, [\$params])\` cases used a signature that doesn't exist (the second slot is \`\$link\`). Switched to the real \`database::prepare(\$sql)->bind([...])->fetch()\` API.
- The \`each()\` test expected a return value of collected callback results. \`each()\` is void by design (no callers anywhere in \`public_html/\` use a return value). Rewrote the test to collect via a closure capture — still proves the callback fires for each row.

## Test plan
- [x] \`php tests/nod_database.php\` → \`[OK]\`
- [x] Regression spot-check: \`database.php\`, \`customer.php\`, \`administrator.php\`, \`cart.php\`, \`func_password.php\`, \`func_token.php\` — all green
- [x] \`php -l\` clean on both changed files
- [ ] CI will stall on the preexisting \`func_catalog.php\` failure — #486 unblocks it. After #486 merges this branch should surface \`nod_database.php\` as the next test that actually runs, and it's green

## Note
CI on this branch stops at \`func_catalog.php\` because \`continue-on-error: true\` is on the step but the runner still exits at the first fail. #486 fixes that one and lets \`nod_database.php\` run downstream.