### PR TITLE
[v3] Fix Geo Zones pending Add row dropped silently on Save (#498)

### DIFF
--- a/public_html/backend/apps/localization/geo_zones/edit_geo_zone.inc.php
+++ b/public_html/backend/apps/localization/geo_zones/edit_geo_zone.inc.php
@@ -24,6 +24,11 @@
 				$_POST['zones'] = [];
 			}
 
+		// Fold a pending row that was filled but not added via the Add button
+			if (!empty($_POST['new_zone']['country_code'])) {
+				$_POST['zones']['new_pending'] = $_POST['new_zone'];
+			}
+
 			foreach ([
 				'code',
 				'name',


### PR DESCRIPTION
Same idea as the v2 PR — server-side absorption of a pending Add row, just on the v3 side.

## What

`new_zone[...]` is the input row in the `<tfoot>`. The JS Add handler clones it into `<tbody>` as `zones[new_X][...]`. v3 already alerts when the user hits Save without clicking Add, but the alert can be dismissed and the form re-submits with the row still missing — the save handler only reads `$_POST['zones']`.

Two-line server-side fix: if `new_zone` has a country code, fold it into `zones` before persisting.

## Why both alert and absorption

| | |
|---|---|
| Alert | Catches the common case (mouse user, JS active) — keeps the muscle-memory hint |
| Server absorption | Catches Enter-submit, dismissed alerts, and any future JS regression |

The alert stays, this just makes the data path forgiving.

## Test plan

- [ ] Edit geo zone, fill new-row Country/Zone, hit Save (no Add click) → row persists
- [ ] Press Enter inside the City field → row persists
- [ ] Country only (Zone/City blank) → row persists with All Zones / All Cities
- [ ] Empty Add row + Save → no spurious row created
- [ ] Existing rows + new row simultaneously → all persist
- [ ] Zone Based Shipping evaluates the zone correctly post-save

Closes #498