### PR TITLE
[v3] Fix category picker search scoped to current parent

### DIFF
--- a/public_html/backend/apps/catalog/categories.json.inc.php
+++ b/public_html/backend/apps/catalog/categories.json.inc.php
@@ -38,7 +38,9 @@
 				'(". database::input(t('title_untitled', 'Untitled')) .")'
 			) as name
 			from ". DB_TABLE_PREFIX ."categories c
-			where ". (!empty($_GET['parent_id']) ? "c.parent_id = ". (int)$_GET['parent_id'] : "c.parent_id is null") ."
+			where ". (empty($_GET['query'])
+				? (!empty($_GET['parent_id']) ? "c.parent_id = ". (int)$_GET['parent_id'] : "c.parent_id is null")
+				: "1=1") ."
 			". (!empty($sql_find) ? "and (". implode(" or ", $sql_find) .")" : "") ."
 			order by c.priority, name;"
 		)->fetch_all(function($subcategory) {


### PR DESCRIPTION
Tiny one. Noticed while triaging #469 — same bug exists in v3 (the v2 fix is in its own PR against \`dev\`).

## Summary
| Change | File |
|---|---|
| Skip the \`parent_id\` WHERE-clause when a \`query\` is supplied, so the picker searches the full tree instead of just the current parent's direct children | \`public_html/backend/apps/catalog/categories.json.inc.php\` |

## Why
\`categories.json.inc.php\` always constrains the query to \`c.parent_id = <current>\` (or \`c.parent_id is null\` at root). When the admin types into the picker's search field from the root, any category living deeper than the first level never surfaces — the widget falls back to its "no results" state.

Drop that clause when \`\$_GET['query']\` is set. The \`path\` loop already builds the ancestor chain for each result, so the dropdown continues to render the full breadcrumb.

## Test plan
- [ ] Open a product, click the category picker, type a term that only matches a subcategory — result should now appear with its full path
- [ ] Browse into a subcategory and leave the search empty — directory-style listing still shows only direct children (unchanged)