### PR TITLE
[v3] Fix administrator known_ips/known_fingerprints array drift (#503)

### DIFF
--- a/public_html/backend/apps/administrators/edit_administrator.inc.php
+++ b/public_html/backend/apps/administrators/edit_administrator.inc.php
@@ -346,14 +346,14 @@
 					<label class="form-group">
 						<div class="form-label"><?php echo t('title_known_ip_addresses', 'Known IP Addresses'); ?></div>
 						<div class="form-input" readonly style="height: 80px;">
-							<?php echo str_replace(',', ', ', $administrator->data['known_ips']); ?>
+							<?php echo implode(', ', $administrator->data['known_ips']); ?>
 						</div>
 					</label>
 
 					<label class="form-group">
 						<div class="form-label"><?php echo t('title_known_fingerprints', 'Known Fingerprints'); ?></div>
 						<div class="form-input" readonly style="height: 80px;">
-							<?php echo str_replace(',', ', ', $administrator->data['fingerprints']); ?>
+							<?php echo implode(', ', $administrator->data['known_fingerprints']); ?>
 						</div>
 					</label>
 					<?php } ?>

--- a/public_html/includes/entities/ent_administrator.inc.php
+++ b/public_html/includes/entities/ent_administrator.inc.php
@@ -25,6 +25,8 @@
 
 			$this->data['apps'] = [];
 			$this->data['widgets'] = [];
+			$this->data['known_ips'] = [];
+			$this->data['known_fingerprints'] = [];
 
 			$this->previous = $this->data;
 		}
@@ -53,6 +55,8 @@
 
 			$this->data['apps'] = !empty($this->data['apps']) ? json_decode($this->data['apps'], true) : [];
 			$this->data['widgets'] = !empty($this->data['widgets']) ? json_decode($this->data['widgets'], true) : [];
+			$this->data['known_ips'] = f::string_split($this->data['known_ips']);
+			$this->data['known_fingerprints'] = f::string_split($this->data['known_fingerprints']);
 
 			$this->previous = $this->data;
 		}


### PR DESCRIPTION
Following your hint in #503 — `f::string_split` on load. Plus a small typo fix in the edit form that I noticed on the way through.

## What

`tests/administrator.php` was failing at the `administrator::$data` vs `$administrator->data` assertion because the two layers stored `known_ips` / `known_fingerprints` in different shapes:

| Layer | Shape after load |
|-------|------------------|
| `nod_administrator::load()` (line 157-158) | array (split on `,`) |
| `ent_administrator::load()` | comma-separated string (raw DB value) |

`f::array_intersect_compare` saw `'1.2.3.4,5.6.7.8'` against `['1.2.3.4', '5.6.7.8']` and threw.

## Fix

| File | Change |
|------|--------|
| `includes/entities/ent_administrator.inc.php` | `load()` now applies `f::string_split()` to `known_ips` and `known_fingerprints`, matching the node. `reset()` initialises both to `[]` for the new-administrator path. |
| `backend/apps/administrators/edit_administrator.inc.php` | Switched the two readonly displays from `str_replace(',', ', ', $string)` to `implode(', ', $array)`, since the entity now hands the form an array. Also fixed a pre-existing typo: `$administrator->data['fingerprints']` → `$administrator->data['known_fingerprints']` (the form was reading a non-existent key). |

No save-side change needed — `ent_administrator::save()` doesn't write `known_ips` / `known_fingerprints`. Those columns are populated by direct UPDATE statements in `nod_administrator::init()` (login tracking) and `pages/verify.inc.php` (known-IP enrolment) using comma-string concat. Both keep working unchanged.

## Verified

- `php -l` clean on both files
- `f::string_split('')` returns `[]`, so the new-record / never-logged-in case is fine
- The `(string)` cast inside `string_split()` makes the call PHP 8.5 deprecation-safe even if the column is null

## Test plan

- [ ] `php tests/administrator.php` exits 0 (was: `[FAIL]` on first assertion)
- [ ] Edit administrator page renders without warnings — IP/fingerprint readonly blocks show a comma-space-separated list
- [ ] New administrator (id=null) form renders cleanly with empty IP/fingerprint blocks
- [ ] Existing admins continue to log in; `init()` and `verify.inc.php` write paths untouched

Closes #503