### PR TITLE
[v2] Fix category picker search scoped to current parent

### DIFF
--- a/public_html/admin/catalog.app/categories.json.inc.php
+++ b/public_html/admin/catalog.app/categories.json.inc.php
@@ -29,7 +29,7 @@
       "select c.id, c.parent_id, ci.name, c.date_created from ". DB_TABLE_PREFIX ."categories c
       left join ". DB_TABLE_PREFIX ."categories_info ci on (ci.category_id = c.id and ci.language_code = '". database::input($_GET['language_code']) ."')
       where c.id
-      ". (isset($_GET['parent_id']) ? "and c.parent_id = ". (int)$_GET['parent_id'] : "") ."
+      ". (isset($_GET['parent_id']) && empty($_GET['query']) ? "and c.parent_id = ". (int)$_GET['parent_id'] : "") ."
       ". (!empty($sql_find) ? "and (". implode(" or ", $sql_find) .")" : "") ."
       order by c.priority, ci.name;"
     );


### PR DESCRIPTION
Closes #469.

## Summary
| Change | File |
|---|---|
| Skip the \`parent_id\` WHERE-clause when a \`query\` is supplied, so the picker searches the full tree instead of just the current parent's direct children | \`public_html/admin/catalog.app/categories.json.inc.php\` |

## Why
The endpoint unintentionally ANDs the search term with the current \`parent_id\` (which defaults to \`0\`). When a user types into the picker from the root, only categories directly under the root surface; anything under \`/footwear/shoes/\` never does, and the widget shows its "not found" state.

Dropping the \`parent_id\` clause when \`\$_GET['query']\` is set lets the search span the tree. The \`path\` loop already carries ancestors into each result, so the dropdown still renders the full breadcrumb after the fix.

Same logic error exists in v3; that's in a separate PR against \`dev-major\`.

## Test plan
- [ ] In admin, open a product, click the category picker, type a term that only matches a subcategory — result should now appear with its full path
- [ ] Browse into a subcategory and leave the search empty — directory-style listing still shows only direct children (unchanged)