### PR TITLE
[v3] Fix backend authorization gaps across apps, search, MCP, storage (#479)

### DIFF
--- a/public_html/backend/apps/storage/storage.inc.php
+++ b/public_html/backend/apps/storage/storage.inc.php
@@ -96,15 +96,21 @@
 				throw new Exception('No files or folders selected');
 			}
 
+			// Sanitize incoming paths: f::file_resolve_path() throws when a path
+			// climbs above the storage root via .. segments.
 			if (!empty($_POST['folders'])) {
 				foreach ($_POST['folders'] as $folder) {
-					f::file_delete('storage://' . trim($folder, '/'), true);
+					$resolved = f::file_resolve_path(trim($folder, '/'));
+					if ($resolved === '') continue;
+					f::file_delete('storage://' . $resolved, true);
 				}
 			}
 
 			if (!empty($_POST['files'])) {
 				foreach ($_POST['files'] as $file) {
-					f::file_delete('storage://' . trim($file, '/'));
+					$resolved = f::file_resolve_path(trim($file, '/'));
+					if ($resolved === '') continue;
+					f::file_delete('storage://' . $resolved);
 				}
 			}
 
@@ -156,6 +162,21 @@
 
 			if (empty($_POST['folders']) && empty($_POST['files'])) {
 				throw new Exception('No files or folders selected');
+			}
+
+			// Sanitize incoming paths: reject any traversal above the storage root.
+			if (!empty($_POST['folders'])) {
+				foreach ($_POST['folders'] as &$_folder) {
+					$_folder = f::file_resolve_path(trim($_folder, '/'));
+				}
+				unset($_folder);
+			}
+
+			if (!empty($_POST['files'])) {
+				foreach ($_POST['files'] as &$_file) {
+					$_file = f::file_resolve_path(trim($_file, '/'));
+				}
+				unset($_file);
 			}
 
 			// Pack multiple files into a zip archive

--- a/public_html/backend/mcp/mcp_orders_list.inc.php
+++ b/public_html/backend/mcp/mcp_orders_list.inc.php
@@ -2,6 +2,7 @@
 
 	return $schema = [
 		'name' => 'orders_list',
+		'app' => 'orders',
 		'description' => 'List recent orders with status, customer, total, and date. Supports filtering by status, customer, and date range.',
 		'inputSchema' => [
 			'type' => 'object',

--- a/public_html/backend/mcp/mcp_products_search.inc.php
+++ b/public_html/backend/mcp/mcp_products_search.inc.php
@@ -2,6 +2,7 @@
 
 	return $schema = [
 		'name' => 'products_search',
+		'app' => 'catalog',
 		'description' => 'Search products by keyword, category, or brand. Returns id, name, price, quantity, status, and image URL.',
 		'inputSchema' => [
 			'type' => 'object',

--- a/public_html/backend/mcp/mcp_stats_summary.inc.php
+++ b/public_html/backend/mcp/mcp_stats_summary.inc.php
@@ -2,6 +2,7 @@
 
 	return $schema = [
 		'name' => 'stats_summary',
+		'app' => 'reports',
 		'description' => 'Returns shop statistics: sales totals (month/year/all-time), order counts, averages, top 5 products by quantity, and customer/product/category counts. All monetary values in the store\'s base currency.',
 		'inputSchema' => [
 			'type' => 'object',

--- a/public_html/backend/pages/index.inc.php
+++ b/public_html/backend/pages/index.inc.php
@@ -25,11 +25,13 @@
 		$is_helper = preg_match('/\.(json|csv)$/', __DOC__)
 		          || str_ends_with(__DOC__, '_picker');
 
-		if (!empty(administrator::$data['apps'][__APP__]['status'])
-		    && !$is_helper
-		    && !in_array(__DOC__, administrator::$data['apps'][__APP__]['docs'])) {
-			notices::add('errors', t('title_access_denied', 'Access Denied'));
-			return;
+		// Empty apps map = unrestricted (super admin); non-empty = restricted to listed apps/docs.
+		if (!empty(administrator::$data['apps'])) {
+			if (empty(administrator::$data['apps'][__APP__]['status'])
+			    || (!$is_helper && !in_array(__DOC__, administrator::$data['apps'][__APP__]['docs']))) {
+				notices::add('errors', t('title_access_denied', 'Access Denied'));
+				return;
+			}
 		}
 
 		// Resolve requested document file

--- a/public_html/backend/pages/mcp.inc.php
+++ b/public_html/backend/pages/mcp.inc.php
@@ -92,6 +92,19 @@
 				);
 			}
 
+		// Resolve administrator's app permissions for per-tool gating
+		$admin_apps = !empty($administrator['apps']) ? json_decode($administrator['apps'], true) : [];
+
+		// Helper: is the administrator allowed to use this MCP tool?
+		// Tool schemas may declare an 'app' key. Tools without 'app' are system tools (allowed for any authenticated admin).
+		// When 'app' is set, restricted admins (non-empty apps map) must have status=1 on that app.
+		$mcp_tool_allowed = function($tool_schema) use ($admin_apps) {
+			$app = $tool_schema['app'] ?? '';
+			if (!$app) return true;
+			if (empty($admin_apps)) return true;
+			return !empty($admin_apps[$app]['status']);
+		};
+
 		// MCP method dispatch
 		switch ($rpc['method']) {
 
@@ -128,6 +141,9 @@
 						return include $mcp_file;
 					})();
 
+					// Skip tools the administrator isn't permitted to use
+					if (!$mcp_tool_allowed($tool_schema)) continue;
+
 					if (!empty($tool_schema['name']) && is_array($tool_schema['inputSchema'])) {
 						$tool_schemas[] = [
 							'name' => $tool_schema['name'],
@@ -162,6 +178,12 @@
 					})();
 
 					if (is_array($tool_schema) && !empty($tool_schema['name']) && $tool_schema['name'] === $params['name']) {
+
+						// Per-tool permission check
+						if (!$mcp_tool_allowed($tool_schema)) {
+							throw new McpException('Tool not permitted for this administrator', 403, -32001, $rpc_id);
+						}
+
 						$tool_function = 'mcp_' . str_replace(['/', '-'], '_', $tool_schema['name']);
 
 						if (function_exists($tool_function)) {

--- a/public_html/backend/pages/search_results.json.inc.php
+++ b/public_html/backend/pages/search_results.json.inc.php
@@ -15,6 +15,10 @@
 
 		foreach (array_column($apps, 'search_results', 'id') as $app => $file) {
 
+			// Skip apps the administrator doesn't have access to.
+			// Empty apps map = unrestricted; non-empty = restricted to listed apps.
+			if (!empty(administrator::$data['apps']) && empty(administrator::$data['apps'][$app]['status'])) continue;
+
 			$results = (function($app, $file, $query) {
 				return include 'app://backend/apps/' . $app .'/' . $file;
 			})($app, $file, $_GET['query']);


### PR DESCRIPTION
Following up on #479 — here's the cleanup PR I queued internally as PROJ-25, now that the other v3 work is through.

PROJ-25 closes the four authorization gaps from the issue. All four were exploitable by a restricted admin (or, for the storage delete/download paths, by anyone with backend access via path-traversal).

## Items addressed

| # | Symptom | Root cause | Fix |
|---|---------|------------|-----|
| 1 | Direct URL to an unassigned app loads | `index.inc.php` gate only ran when the app key existed in the admin's apps map (`!empty($apps[__APP__]['status'])`). A missing key fell through and the page rendered. | Restructure the check: when the admin has *any* restrictions configured (`!empty($apps)`), enforce per-app status + per-doc allow-list strictly. Empty apps map = unrestricted (super admin). |
| 2 | Global search returns customer / order PII to restricted admins | `search_results.json.inc.php` looped every app's `search_results` provider with no permission filter. | Skip apps the admin doesn't have status=1 on, mirroring the box_apps_menu pattern. |
| 3 | MCP `tools/list` and `tools/call` dispatch any tool after basic auth | No per-tool permission concept existed. All four built-in tools (`ping`, `products_search`, `orders_list`, `stats_summary`) were callable by any authenticated admin regardless of app restrictions. | Tool schemas gain an optional `app` key. Empty/absent = system tool (e.g. `ping`), allowed for any auth. Set = restricted admins must have that app enabled. `tools/list` filters; `tools/call` rejects with JSON-RPC `-32001` if not permitted. |
| 4 | Storage manager POST paths not normalized | `mkdir` and `chmod` had `preg_match` guards (lines 44, 74), but `delete` and `download` accepted `$_POST['files']` / `$_POST['folders']` raw — a `files[]=../../includes/config.inc.php` would escape the storage root. | Both POST paths now run each entry through `f::file_resolve_path()`, which throws when the path climbs above the root. |

## Files

| File | Lines | Purpose |
|------|-------|---------|
| `backend/pages/index.inc.php` | +6 / -4 | Item 1: restricted-apps check restructured |
| `backend/pages/search_results.json.inc.php` | +4 | Item 2: per-app permission filter |
| `backend/pages/mcp.inc.php` | +22 | Item 3: `mcp_tool_allowed` helper + filter in tools/list + check in tools/call |
| `backend/mcp/mcp_products_search.inc.php` | +1 | Item 3: declare `'app' => 'catalog'` |
| `backend/mcp/mcp_orders_list.inc.php` | +1 | Item 3: declare `'app' => 'orders'` |
| `backend/mcp/mcp_stats_summary.inc.php` | +1 | Item 3: declare `'app' => 'reports'` |
| `backend/apps/storage/storage.inc.php` | +23 | Item 4: `f::file_resolve_path()` on delete + download |

`mcp_ping.inc.php` deliberately stays without an `app` key — it's a connectivity check, no data exposure.

## Verified

- Each file `php -l` clean on PHP 8.5
- No deprecation paths introduced (no `null` to string functions, no implicit-nullable signatures, no `mb_*` numeric)
- Pattern compatibility: the `!empty(administrator::$data['apps'])` convention used in `box_apps_menu.inc.php:58` is now applied consistently in `index.inc.php` and `search_results.json.inc.php`

## Test plan

**Item 1**

- [ ] Create restricted admin with `apps = {"catalog":{"status":"1","docs":["catalog"]}}`
- [ ] Direct URL `?app=orders&doc=orders` → Access Denied (was: page rendered)
- [ ] Direct URL `?app=catalog&doc=catalog` → page renders
- [ ] Helper `?app=catalog&doc=categories.json` → JSON returned (helpers still allowed)
- [ ] Unrestricted admin (apps map empty) → all routes work as before

**Item 2**

- [ ] Restricted admin with `apps` limited to catalog → global search returns only product results, no order/customer rows
- [ ] Unrestricted admin → all groups returned as before

**Item 3**

- [ ] Restricted admin with `apps = {"catalog":{"status":"1","docs":["catalog"]}}` calling MCP `tools/list` → only `ping` and `products_search` returned
- [ ] Same admin calling `tools/call` for `orders_list` → JSON-RPC error with code `-32001`
- [ ] Unrestricted admin → all four tools listed and callable

**Item 4**

- [ ] POST `delete` with `files[]=../../includes/config.inc.php` → throws "Climbing above the root is not permitted." (caught and shown as error notice)
- [ ] POST `download` with traversal payload → same
- [ ] Normal in-storage delete / download → unchanged behaviour

Closes #479