### PR TITLE
[v3] Fix CI MariaDB matrix — MARIADB_* env vars and mariadb-admin healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         db:
           - image: mariadb:latest
             slug: mariadb-latest
-            health: 'mysqladmin ping -h localhost'
+            health: 'mariadb-admin ping -h localhost'
           - image: mysql:latest
             slug: mysql-latest
             health: 'mysqladmin ping -h localhost'
@@ -119,10 +119,17 @@ jobs:
       database:
         image: ${{ matrix.db.image }}
         env:
+          # Both env-var families are set so the service block works on
+          # mariadb:latest (which no longer accepts the legacy MYSQL_*
+          # aliases) and on mysql:latest (which ignores MARIADB_*).
           MYSQL_ROOT_PASSWORD: litecart
           MYSQL_DATABASE: litecart
           MYSQL_USER: litecart
           MYSQL_PASSWORD: litecart
+          MARIADB_ROOT_PASSWORD: litecart
+          MARIADB_DATABASE: litecart
+          MARIADB_USER: litecart
+          MARIADB_PASSWORD: litecart
         ports:
           - 3306:3306
         options: >-
@@ -156,14 +163,20 @@ jobs:
       mariadb:
         image: mariadb:latest
         env:
+          # mariadb:latest no longer accepts legacy MYSQL_* aliases — set
+          # both families so this block survives future image renames too.
           MYSQL_ROOT_PASSWORD: litecart
           MYSQL_DATABASE: litecart
           MYSQL_USER: litecart
           MYSQL_PASSWORD: litecart
+          MARIADB_ROOT_PASSWORD: litecart
+          MARIADB_DATABASE: litecart
+          MARIADB_USER: litecart
+          MARIADB_PASSWORD: litecart
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h localhost"
+          --health-cmd="mariadb-admin ping -h localhost"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -205,7 +218,7 @@ jobs:
         db:
           - image: mariadb:latest
             slug: mariadb-latest
-            health: 'mysqladmin ping -h localhost'
+            health: 'mariadb-admin ping -h localhost'
           - image: mysql:latest
             slug: mysql-latest
             health: 'mysqladmin ping -h localhost'
@@ -214,10 +227,16 @@ jobs:
       mariadb:
         image: ${{ matrix.db.image }}
         env:
+          # Set both env-var families so the block works on either engine
+          # (mariadb:latest no longer accepts legacy MYSQL_* aliases).
           MYSQL_ROOT_PASSWORD: litecart
           MYSQL_DATABASE: litecart
           MYSQL_USER: litecart
           MYSQL_PASSWORD: litecart
+          MARIADB_ROOT_PASSWORD: litecart
+          MARIADB_DATABASE: litecart
+          MARIADB_USER: litecart
+          MARIADB_PASSWORD: litecart
         ports:
           - 3306:3306
         options: >-


### PR DESCRIPTION
Tiny CI-only fix — the matrix moved from `mariadb:12` (PROJ-31, #512) to `mariadb:latest` somewhere along the way, and current MariaDB releases stopped accepting the legacy `MYSQL_*` env-var aliases that the service block was relying on. Result: every run on `dev-major` has the MariaDB column failing at `Initialize containers` with `unhealthy` after the retries window. The MySQL column is fine.

## What changes

| Block | Before | After |
|-------|--------|-------|
| Install / platform-tests / e2e-tests env vars | `MYSQL_*` only | `MYSQL_*` **and** `MARIADB_*` set side by side |
| Install / e2e-tests matrix healthcheck (MariaDB row) | `mysqladmin ping -h localhost` | `mariadb-admin ping -h localhost` |
| Install / e2e-tests matrix healthcheck (MySQL row) | unchanged | unchanged (`mysqladmin`) |
| platform-tests hardcoded MariaDB service healthcheck | `mysqladmin ping` | `mariadb-admin ping` |

`mariadb-admin` has shipped in every MariaDB release since 10.5 — the `mysqladmin` symlink is being phased out and is already unreliable on `:latest`. MySQL's tool keeps the original name.

Both env-var families are set rather than picking one, so the block survives whichever engine drops its alias next. Cost is zero — each engine ignores the other family.

## Verified

- `python -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` — green
- ci.yml diff is +22/-3, single file
- No application-code or schema change

## Test plan

- [ ] CI green across all four matrix columns (`install` mariadb-latest + mysql-latest, `e2e-tests` mariadb-latest + mysql-latest)
- [ ] `platform-tests` job runs through against the hardcoded MariaDB service

Sequenced behind #522 (`closes #523`) only because that one is the substantive change — this one is independent and merge-order doesn't matter.
