### PR TITLE
[v3] Fix race condition in cleaner job

### DIFF
--- a/public_html/includes/modules/jobs/job_cleaner.inc.php
+++ b/public_html/includes/modules/jobs/job_cleaner.inc.php
@@ -125,9 +125,11 @@
 					$deleted_files++;
 				}
 
-				if (!is_dir($dir)) continue;
-
-				$is_empty_dir = !(new \FilesystemIterator($dir))->valid();
+				try {
+					$is_empty_dir = !(new \FilesystemIterator($dir))->valid();
+				} catch (\UnexpectedValueException $e) {
+					continue;
+				}
 
 				if ($is_empty_dir) {
 					rmdir($dir);

--- a/public_html/includes/modules/jobs/job_cleaner.inc.php
+++ b/public_html/includes/modules/jobs/job_cleaner.inc.php
@@ -125,6 +125,8 @@
 					$deleted_files++;
 				}
 
+				if (!is_dir($dir)) continue;
+
 				$is_empty_dir = !(new \FilesystemIterator($dir))->valid();
 
 				if ($is_empty_dir) {


### PR DESCRIPTION
Carry-over from the v2 fix in #514 — same race lives in v3's `job_cleaner`. Reported by a 2.6.2 user, but the bug is older than the fork between branches.

Related to #513

## Summary

`job_cleaner` enumerates `storage://cache/*` via glob, deletes stale `*.cache` files, then probes each directory with `new FilesystemIterator($dir)` to decide whether to `rmdir`. Between the two steps the directory can disappear — concurrent push_jobs run, an admin-side cache wipe, anything that removes a shard. `FilesystemIterator::__construct` then throws `UnexpectedValueException` and the cron dies mid-loop.

## Root cause

| Step | What happens |
|------|--------------|
| L117 | `glob('storage://cache/*', GLOB_ONLYDIR)` — directory exists |
| L119-126 | iterate stale files, `unlink()` |
| (race) | another process removes the directory |
| L128 | `new FilesystemIterator($dir)` — fatal |

## Why try/catch and not is_dir()

First commit used `if (!is_dir($dir)) continue;`. @timint pointed out (correctly) that this isn't tight: `glob()` with `GLOB_ONLYDIR` populates PHP's stat cache via `VCWD_LSTAT` (php-src `ext/standard/dir.c`), so a subsequent `is_dir()` in the same process can return a stale `true` even after the dir is gone.

`FilesystemIterator::__construct` doesn't go through the stat cache — it calls `opendir()` directly, syscall returns ENOENT fresh. Catching `UnexpectedValueException` catches the actual failure regardless of cache state. Second commit replaces the guard with try/catch.

## Test plan

- [ ] `npm run phplint`
- [ ] Trigger `Cleaner` job manually from admin → completes without fatal
- [ ] `rm -rf` a `storage/cache/<shard>/` directory mid-run → loop continues

Reported in https://www.litecart.net/forums/15/errors-and-troubleshooting/24741/error-report-email-generated-filesystemiterator-construct