### PR TITLE
[v2] Fix Geo Zones pending Add row dropped silently on Save (#498)

### DIFF
--- a/public_html/admin/geo_zones.app/edit_geo_zone.inc.php
+++ b/public_html/admin/geo_zones.app/edit_geo_zone.inc.php
@@ -21,6 +21,11 @@
 
       if (empty($_POST['zones'])) $_POST['zones'] = [];
 
+    // Fold a pending row that was filled but not added via the Add button
+      if (!empty($_POST['new_zone']['country_code'])) {
+        $_POST['zones']['new_pending'] = $_POST['new_zone'];
+      }
+
       $fields = [
         'code',
         'name',


### PR DESCRIPTION
Quick follow-up to #498 — pending row absorbed server-side now, JS path unchanged.

## What

`new_zone[...]` is the input row in the `<tfoot>`. The JS Add handler clones it into `<tbody>` as `zones[new_X][...]`, but if the user submits without clicking Add, the save handler only reads `$_POST['zones']` and the entire `new_zone` payload is silently dropped.

Two-line server-side fix: if `new_zone` has a country code, fold it into `zones` before persisting.

## Why server-side

| | |
|---|---|
| Default Enter submit | Pressing Enter inside the City field doesn't trigger the Add click |
| JS disabled / failed load | Form still submits, row would still be lost |
| Mirrors user intent | What the user already expected to happen |

## Test plan

- [ ] Edit geo zone, fill new-row Country/Zone, hit Save (no Add click) → row persists
- [ ] Press Enter inside the City field → row persists
- [ ] Country only (Zone/City blank) → row persists with All Zones / All Cities semantics
- [ ] Empty Add row + Save → no spurious row created
- [ ] Existing rows + new row simultaneously → all persist
- [ ] Zone Based Shipping evaluates the zone correctly post-save (no fallthrough to Non-matched)

Closes #498