### PR TITLE
[v2] Fix category attributes filter crashes on non-array input (#501)

### DIFF
--- a/public_html/pages/category.inc.php
+++ b/public_html/pages/category.inc.php
@@ -13,9 +13,12 @@
     exit;
   }
 
-  if (!empty($_GET['attributes'])) {
+  if (!empty($_GET['attributes']) && is_array($_GET['attributes'])) {
+    $_GET['attributes'] = array_filter($_GET['attributes'], 'is_array');
     $_GET['attributes'] = array_map('array_filter', $_GET['attributes']);
     $_GET['attributes'] = array_filter($_GET['attributes']);
+  } else {
+    unset($_GET['attributes']);
   }
 
   $category = reference::category($_GET['category_id']);


### PR DESCRIPTION
@s22-tech tracked this one down nicely in #501 — `?attributes=foo` (or any non-2D-array shape) hits `array_map('array_filter', $string)` and throws a 500. Same code path lives in v3, separate PR for that.

## What

`pages/category.inc.php:16-19` assumed `$_GET['attributes']` is always a 2D array shaped like `?attributes[group_id][value_id]=1`. Crawlers, bots, and copy-pasted URLs routinely send shapes that aren't:

| Input | Original | Now |
|---|---|---|
| `?attributes=foo` | `array_map(): Argument #2 must be of type array, string given` → 500 | `unset` (filter ignored) |
| `?attributes[1]=foo` | `array_filter('foo')` → 500 | empty array (then unset by downstream `!empty()` check) |
| `?attributes[1][2]=1` (legit 2D) | works | works (unchanged) |
| `?attributes[1][2]=1&attributes[2]=stray` | crash on the stray | stray key dropped, valid keys kept |
| `?attributes=` empty / unset | skip | skip + `unset` |

## Fix

Three-line tweak: top-level `is_array` guard, drop non-array children at the second level before `array_map`, and `unset` if the input is bogus so downstream filter logic sees a clean state.

```php
if (!empty($_GET['attributes']) && is_array($_GET['attributes'])) {
  $_GET['attributes'] = array_filter($_GET['attributes'], 'is_array');
  $_GET['attributes'] = array_map('array_filter', $_GET['attributes']);
  $_GET['attributes'] = array_filter($_GET['attributes']);
} else {
  unset($_GET['attributes']);
}
```

`@s22-tech`'s fix in the issue body works too — this version keeps the existing `array_map('array_filter', ...)` shape Tim wrote and just hardens the input contract.

## Why it matters beyond DX

Anyone can trigger a 500 by hitting `/category/<slug>?attributes=anything`. Cheap DoS / log-spam vector and noisy in error monitoring. After this, invalid attribute payloads are quietly ignored and the page renders normally.

## Test plan

- [ ] `?attributes=foo` → 200, page renders without filter
- [ ] `?attributes[1]=foo` → 200, no filter applied
- [ ] `?attributes[1][2]=1` (legit 2D) → 200, filter applied as before
- [ ] `?attributes[1][2]=1&attributes[2]=stray` → 200, stray ignored, group 1 filter applies
- [ ] No `?attributes` at all → 200, identical to current behavior

Closes #501