### PR TITLE
[v3] Fold TOTP 2FA add-on into administrator auth

### DIFF
--- a/public_html/backend/apps/administrators/edit_administrator.inc.php
+++ b/public_html/backend/apps/administrators/edit_administrator.inc.php
@@ -15,6 +15,68 @@
 	breadcrumbs::add(t('title_administrators', 'Administrators'), document::href_ilink(__APP__.'/administrators'));
 	breadcrumbs::add(!empty($administrator->data['username']) ? t('title_edit_administrator', 'Edit Administrator') : t('title_create_new_administrator', 'Create New Administrator'));
 
+	// TOTP enroll/confirm/disable — handled before the main save so the sub-form
+	// buttons (totp_setup, totp_confirm, totp_disable) don't have to go through
+	// the generic save validation.
+	if (!empty($administrator->data['id']) && (!empty($_POST['totp_setup']) || !empty($_POST['totp_confirm']) || !empty($_POST['totp_disable']))) {
+
+		require_once 'app://includes/functions/func_totp.inc.php';
+
+		try {
+
+			if (!empty($_POST['totp_setup'])) {
+				session::$data['totp_pending_secret'] = totp_generate_secret();
+				redirect(document::ilink());
+				exit;
+			}
+
+			if (!empty($_POST['totp_confirm'])) {
+
+				if (empty(session::$data['totp_pending_secret'])) {
+					throw new Exception(t('error_totp_setup_expired', 'TOTP setup session expired. Please try again.'));
+				}
+
+				if (empty($_POST['totp_code']) || !totp_verify_code(session::$data['totp_pending_secret'], $_POST['totp_code'])) {
+					throw new Exception(t('error_invalid_verification_code', 'Invalid verification code'));
+				}
+
+				database::query(
+					"update ". DB_TABLE_PREFIX ."administrators
+					set totp_secret = '". database::input(session::$data['totp_pending_secret']) ."'
+					where id = ". (int)$administrator->data['id'] ."
+					limit 1;"
+				);
+
+				unset(session::$data['totp_pending_secret']);
+				notices::add('success', t('success_totp_enabled', 'TOTP has been enabled'));
+				redirect(document::ilink());
+				exit;
+			}
+
+			if (!empty($_POST['totp_disable'])) {
+
+				if (empty($_POST['totp_disable_password']) || !password_verify($_POST['totp_disable_password'], $administrator->data['password_hash'])) {
+					throw new Exception(t('error_wrong_password', 'Wrong password'));
+				}
+
+				database::query(
+					"update ". DB_TABLE_PREFIX ."administrators
+					set totp_secret = null
+					where id = ". (int)$administrator->data['id'] ."
+					limit 1;"
+				);
+
+				unset(session::$data['totp_pending_secret']);
+				notices::add('success', t('success_totp_disabled', 'TOTP has been disabled'));
+				redirect(document::ilink());
+				exit;
+			}
+
+		} catch (Exception $e) {
+			notices::add('errors', $e->getMessage());
+		}
+	}
+
 	if (isset($_POST['save'])) {
 
 		try {
@@ -161,6 +223,63 @@
 							</label>
 						</div>
 					</div>
+
+					<?php if (!empty($administrator->data['id'])) { ?>
+					<div class="grid">
+						<div class="col-md-12">
+							<div class="form-group">
+								<div class="form-label"><?php echo t('title_totp_authenticator', 'TOTP Authenticator'); ?></div>
+
+								<?php if (!empty($administrator->data['totp_secret'])) { ?>
+
+									<div class="alert alert-success" style="margin-bottom: 1em;">
+										<?php echo t('text_totp_enabled', 'TOTP is enabled. You will be prompted for a code on each login.'); ?>
+									</div>
+
+									<div class="grid">
+										<div class="col-md-6">
+											<?php echo f::form_input_password('totp_disable_password', '', 'autocomplete="off" placeholder="'. t('title_password', 'Password') .'"'); ?>
+										</div>
+										<div class="col-md-6">
+											<?php echo f::form_button('totp_disable', t('title_disable_totp', 'Disable TOTP'), 'submit', 'class="btn btn-danger"'); ?>
+										</div>
+									</div>
+
+								<?php } elseif (!empty(session::$data['totp_pending_secret'])) { ?>
+
+									<?php
+										require_once 'app://includes/functions/func_totp.inc.php';
+										$totp_uri = totp_build_uri(session::$data['totp_pending_secret'], $administrator->data['username'], settings::get('store_name'));
+										$totp_svg = totp_generate_qr_svg($totp_uri, 200);
+									?>
+
+									<div style="text-align: center; margin-bottom: 1em;">
+										<?php echo $totp_svg; ?>
+									</div>
+
+									<div class="form-group">
+										<div class="form-label"><?php echo t('title_manual_setup_key', 'Manual Setup Key'); ?></div>
+										<code style="word-break: break-all; user-select: all;"><?php echo session::$data['totp_pending_secret']; ?></code>
+									</div>
+
+									<div class="grid">
+										<div class="col-md-6">
+											<?php echo f::form_input_text('totp_code', '', 'placeholder="'. t('title_verification_code', 'Verification Code') .'" autocomplete="one-time-code" inputmode="numeric" maxlength="6" pattern="\d{6}"'); ?>
+										</div>
+										<div class="col-md-6">
+											<?php echo f::form_button('totp_confirm', t('title_confirm', 'Confirm'), 'submit', 'class="btn btn-success"'); ?>
+										</div>
+									</div>
+
+								<?php } else { ?>
+
+									<?php echo f::form_button('totp_setup', t('title_enable_totp', 'Enable TOTP'), 'submit', 'class="btn btn-default"'); ?>
+
+								<?php } ?>
+							</div>
+						</div>
+					</div>
+					<?php } ?>
 
 					<div class="grid">
 						<div class="col-md-6">

--- a/public_html/backend/pages/login.inc.php
+++ b/public_html/backend/pages/login.inc.php
@@ -153,6 +153,25 @@
 
 			unset(session::$data['security_verification']);
 
+			// TOTP (opt-in per administrator). When enrolled, always challenge —
+			// independent of the known-IP check below. Email OTP remains the
+			// fallback for admins who haven't enrolled.
+			if (!empty($administrator['totp_secret'])) {
+
+				session::$data['security_verification'] = [
+					'type' => 'totp',
+					'attempts' => 0,
+				];
+
+				if (!empty($_POST['redirect_url'])) {
+					redirect(document::ilink('verify', ['redirect_url' => $_POST['redirect_url']]));
+				} else {
+					redirect(document::ilink('verify'));
+				}
+
+				exit;
+			}
+
 			$is_known_ip = false;
 			$is_known_range = false;
 

--- a/public_html/backend/pages/verify.inc.php
+++ b/public_html/backend/pages/verify.inc.php
@@ -35,29 +35,46 @@
 				throw new Exception(t('error_must_provide_verification_code', 'You must provide a verification code'));
 			}
 
-			if ($_POST['code'] != session::$data['security_verification']['code']) {
-				throw new Exception(t('error_invalid_verification_code', 'Invalid verification code'));
+			$is_totp = !empty(session::$data['security_verification']['type'])
+				&& session::$data['security_verification']['type'] === 'totp';
+
+			if ($is_totp) {
+
+				require_once 'app://includes/functions/func_totp.inc.php';
+
+				if (empty(administrator::$data['totp_secret'])
+					|| !totp_verify_code(administrator::$data['totp_secret'], $_POST['code'])) {
+					throw new Exception(t('error_invalid_verification_code', 'Invalid verification code'));
+				}
+
+			} else {
+
+				if ($_POST['code'] != session::$data['security_verification']['code']) {
+					throw new Exception(t('error_invalid_verification_code', 'Invalid verification code'));
+				}
+
+				if (time() > session::$data['security_verification']['expires']) {
+					throw new Exception(t('error_verification_code_expired', 'The verification code has expired'));
+				}
+
+				// The unknown-IP challenge records the successful IP as trusted.
+				// TOTP is location-independent and intentionally doesn't.
+				$known_ips = preg_split('#\s*,\s*#', administrator::$data['known_ips'], -1, PREG_SPLIT_NO_EMPTY);
+
+				array_unshift($known_ips, $_SERVER['REMOTE_ADDR']);
+				$known_ips = array_unique($known_ips);
+
+				if (count($known_ips) > 5) {
+					array_pop($known_ips);
+				}
+
+				database::query(
+					"update ". DB_TABLE_PREFIX ."administrators
+					set known_ips = '". database::input(implode(',', $known_ips)) ."'
+					where id = ". (int)administrator::$data['id'] ."
+					limit 1;"
+				);
 			}
-
-			if (time() > session::$data['security_verification']['expires']) {
-				throw new Exception(t('error_verification_code_expired', 'The verification code has expired'));
-			}
-
-			$known_ips = preg_split('#\s*,\s*#', administrator::$data['known_ips'], -1, PREG_SPLIT_NO_EMPTY);
-
-			array_unshift($known_ips, $_SERVER['REMOTE_ADDR']);
-			$known_ips = array_unique($known_ips);
-
-			if (count($known_ips) > 5) {
-				array_pop($known_ips);
-			}
-
-			database::query(
-				"update ". DB_TABLE_PREFIX ."administrators
-				set known_ips = '". database::input(implode(',', $known_ips)) ."'
-				where id = ". (int)administrator::$data['id'] ."
-				limit 1;"
-			);
 
 			unset(session::$data['security_verification']);
 
@@ -178,9 +195,11 @@ input[autocomplete="one-time-code"] {
 					<?php echo f::form_button('verify', t('title_verify', 'Verify'), 'submit', 'class="btn btn-default btn-block btn-lg"'); ?>
 				</label>
 
+				<?php if (empty(session::$data['security_verification']['type']) || session::$data['security_verification']['type'] !== 'totp') { ?>
 				<label class="form-group text-center">
 					<?php echo f::form_button('resend', t('title_resend_code', 'Resend Code'), 'submit', 'class="btn btn-default btn-sm"'); ?>
 				</label>
+				<?php } ?>
 			</div>
 
 		<?php echo f::form_end(); ?>

--- a/public_html/includes/functions/func_totp.inc.php
+++ b/public_html/includes/functions/func_totp.inc.php
@@ -1,0 +1,385 @@
+<?php
+
+	// TOTP (RFC 6238) helper functions — no external dependencies
+
+	function totp_generate_secret($length = 20) {
+
+		$bytes = random_bytes($length);
+		return totp_base32_encode($bytes);
+	}
+
+	function totp_generate_code($secret, $time = null, $digits = 6, $period = 30) {
+
+		if ($time === null) $time = time();
+
+		$counter = pack('J', intdiv($time, $period));
+		$key = totp_base32_decode($secret);
+		$hash = hash_hmac('sha1', $counter, $key, true);
+
+		$offset = ord($hash[19]) & 0x0F;
+		$code = (
+			((ord($hash[$offset]) & 0x7F) << 24) |
+			((ord($hash[$offset + 1]) & 0xFF) << 16) |
+			((ord($hash[$offset + 2]) & 0xFF) << 8) |
+			(ord($hash[$offset + 3]) & 0xFF)
+		) % pow(10, $digits);
+
+		return str_pad($code, $digits, '0', STR_PAD_LEFT);
+	}
+
+	function totp_verify_code($secret, $code, $window = 1, $period = 30) {
+
+		$time = time();
+
+		for ($i = -$window; $i <= $window; $i++) {
+			$expected = totp_generate_code($secret, $time + ($i * $period));
+			if (hash_equals($expected, $code)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	function totp_build_uri($secret, $account, $issuer) {
+
+		return 'otpauth://totp/' . rawurlencode($issuer) . ':' . rawurlencode($account)
+			. '?secret=' . $secret
+			. '&issuer=' . rawurlencode($issuer)
+			. '&algorithm=SHA1'
+			. '&digits=6'
+			. '&period=30';
+	}
+
+	function totp_base32_encode($data) {
+
+		$alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+		$binary = '';
+
+		foreach (str_split($data) as $char) {
+			$binary .= str_pad(decbin(ord($char)), 8, '0', STR_PAD_LEFT);
+		}
+
+		$encoded = '';
+		foreach (str_split($binary, 5) as $chunk) {
+			$chunk = str_pad($chunk, 5, '0', STR_PAD_RIGHT);
+			$encoded .= $alphabet[bindec($chunk)];
+		}
+
+		return $encoded;
+	}
+
+	function totp_base32_decode($data) {
+
+		$alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+		$binary = '';
+
+		foreach (str_split(strtoupper($data)) as $char) {
+			$index = strpos($alphabet, $char);
+			if ($index === false) continue;
+			$binary .= str_pad(decbin($index), 5, '0', STR_PAD_LEFT);
+		}
+
+		$decoded = '';
+		foreach (str_split($binary, 8) as $byte) {
+			if (strlen($byte) < 8) break;
+			$decoded .= chr(bindec($byte));
+		}
+
+		return $decoded;
+	}
+
+	function totp_generate_qr_svg($data, $size = 200) {
+
+		// Minimal QR Code generator (Mode: Byte, ECC: L, Version: auto)
+		// Based on the QR code specification (ISO/IEC 18004)
+
+		$encoded = totp_qr_encode($data);
+		if (!$encoded) return '';
+
+		$modules = $encoded['modules'];
+		$count = count($modules);
+		$scale = $size / ($count + 8); // 4 modules quiet zone on each side
+
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 '. ($count + 8) .' '. ($count + 8) .'" width="'. $size .'" height="'. $size .'">';
+		$svg .= '<rect width="100%" height="100%" fill="#fff"/>';
+
+		// Build path data — merge consecutive dark modules per row
+		$path = '';
+		for ($y = 0; $y < $count; $y++) {
+			$x = 0;
+			while ($x < $count) {
+				if ($modules[$y][$x]) {
+					$start = $x;
+					while ($x < $count && $modules[$y][$x]) $x++;
+					$path .= 'M'. ($start + 4) .','. ($y + 4) .'h'. ($x - $start) .'v1h-'. ($x - $start) .'z';
+				} else {
+					$x++;
+				}
+			}
+		}
+
+		if ($path) $svg .= '<path d="'. $path .'" fill="#000"/>';
+
+		$svg .= '</svg>';
+
+		return $svg;
+	}
+
+	function totp_qr_encode($data) {
+
+		// Byte mode encoding for QR Code Version 1-6 (ECC Level L)
+		$data_bytes = array_values(unpack('C*', $data));
+		$data_length = count($data_bytes);
+
+		// Version capacity table (Byte mode, ECC Level L)
+		$capacities = [0, 17, 32, 53, 78, 106, 134];
+
+		$version = 0;
+		for ($v = 1; $v <= 6; $v++) {
+			if ($data_length <= $capacities[$v]) {
+				$version = $v;
+				break;
+			}
+		}
+
+		if (!$version) return false; // Data too long
+
+		$module_count = 17 + $version * 4;
+
+		// Total data codewords (ECC Level L)
+		$total_codewords = [0, 19, 34, 55, 80, 108, 136];
+		$ec_codewords = [0, 7, 10, 15, 20, 26, 36];
+
+		$data_cw_count = $total_codewords[$version];
+		$ec_cw_count = $ec_codewords[$version];
+
+		// Build data bitstream
+		$bits = '';
+		$bits .= '0100'; // Byte mode indicator
+		$bits .= str_pad(decbin($data_length), $version <= 1 ? 8 : 16, '0', STR_PAD_LEFT);
+
+		foreach ($data_bytes as $byte) {
+			$bits .= str_pad(decbin($byte), 8, '0', STR_PAD_LEFT);
+		}
+
+		// Terminator
+		$bits .= str_repeat('0', min(4, $data_cw_count * 8 - strlen($bits)));
+
+		// Pad to byte boundary
+		while (strlen($bits) % 8 !== 0) {
+			$bits .= '0';
+		}
+
+		// Pad codewords
+		$pad_patterns = ['11101100', '00010001'];
+		$pad_index = 0;
+		while (strlen($bits) < $data_cw_count * 8) {
+			$bits .= $pad_patterns[$pad_index % 2];
+			$pad_index++;
+		}
+
+		// Convert to codewords
+		$codewords = [];
+		for ($i = 0; $i < strlen($bits); $i += 8) {
+			$codewords[] = bindec(substr($bits, $i, 8));
+		}
+
+		// Generate error correction codewords
+		$ec = totp_qr_reed_solomon($codewords, $ec_cw_count);
+		$all_codewords = array_merge($codewords, $ec);
+
+		// Initialize module grid
+		$modules = array_fill(0, $module_count, array_fill(0, $module_count, 0));
+		$is_function = array_fill(0, $module_count, array_fill(0, $module_count, false));
+
+		// Place finder patterns
+		totp_qr_place_finder($modules, $is_function, 0, 0, $module_count);
+		totp_qr_place_finder($modules, $is_function, $module_count - 7, 0, $module_count);
+		totp_qr_place_finder($modules, $is_function, 0, $module_count - 7, $module_count);
+
+		// Timing patterns
+		for ($i = 8; $i < $module_count - 8; $i++) {
+			if (!$is_function[$i][6]) {
+				$modules[$i][6] = ($i % 2 === 0) ? 1 : 0;
+				$is_function[$i][6] = true;
+			}
+			if (!$is_function[6][$i]) {
+				$modules[6][$i] = ($i % 2 === 0) ? 1 : 0;
+				$is_function[6][$i] = true;
+			}
+		}
+
+		// Dark module
+		$modules[$module_count - 8][8] = 1;
+		$is_function[$module_count - 8][8] = true;
+
+		// Reserve format info areas
+		for ($i = 0; $i < 8; $i++) {
+			if (!$is_function[$i][8]) $is_function[$i][8] = true;
+			if (!$is_function[8][$i]) $is_function[8][$i] = true;
+			if (!$is_function[$module_count - 1 - $i][8]) $is_function[$module_count - 1 - $i][8] = true;
+			if (!$is_function[8][$module_count - 1 - $i]) $is_function[8][$module_count - 1 - $i] = true;
+		}
+		$is_function[8][8] = true;
+
+		// Alignment pattern (version >= 2)
+		if ($version >= 2) {
+			$align_pos = [0, 6, $module_count - 7];
+			$center = $module_count - 7;
+			totp_qr_place_alignment($modules, $is_function, $center, $center, $module_count);
+		}
+
+		// Place data bits
+		$bit_index = 0;
+		$all_bits = '';
+		foreach ($all_codewords as $cw) {
+			$all_bits .= str_pad(decbin($cw), 8, '0', STR_PAD_LEFT);
+		}
+
+		$x = $module_count - 1;
+		$upward = true;
+
+		while ($x >= 1) {
+			if ($x === 6) $x--; // Skip timing column
+
+			for ($i = 0; $i < $module_count; $i++) {
+				$y = $upward ? ($module_count - 1 - $i) : $i;
+
+				for ($j = 0; $j < 2; $j++) {
+					$col = $x - $j;
+					if ($col < 0) continue;
+					if ($is_function[$y][$col]) continue;
+
+					$modules[$y][$col] = ($bit_index < strlen($all_bits) && $all_bits[$bit_index] === '1') ? 1 : 0;
+					$bit_index++;
+				}
+			}
+
+			$x -= 2;
+			$upward = !$upward;
+		}
+
+		// Apply mask pattern 0 (checkerboard)
+		for ($y = 0; $y < $module_count; $y++) {
+			for ($x = 0; $x < $module_count; $x++) {
+				if (!$is_function[$y][$x]) {
+					if (($y + $x) % 2 === 0) {
+						$modules[$y][$x] ^= 1;
+					}
+				}
+			}
+		}
+
+		// Place format info (ECC Level L = 01, Mask 0 = 000)
+		$format_bits = [1,0,1,0,1,0,0,0,0,0,1,0,0,1,0]; // Pre-computed: L + mask 0
+		$format_positions_a = [[0,8],[1,8],[2,8],[3,8],[4,8],[5,8],[7,8],[8,8],[8,7],[8,5],[8,4],[8,3],[8,2],[8,1],[8,0]];
+		$format_positions_b = [[$module_count-1,8],[$module_count-2,8],[$module_count-3,8],[$module_count-4,8],[$module_count-5,8],[$module_count-6,8],[$module_count-7,8],[8,$module_count-8],[8,$module_count-7],[8,$module_count-6],[8,$module_count-5],[8,$module_count-4],[8,$module_count-3],[8,$module_count-2],[8,$module_count-1]];
+
+		for ($i = 0; $i < 15; $i++) {
+			$modules[$format_positions_a[$i][0]][$format_positions_a[$i][1]] = $format_bits[$i];
+			$modules[$format_positions_b[$i][0]][$format_positions_b[$i][1]] = $format_bits[$i];
+		}
+
+		return ['modules' => $modules, 'version' => $version, 'size' => $module_count];
+	}
+
+	function totp_qr_place_finder(&$modules, &$is_function, $row, $col, $size) {
+
+		for ($r = -1; $r <= 7; $r++) {
+			for ($c = -1; $c <= 7; $c++) {
+				$y = $row + $r;
+				$x = $col + $c;
+				if ($y < 0 || $y >= $size || $x < 0 || $x >= $size) continue;
+
+				$is_function[$y][$x] = true;
+
+				if ($r >= 0 && $r <= 6 && ($c === 0 || $c === 6)) {
+					$modules[$y][$x] = 1;
+				} elseif ($c >= 0 && $c <= 6 && ($r === 0 || $r === 6)) {
+					$modules[$y][$x] = 1;
+				} elseif ($r >= 2 && $r <= 4 && $c >= 2 && $c <= 4) {
+					$modules[$y][$x] = 1;
+				} else {
+					$modules[$y][$x] = 0;
+				}
+			}
+		}
+	}
+
+	function totp_qr_place_alignment(&$modules, &$is_function, $center_y, $center_x, $size) {
+
+		for ($r = -2; $r <= 2; $r++) {
+			for ($c = -2; $c <= 2; $c++) {
+				$y = $center_y + $r;
+				$x = $center_x + $c;
+				if ($y < 0 || $y >= $size || $x < 0 || $x >= $size) continue;
+				if ($is_function[$y][$x]) return; // Overlap with finder
+
+				$is_function[$y][$x] = true;
+				if (abs($r) === 2 || abs($c) === 2 || ($r === 0 && $c === 0)) {
+					$modules[$y][$x] = 1;
+				} else {
+					$modules[$y][$x] = 0;
+				}
+			}
+		}
+	}
+
+	function totp_qr_reed_solomon($data, $ec_count) {
+
+		// Generator polynomial coefficients for common EC counts
+		$generators = [
+			7  => [87,229,146,149,238,102,21],
+			10 => [251,67,46,61,118,70,64,94,32,45],
+			15 => [29,196,111,163,112,74,10,105,105,139,132,151,32,134,26],
+			20 => [173,125,158,2,103,182,118,17,145,201,111,28,165,53,161,21,245,142,13,102],
+			26 => [173,125,158,2,103,182,118,17,145,201,111,28,165,53,161,21,245,142,13,102,48,227,153,145,218,70],
+			36 => [120,104,107,109,102,161,76,3,91,191,147,169,182,194,225,120,215,106,155,130,62,127,99,169,124,185,176,78,47,18,151,254,120,77,227,148],
+		];
+
+		if (!isset($generators[$ec_count])) return array_fill(0, $ec_count, 0);
+
+		$gen = $generators[$ec_count];
+		$result = array_merge($data, array_fill(0, $ec_count, 0));
+
+		for ($i = 0; $i < count($data); $i++) {
+			$coef = $result[$i];
+			if ($coef === 0) continue;
+
+			$log_coef = totp_qr_gf_log($coef);
+			for ($j = 0; $j < $ec_count; $j++) {
+				$result[$i + 1 + $j] ^= totp_qr_gf_exp(($log_coef + $gen[$j]) % 255);
+			}
+		}
+
+		return array_slice($result, count($data));
+	}
+
+	function totp_qr_gf_exp($x) {
+		static $table = null;
+		if ($table === null) {
+			$table = [];
+			$val = 1;
+			for ($i = 0; $i < 256; $i++) {
+				$table[$i] = $val;
+				$val <<= 1;
+				if ($val >= 256) $val ^= 0x11D;
+			}
+		}
+		return $table[$x % 255];
+	}
+
+	function totp_qr_gf_log($x) {
+		static $table = null;
+		if ($table === null) {
+			$table = [];
+			$val = 1;
+			for ($i = 0; $i < 255; $i++) {
+				$table[$val] = $i;
+				$val <<= 1;
+				if ($val >= 256) $val ^= 0x11D;
+			}
+		}
+		return $table[$x];
+	}

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -12,6 +12,7 @@
 				"widgets": { "type": "VARCHAR", "length": 512, "default": "''" },
 				"password_hash": { "type": "VARCHAR", "length": 255, "default": "''" },
 				"two_factor_auth": { "type": "TINYINT", "length": 1, "unsigned": true, "default": 0 },
+				"totp_secret": { "type": "VARCHAR", "length": 64, "nullable": true },
 				"login_attempts": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
 				"total_logins": { "type": "INT", "length": 10, "unsigned": true, "default": 0 },
 				"known_ips": { "type": "VARCHAR", "length": 512, "default": "''" },


### PR DESCRIPTION
Follow-up to #478 — wiring up the TOTP proof-of-concept you asked about.

The existing unknown-IP email OTP stays exactly as-is. TOTP lives on top of it as an opt-in second factor: once an admin enrolls, every login (from any IP) goes through the TOTP challenge. Admins who don't enroll keep the current behaviour.

## Summary

| Area | Change | File |
|---|---|---|
| Helpers | New dependency-free TOTP module (base32 + `hash_hmac('sha1')`, inline-SVG QR generator, RFC 6238) | `public_html/includes/functions/func_totp.inc.php` (new) |
| Storage | Single new column `administrators.totp_secret VARCHAR(64) NULL` — no migration needed, picked up by the structure.json auto-patcher | `public_html/install/structure.json` |
| Login flow | After password verify, admins with `totp_secret` are redirected to the verify page with `security_verification.type = 'totp'` before the known-IP check runs | `public_html/backend/pages/login.inc.php` |
| Verify page | Accepts TOTP codes when `type = 'totp'`, otherwise keeps the existing email-OTP path. Known-IP trust is only updated via the email-OTP branch (TOTP is location-independent on purpose). Hides "Resend Code" in TOTP mode | `public_html/backend/pages/verify.inc.php` |
| Admin UI | New TOTP section on the edit-administrator page: Enable -> QR code + manual setup key + confirm code -> Disable (requires password re-entry) | `public_html/backend/apps/administrators/edit_administrator.inc.php` |

## Design choices

- **Layered, not replacing.** Email OTP is an unknown-IP challenge; TOTP is a permanent 2nd factor. Keeping both means admins without authenticator apps keep the IP-based speed-bump, enrolled admins get strong 2FA on every login. Matches GitHub / GitLab / Bitwarden.
- **No third-party library.** Base32 + HMAC-SHA1 are a few dozen lines; the QR generator (Version 1–6, ECC L, byte mode) is ~200 lines of straight PHP. No vendor tree, no Composer lift.
- **Recovery deliberately minimal.** No backup codes in v1 — if an admin loses their authenticator, another admin disables TOTP for them or sets `totp_secret = NULL` directly in the table. Can add backup codes later if desired; wanted to keep the first cut focused.
- **Session gate stays.** `nod_administrator::init()` already redirects to `verify` whenever `security_verification` is pending, so a half-logged-in admin can't touch other backend routes during the TOTP step.

## Test plan

- [x] `php -l` clean on all five touched files
- [x] Platform Tests job: all 60 tests green on this branch (including the four PROJ-23 tests and the existing admin/customer/cart suites)
- [ ] Manual: log in as an admin without TOTP — email OTP still triggers on unknown IP (unchanged behaviour)
- [ ] Manual: enroll TOTP on the edit-administrator page, scan QR with Google Authenticator / Authy / 1Password, confirm with the 6-digit code — `totp_secret` populated
- [ ] Manual: log in again — TOTP challenge replaces the email flow, login from a known IP still triggers the TOTP step
- [ ] Manual: disable TOTP with correct password — `totp_secret` cleared; wrong password rejected
- [ ] Manual: half-way through enrollment (pending secret in session), reload the admin edit page — the pending confirm UI persists until confirmed or the page is left alone across a session reset

## Not in scope here

- Backup/recovery codes (can add later if you want)
- Customer-side TOTP (PROJ-11 in my notes, separate PR)
- Remember-me 2FA integration (one of the other items in #478)
- Translation strings beyond the fallback English — lazy-seeded per the v3 convention; a dedicated seed pass can follow

Marked as a proof-of-concept per the "happy to spec that" offer in #478. Pick it apart freely — happy to rework the storage shape, split enrollment into a dedicated app, or change the UI placement if you'd prefer.