### PR TITLE
[v2] Fix restricted admins getting Access Denied on JSON/picker helpers

### DIFF
--- a/public_html/admin/index.php
+++ b/public_html/admin/index.php
@@ -97,7 +97,15 @@
 // App content
   } else {
 
-    if (empty(user::$data['apps']) || (!empty(user::$data['apps'][$_GET['app']]['status']) && in_array($_GET['doc'], user::$data['apps'][$_GET['app']]['docs']))) {
+  // Helper endpoints (*.json, *.csv, *_picker) aren't individually tickable in the
+  // administrator edit UI — they're auxiliary routes consumed by the main docs.
+  // Allow them implicitly as long as the user has the app enabled.
+    $is_helper = preg_match('#\.(json|csv)$#', $_GET['doc'] ?? '')
+              || str_ends_with($_GET['doc'] ?? '', '_picker');
+
+    if (empty(user::$data['apps'])
+    || (!empty(user::$data['apps'][$_GET['app']]['status'])
+        && ($is_helper || in_array($_GET['doc'], user::$data['apps'][$_GET['app']]['docs'])))) {
 
       if (!is_file(FS_DIR_ADMIN . $_GET['app'].'.app/config.inc.php')) {
         http_response_code(404);


### PR DESCRIPTION
Closes #469 and closes #492.

The admin permission gate in `admin/index.php` matches `$_GET['doc']` strictly against the user's allow-list, which only carries the visible menu docs (`catalog`, `edit_product`, ...). Auxiliary helpers declared in each app's `config.inc.php` — `categories.json`, `attribute_values.json`, `category_picker`, `product_picker`, etc. — are never tickable in the administrator edit UI but still get routed through the same gate. Result: a restricted admin opens the product editor, the category picker fires an AJAX call to `categories.json`, and the check rejects it with Access Denied; the picker receives HTML where it expected JSON (`SyntaxError: Unexpected token '<'`).

## Summary
| Change | File |
|---|---|
| Allow helper docs (`*.json`, `*.csv`, `*_picker`) implicitly when the user has the app enabled; still require `status = 1`, still reject otherwise-unknown docs | `public_html/admin/index.php` |

## Why this shape
- Unrestricted admins were never affected — the `empty(user::$data['apps'])` branch short-circuits for them.
- Restricted admins who don't have the app active at all are still refused; the `status` check is unchanged.
- The helper-detection pattern (`*.json` / `*.csv` / `*_picker`) matches every auxiliary endpoint I can find across the current `admin/*.app/config.inc.php` files — please shout if you spot add-on conventions I missed.

## Test plan
- [ ] Create a restricted administrator with `apps = {"catalog":{"status":"1","docs":["catalog","edit_product"]}}`
- [ ] Log in as that user, open any product
- [ ] Click the category picker's search field, type a query — suggestions from `categories.json` now return properly (previously: Access Denied / broken picker)
- [ ] Open a product not in the admin's permitted docs — still 404
- [ ] Call an unknown helper (`?app=catalog&doc=nonexistent.json`) — still rejected by the app's own router

The v3 counterpart (`backend/pages/index.inc.php`) has the same bug and is being sent in a separate PR against `dev-major`.