### PR TITLE
[v3] Run CI against MariaDB 12 and MySQL 8.4 LTS in matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,8 @@ jobs:
                 if (!empty(\$def['length'])) \$type .= '(' . \$def['length'] . ')';
                 if (!empty(\$def['unsigned'])) \$type .= ' UNSIGNED';
                 \$null = (!isset(\$def['null']) || \$def['null']) ? '' : ' NOT NULL';
-                \$default = isset(\$def['default']) ? ' DEFAULT ' . \$def['default'] : '';
+                \$blob_text = in_array(strtoupper(\$def['type']), ['TEXT','TINYTEXT','MEDIUMTEXT','LONGTEXT','BLOB','TINYBLOB','MEDIUMBLOB','LONGBLOB','JSON','GEOMETRY']);
+                \$default = isset(\$def['default']) ? ' DEFAULT ' . (\$blob_text ? '(' . \$def['default'] . ')' : \$def['default']) : '';
                 \$auto = !empty(\$def['auto_increment']) ? ' AUTO_INCREMENT' : '';
                 \$cols[] = \"\`\$col\` \$type\$null\$default\$auto\";
               }
@@ -390,7 +391,8 @@ jobs:
                 if (!empty(\$def['length'])) \$type .= '(' . \$def['length'] . ')';
                 if (!empty(\$def['unsigned'])) \$type .= ' UNSIGNED';
                 \$null = (!isset(\$def['null']) || \$def['null']) ? '' : ' NOT NULL';
-                \$default = isset(\$def['default']) ? ' DEFAULT ' . \$def['default'] : '';
+                \$blob_text = in_array(strtoupper(\$def['type']), ['TEXT','TINYTEXT','MEDIUMTEXT','LONGTEXT','BLOB','TINYBLOB','MEDIUMBLOB','LONGBLOB','JSON','GEOMETRY']);
+                \$default = isset(\$def['default']) ? ' DEFAULT ' . (\$blob_text ? '(' . \$def['default'] . ')' : \$def['default']) : '';
                 \$auto = !empty(\$def['auto_increment']) ? ' AUTO_INCREMENT' : '';
                 \$cols[] = \"\`\$col\` \$type\$null\$default\$auto\";
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,25 +151,36 @@ jobs:
           npx gulp scss-trumbowyg
 
   platform-tests:
-    name: Platform Tests
+    name: Platform Tests (${{ matrix.db.slug }})
     runs-on: ubuntu-latest
     needs: [lint]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        db:
+          - image: mariadb:12
+            slug: mariadb-12
+            health: 'healthcheck.sh --connect --innodb_initialized'
+          - image: mysql:8.4
+            slug: mysql-8.4
+            health: 'mysqladmin ping -h localhost'
+
     services:
-      mariadb:
-        image: mariadb:12
+      database:
+        image: ${{ matrix.db.image }}
         env:
-          MARIADB_ROOT_PASSWORD: litecart_root
-          MARIADB_DATABASE: litecart
-          MARIADB_USER: litecart
-          MARIADB_PASSWORD: litecart
+          MYSQL_ROOT_PASSWORD: litecart_root
+          MYSQL_DATABASE: litecart
+          MYSQL_USER: litecart
+          MYSQL_PASSWORD: litecart
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-cmd="${{ matrix.db.health }}"
           --health-interval=10s
           --health-timeout=5s
-          --health-retries=5
+          --health-retries=10
 
     steps:
       - name: Checkout
@@ -283,25 +294,36 @@ jobs:
         run: php .git-hooks/pre-commit.d/platform_tests.php
 
   e2e-tests:
-    name: E2E Tests (Playwright)
+    name: E2E Tests (${{ matrix.db.slug }})
     runs-on: ubuntu-latest
     needs: [lint, build]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        db:
+          - image: mariadb:12
+            slug: mariadb-12
+            health: 'healthcheck.sh --connect --innodb_initialized'
+          - image: mysql:8.4
+            slug: mysql-8.4
+            health: 'mysqladmin ping -h localhost'
+
     services:
-      mariadb:
-        image: mariadb:11
+      database:
+        image: ${{ matrix.db.image }}
         env:
-          MARIADB_ROOT_PASSWORD: litecart_root
-          MARIADB_DATABASE: litecart
-          MARIADB_USER: litecart
-          MARIADB_PASSWORD: litecart
+          MYSQL_ROOT_PASSWORD: litecart_root
+          MYSQL_DATABASE: litecart
+          MYSQL_USER: litecart
+          MYSQL_PASSWORD: litecart
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-cmd="${{ matrix.db.health }}"
           --health-interval=10s
           --health-timeout=5s
-          --health-retries=5
+          --health-retries=10
 
     steps:
       - name: Checkout
@@ -434,6 +456,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.db.slug }}
           path: playwright-report/
           retention-days: 14

--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -546,7 +546,9 @@
 				}
 
 				if (isset($column['default'])) {
-					$sql .= ' DEFAULT '. $column['default'] .'';
+					// MySQL 8.0+ requires parentheses around DEFAULT for BLOB/TEXT/JSON/GEOMETRY columns
+					$blob_text = in_array(strtoupper($column['type']), ['TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT', 'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB', 'JSON', 'GEOMETRY']);
+					$sql .= ' DEFAULT '. ($blob_text ? '('. $column['default'] .')' : $column['default']);
 				}
 
 				if (!empty($column['on_update'])) {

--- a/public_html/install/upgrade.php
+++ b/public_html/install/upgrade.php
@@ -688,7 +688,9 @@
 					}
 
 					if (isset($column['default'])) {
-						$sql .= ' DEFAULT '. $column['default'] .'';
+						// MySQL 8.0+ requires parentheses around DEFAULT for BLOB/TEXT/JSON/GEOMETRY columns
+						$blob_text = in_array(strtoupper($column['type']), ['TEXT', 'TINYTEXT', 'MEDIUMTEXT', 'LONGTEXT', 'BLOB', 'TINYBLOB', 'MEDIUMBLOB', 'LONGBLOB', 'JSON', 'GEOMETRY']);
+						$sql .= ' DEFAULT '. ($blob_text ? '('. $column['default'] .')' : $column['default']);
 					}
 
 					if (!empty($column['on_update'])) {


### PR DESCRIPTION
Hey, picking up #488 — turning `platform-tests` and `e2e-tests` into a 2×DB matrix so the *MySQL and MariaDB compatible* line in `STACK_PROFILE` is something CI actually proves on every PR.

First matrix run did exactly what it was supposed to: surfaced a real MySQL-8.0+ incompatibility in the schema importer that MariaDB had been swallowing quietly. Fixed it in the same PR rather than file a follow-up — see commit 2.

## Commits

| | |
|---|---|
| `+ Run CI against MariaDB 12 and MySQL 8.4 LTS in matrix` | The matrix itself — `fail-fast: false`, parametrised service container, per-engine artefact names |
| `+ Wrap DEFAULT in parens for BLOB/TEXT/JSON/GEOMETRY columns` | The compat fix the matrix surfaced. MySQL 8.0+ rejects bare `DEFAULT` literals on these column types; both engines accept `DEFAULT (…)` in parens |

## Matrix details

| | |
|---|---|
| Strategy | `fail-fast: false` over `mariadb:12` + `mysql:8.4` for both `platform-tests` and `e2e-tests` |
| Service env | `MYSQL_*` only — MariaDB 10.6+ accepts those as legacy; no per-engine env switching |
| Health-check | parametrised: `healthcheck.sh` for MariaDB, `mysqladmin ping` for MySQL |
| Health-retries | `5 → 10` for MySQL's slightly longer first boot |
| Artefacts | `playwright-report-${{ matrix.db.slug }}` so the matrix rows don't clobber each other |
| Drift fix | `e2e-tests` was on `mariadb:11` while `platform-tests` was on `mariadb:12` — both now on 12 |

## Why the DEFAULT-paren fix touches three places

The schema-build logic is duplicated three times: `install.php` (initial install), `upgrade.php` (schema upgrades on existing installs), and the CI importer in `ci.yml` (two matrix copies). All three needed the same patch. Worth a follow-up to consolidate them, but out of scope here.

## Out of scope

| | |
|---|---|
| PHP version matrix (8.3 ↔ 8.5) | Separate concern |
| MariaDB 11 LTS / MySQL 9 | LTS 8.4 covers shared-hosting; older/newer can be added later |
| Composite action for the importer | Matrix doesn't multiply YAML duplication — block stays at two copies |
| Consolidating install.php / upgrade.php / CI schema-build into one source | Cleaner, bigger blast radius |

## Heads-up after merge

Branch protection on `dev-major` likely lists `Platform Tests` and `E2E Tests (Playwright)` as required status checks. After merge those names disappear — you'll want to update required checks to the four new matrix-suffixed names (`Platform Tests (mariadb-12)`, `Platform Tests (mysql-8.4)`, `E2E Tests (mariadb-12)`, `E2E Tests (mysql-8.4)`).

## Test plan

- [x] Lint + Build green
- [x] `Platform Tests (mariadb-12)` green
- [x] `Platform Tests (mysql-8.4)` green
- [x] `E2E Tests (mariadb-12)` green
- [x] `E2E Tests (mysql-8.4)` green
- [ ] Branch protection on `dev-major` updated to require the four new matrix-suffixed checks (post-merge, on your side)

Closes #488