### PR TITLE
[v3] Fix category attributes filter crashes on non-array input (#501)

### DIFF
--- a/public_html/frontend/pages/category.inc.php
+++ b/public_html/frontend/pages/category.inc.php
@@ -24,9 +24,12 @@
 		exit;
 	}
 
-	if (!empty($_GET['attributes'])) {
+	if (!empty($_GET['attributes']) && is_array($_GET['attributes'])) {
+		$_GET['attributes'] = array_filter($_GET['attributes'], 'is_array');
 		$_GET['attributes'] = array_map('array_filter', $_GET['attributes']);
 		$_GET['attributes'] = array_filter($_GET['attributes']);
+	} else {
+		unset($_GET['attributes']);
 	}
 
 	$category = reference::category($_GET['category_id']);


### PR DESCRIPTION
v3 side of #501 — same crash path as the v2 PR, identical fix translated to tabs and `frontend/pages/category.inc.php`.

## What

`frontend/pages/category.inc.php:27-30` assumed `$_GET['attributes']` is always a 2D array shaped like `?attributes[group_id][value_id]=1`. Anything else triggers `array_map(): Argument #2 must be of type array, string given` and a 500.

| Input | Original | Now |
|---|---|---|
| `?attributes=foo` | crash | `unset` |
| `?attributes[1]=foo` | crash | empty array, downstream skips |
| `?attributes[1][2]=1` | works | works (unchanged) |
| `?attributes[1][2]=1&attributes[2]=stray` | crash | stray dropped, valid keys kept |

## Fix

```php
if (!empty($_GET['attributes']) && is_array($_GET['attributes'])) {
  $_GET['attributes'] = array_filter($_GET['attributes'], 'is_array');
  $_GET['attributes'] = array_map('array_filter', $_GET['attributes']);
  $_GET['attributes'] = array_filter($_GET['attributes']);
} else {
  unset($_GET['attributes']);
}
```

Top-level `is_array` guard, drop non-array children before `array_map`, and `unset` for bogus input so the downstream filter sees a clean state.

## Test plan

- [ ] `?attributes=foo` → 200, page renders without filter
- [ ] `?attributes[1]=foo` → 200, no filter applied
- [ ] `?attributes[1][2]=1` (legit 2D) → 200, filter applied as before
- [ ] `?attributes[1][2]=1&attributes[2]=stray` → 200, stray ignored, group 1 filter applies
- [ ] No `?attributes` at all → 200, identical to current behavior

Closes #501