### PR TITLE
[v3] Fix restricted admins getting Access Denied on JSON/picker helpers

### DIFF
--- a/public_html/backend/pages/index.inc.php
+++ b/public_html/backend/pages/index.inc.php
@@ -18,8 +18,16 @@
 			'color' => $app_config['theme']['color'] ?? '#97a3b5',
 		];
 
-		// Check if administrator is permitted to access document
-		if (!empty(administrator::$data['apps'][__APP__]['status']) && !in_array(__DOC__, administrator::$data['apps'][__APP__]['docs'])) {
+		// Check if administrator is permitted to access document.
+		// Helper endpoints (*.json, *.csv, *_picker) aren't individually tickable in the
+		// administrator edit UI — they're auxiliary routes consumed by the main docs.
+		// Allow them implicitly as long as the admin has the app enabled.
+		$is_helper = preg_match('/\.(json|csv)$/', __DOC__)
+		          || str_ends_with(__DOC__, '_picker');
+
+		if (!empty(administrator::$data['apps'][__APP__]['status'])
+		    && !$is_helper
+		    && !in_array(__DOC__, administrator::$data['apps'][__APP__]['docs'])) {
 			notices::add('errors', t('title_access_denied', 'Access Denied'));
 			return;
 		}


### PR DESCRIPTION
Same bug the v2 PR addresses, just in the v3 router.

`backend/pages/index.inc.php` gates each admin doc by strict allow-list match. The administrator edit UI only lets you tick the visible menu docs, so auxiliary endpoints declared in each app's `config.inc.php` — `categories.json`, `attribute_values.json`, `category_picker`, `product_picker`, etc. — are never in a restricted admin's docs array. Restricted admins open the product editor, the picker fires AJAX, and the gate rejects the helper with Access Denied.

## Summary
| Change | File |
|---|---|
| Allow helper docs (`*.json`, `*.csv`, `*_picker`) implicitly when the administrator has the app enabled | `public_html/backend/pages/index.inc.php` |

## Why
- Unrestricted admins unaffected (status check already bypasses them).
- Restricted admins without the app enabled are still refused — helper-status is not a bypass for app-level disablement.
- Pattern covers every helper I can find in the v3 `backend/apps/*/config.inc.php` files.

## Test plan
- [ ] Create a restricted administrator with `apps = {"catalog":{"status":"1","docs":["catalog","edit_product"]}}`
- [ ] Log in and open a product → picker search hits `categories.json` and returns JSON
- [ ] Unknown helper (`?app=catalog&doc=nonexistent.json`) — still rejected by the app's doc resolver (line 28)

Reported upstream on v2 by @averlon in litecart/litecart#469 and litecart/litecart#492; fix is the same on both branches. The v2 PR is tracked separately.