### PR TITLE
[v3] Fix admin login form never submitting (jQuery submit recursion)

### DIFF
--- a/public_html/backend/pages/login.inc.php
+++ b/public_html/backend/pages/login.inc.php
@@ -368,11 +368,11 @@ body {
 
 	$('form[name="login_form"]').submit(function(e) {
 		e.preventDefault();
-		let $form = $(this);
+		let form = this;
 		$('#box-login .card-body').slideUp(100, function() {
 			$('#box-login').fadeOut(250, function() {
 				$('.loader-wrapper').fadeIn(100, function() {
-					$form.submit();
+					form.submit();
 				});
 			});
 		});


### PR DESCRIPTION
Small JS regression introduced in bd9fef9 "Fix bad search and replace" — it changed the login form's submit callback to use a jQuery-wrapped reference:

```js
$('form[name="login_form"]').submit(function(e) {
  e.preventDefault();
  let $form = $(this);   // was: let form = this;
  ...
  $form.submit();        // was: form.submit();
});
```

`$form.submit()` is a jQuery call that re-triggers the submit *event*, which hits the handler again, which `preventDefault()`s again, and so on. The native POST never fires — the admin just watches the login card fade out and nothing else happens. Locally it looks like a slow network; in CI Playwright's `auth.setup.mjs` waits for the Dashboard title, gets `Login · LiteCart` four times in a row, and the whole E2E suite reports `8 did not run` after the setup failure.

## Summary
| Change | File |
|---|---|
| Keep the raw DOM reference (`let form = this; form.submit()`) so the browser fires the actual POST instead of re-entering the jQuery event chain | `public_html/backend/pages/login.inc.php` |

## Why this shape
- The surrounding animation sequence (`slideUp` → `fadeOut` → `fadeIn` → `submit`) worked fine before the rename; keeping the native reference is the minimum revert.
- No functional difference on the PHP side — the form POSTs the same payload.

## Test plan
- [ ] Open `/admin/` in a browser, log in with valid credentials — reaches Dashboard, previously hung on the login page
- [ ] Log in with invalid credentials — still shows the error notice as before
- [ ] CI: `auth.setup.mjs` passes and the downstream E2E suite runs

Side effect in CI: the E2E job has been red on `dev-major` since bd9fef9 (2026-04-18), which is why #493/#494's E2E step is also red — this fix unblocks both.