### PR TITLE
[v3] Fix CI on dev-major (webhook_requests schema + webhooks app config)

### DIFF
--- a/public_html/backend/apps/webhooks/config.inc.php
+++ b/public_html/backend/apps/webhooks/config.inc.php
@@ -1,0 +1,20 @@
+<?php
+
+	return [
+		'name' => t('title_webhooks', 'Webhooks'),
+		'default' => 'webhooks',
+		'group' => 'system',
+		'priority' => 0,
+
+		'theme' => [
+			'color' => '#4dcac3',
+			'icon' => 'icon-link',
+		],
+
+		'menu' => [],
+
+		'docs' => [
+			'edit_webhook' => 'edit_webhook.inc.php',
+			'webhooks' => 'webhooks.inc.php',
+		],
+	];

--- a/public_html/install/structure.json
+++ b/public_html/install/structure.json
@@ -1951,7 +1951,8 @@
 				"updated_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP", "on_update": "CURRENT_TIMESTAMP" },
 				"created_at": { "type": "TIMESTAMP", "default": "CURRENT_TIMESTAMP" }
 			},
-			"indexes": {
+			"primary_key": ["id"],
+			"keys": {
 				"type": ["type"],
 				"status": ["status"],
 				"webhook_id": ["webhook_id"],


### PR DESCRIPTION
Spotted while debugging CI on #500 — `dev-major` itself has been red since the marketplace/webhooks merge. Two small things missing from that commit, both blocking CI.

## What

| # | Issue | Effect |
|---|---|---|
| 1 | `webhook_requests` in `structure.json`: `id` is `auto_increment` but no `primary_key`, and the index block is named `"indexes":` instead of `"keys":` | MySQL: *"there can be only one auto column and it must be defined as a key"* — Platform Tests + E2E `Import database schema` step exits 255 |
| 2 | `backend/apps/webhooks/` ships `webhooks.inc.php` and `edit_webhook.inc.php` but no `config.inc.php` | `func_admin.inc.php:18` requires `config.inc.php` per app — fatal `Failed opening required` when the admin shell scans apps, kills E2E auth setup |

Both are leftover from the *"half baked - not final"* commit (Tim's own wording). Just helping it across the line.

## Fix

**1.** `structure.json` — two-line tweak, keeps the compact format:

```diff
 "created_at": { ... }
 },
+"primary_key": ["id"],
-"indexes": {
+"keys": {
   "type": ["type"], ...
```

**2.** New `backend/apps/webhooks/config.inc.php` — modeled on the existing `vmods/config.inc.php`, system group, only the two existing docs registered (`webhooks`, `edit_webhook`). Empty `index.html` to match the convention used by every other app folder.

## Verified

- `php -r` schema audit over `structure.json` — no remaining auto-without-PK, no remaining `indexes` blocks
- `json_decode` round-trips cleanly
- `php -l` clean on the new config
- The two docs in `'docs' =>` map to files that actually exist

## Test plan

- [ ] Platform Tests job: `Import database schema and seed data` exits 0
- [ ] E2E Tests (Playwright) job: admin auth setup completes, no `Failed opening required` for webhooks
- [ ] No regression on existing tables — diff scoped to the `webhook_requests` block only
- [ ] After merge, #500 CI rerun goes green (it was carrying both of these)