### PR TITLE
[v2] Fix race condition in cache cleaner job

### DIFF
--- a/public_html/includes/modules/jobs/job_cache_cleaner.inc.php
+++ b/public_html/includes/modules/jobs/job_cache_cleaner.inc.php
@@ -39,9 +39,11 @@
           $deleted_files++;
         }
 
-        if (!is_dir($dir)) continue;
-
-        $is_empty_dir = !(new \FilesystemIterator($dir))->valid();
+        try {
+          $is_empty_dir = !(new \FilesystemIterator($dir))->valid();
+        } catch (\UnexpectedValueException $e) {
+          continue;
+        }
 
         if ($is_empty_dir) {
           rmdir($dir);

--- a/public_html/includes/modules/jobs/job_cache_cleaner.inc.php
+++ b/public_html/includes/modules/jobs/job_cache_cleaner.inc.php
@@ -39,6 +39,8 @@
           $deleted_files++;
         }
 
+        if (!is_dir($dir)) continue;
+
         $is_empty_dir = !(new \FilesystemIterator($dir))->valid();
 
         if ($is_empty_dir) {


### PR DESCRIPTION
Spotted via forum report — a 2.6.2 install kept getting fatal-error emails from Wget-driven `push_jobs` runs. Same race exists on dev.

Fixes #513

## Summary

`job_cache_cleaner` enumerates `storage/cache/*` via glob, deletes stale `*.cache` files, then probes each directory with `new FilesystemIterator($dir)` to decide whether to `rmdir`. Between the two steps the directory can disappear — another `push_jobs` run, an admin-side `cache::clear()`, anything that wipes a shard. `FilesystemIterator::__construct` then throws `UnexpectedValueException` and the cron dies mid-loop.

## Root cause

| Step | What happens |
|------|--------------|
| L29 | `glob('storage/cache/*', GLOB_ONLYDIR)` — directory exists |
| L31-40 | iterate stale files, `unlink()` |
| (race) | another process removes the directory |
| L42 | `new FilesystemIterator($dir)` — fatal |

## Why try/catch and not is_dir()

First commit used `if (!is_dir($dir)) continue;`. @timint pointed out (correctly) that this isn't tight: `glob()` with `GLOB_ONLYDIR` populates PHP's stat cache via `VCWD_LSTAT` (php-src `ext/standard/dir.c`), so a subsequent `is_dir()` in the same process can return a stale `true` even after the dir is gone.

`FilesystemIterator::__construct` doesn't go through the stat cache — it calls `opendir()` directly, syscall returns ENOENT fresh. Catching `UnexpectedValueException` catches the actual failure regardless of cache state. Second commit replaces the guard with try/catch.

## Why the race exists despite throttles

`pages/push_jobs.inc.php:11` checks the 5-min `floor(date('i')/5)` bucket, but two requests across a bucket boundary (e.g. 09:09:59 + 09:10:01) both pass. The cleaner's own 1-hour throttle reads `date_processed` at the top of `process()`, but `mod_jobs::process` only writes `date_processed` *after* `process()` returns — so a parallel run started before the writeback sees the old value and proceeds. Run A `rmdir`s shard X, run B hits the iterator on X.

In v2 nothing else `rmdir`s `cache/<shard>/`: `cache::clear_cache()` only `unlink`s files, `functions::file_delete()` is install/upgrade-only. So the deleter is always another instance of the same job.

## Test plan

- [ ] `npm run phplint`
- [ ] Trigger `Cache Cleaner` job manually from admin → completes without fatal
- [ ] `rm -rf` a `storage/cache/<shard>/` directory mid-run → loop continues, picks up next tick

Reported in https://www.litecart.net/forums/15/errors-and-troubleshooting/24741/error-report-email-generated-filesystemiterator-construct