### PR TITLE
[v3] Add type_email datatype (closes #526)

### DIFF
--- a/public_html/includes/datatypes/type_email.inc.php
+++ b/public_html/includes/datatypes/type_email.inc.php
@@ -1,0 +1,164 @@
+<?php
+
+	/*
+		Example usage:
+		$email = new type_email('"John Doe" <john@example.com>');
+		echo $email->local;     // john
+		echo $email->domain;    // example.com
+		echo $email->name;      // John Doe
+		echo $email;            // "John Doe" <john@example.com>
+		echo $email->address;   // john@example.com (without display name)
+
+		Drop-in for ent_email recipient/sender arrays:
+		$email->jsonSerialize(); // ['email' => 'john@example.com', 'name' => 'John Doe']
+	*/
+
+	class type_email implements \JsonSerializable {
+
+		private $_components;
+
+		public function __construct($input='') {
+
+			$this->reset();
+
+			if ($input instanceof type_email) {
+				foreach (array_keys($this->_components) as $component) {
+					$this->$component = $input->$component;
+				}
+				return;
+			}
+
+			if (is_array($input)) {
+				foreach ($input as $component => $value) {
+					$this->$component = $value;
+				}
+				return;
+			}
+
+			if (!is_string($input) || $input === '') {
+				return;
+			}
+
+			// Parse "Name <addr@host>" or "<addr@host>" or "addr@host"
+			if (preg_match('#^\s*("?)(?<name>.*?)\1\s*<(?<address>[^>]+)>\s*$#', $input, $matches)) {
+				$this->name = trim($matches['name']);
+				$this->address = trim($matches['address']);
+			} else {
+				$this->address = trim($input);
+			}
+		}
+
+		public function __isset($component) {
+			return !empty($this->_components[$component]);
+		}
+
+		public function __unset($component) {
+			$this->__set($component, '');
+		}
+
+		public function __get($component) {
+
+			switch ($component) {
+
+				case 'address':
+					if (!empty($this->_components['local']) && !empty($this->_components['domain'])) {
+						return $this->_components['local'] .'@'. $this->_components['domain'];
+					}
+					return '';
+
+				case 'is_valid':
+					return (bool)$this->__get('address')
+						&& (bool)preg_match(
+							'#^([a-zA-Z0-9])+([a-zA-Z0-9\+\._-])*@([a-zA-Z0-9_-])+([a-zA-Z0-9\._-]+)+$#',
+							$this->__get('address')
+						);
+
+				case 'local':
+				case 'domain':
+				case 'name':
+					return $this->_components[$component] ?? '';
+			}
+
+			trigger_error("Unknown email component ($component)", E_USER_WARNING);
+			return null;
+		}
+
+		public function __set($component, $value) {
+
+			switch ($component) {
+
+				case 'address':
+				case 'email':
+					$value = trim((string)$value);
+					$value = filter_var($value, FILTER_SANITIZE_EMAIL);
+
+					if ($value !== '' && str_contains($value, '@')) {
+						[$local, $domain] = explode('@', $value, 2);
+						$this->_components['local'] = $local;
+						$this->_components['domain'] = strtolower($domain);
+					} else if ($value === '') {
+						$this->_components['local'] = '';
+						$this->_components['domain'] = '';
+					} else {
+						// no '@' — treat the whole thing as the local part so callers
+						// setting partial data don't lose it silently
+						$this->_components['local'] = $value;
+						$this->_components['domain'] = '';
+					}
+					return $this;
+
+				case 'local':
+					$this->_components['local'] = trim((string)$value);
+					return $this;
+
+				case 'domain':
+					$this->_components['domain'] = strtolower(trim((string)$value));
+					return $this;
+
+				case 'name':
+					// Strip CRLF / tabs so the value is safe for mail headers.
+					$this->_components['name'] = trim(preg_replace('#[\r\n\t]#', '', (string)$value));
+					return $this;
+			}
+
+			trigger_error("Unknown email component ($component)", E_USER_WARNING);
+			return $this;
+		}
+
+		public function __toString() {
+
+			$address = $this->__get('address');
+
+			if ($address === '') {
+				return '';
+			}
+
+			if (!empty($this->_components['name'])) {
+				// Quote the display name if it contains characters that would otherwise
+				// break the header (e.g. comma, semicolon). Plain ASCII alphanumeric +
+				// space stays unquoted.
+				if (preg_match('#[^\w\s\-\.]#u', $this->_components['name'])) {
+					return '"'. addcslashes($this->_components['name'], '"\\') .'" <'. $address .'>';
+				}
+				return $this->_components['name'] .' <'. $address .'>';
+			}
+
+			return $address;
+		}
+
+		#[\ReturnTypeWillChange] // Fix PHP 8.1
+		public function jsonSerialize() {
+			return [
+				'email' => $this->__get('address'),
+				'name'  => $this->_components['name'] ?? '',
+			];
+		}
+
+		public function reset() {
+			$this->_components = [
+				'local'  => '',
+				'domain' => '',
+				'name'   => '',
+			];
+		}
+	}

--- a/tests/type_email.php
+++ b/tests/type_email.php
@@ -1,0 +1,217 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/datatypes/type_email.inc.php';
+
+	try {
+
+		########################################################################
+		## TC-01: Constructor parses bare address
+		########################################################################
+
+		$email = new type_email('john@example.com');
+
+		if ($email->local !== 'john') {
+			throw new Exception('TC-01: local not parsed (got "'. $email->local .'")');
+		}
+
+		if ($email->domain !== 'example.com') {
+			throw new Exception('TC-01: domain not parsed (got "'. $email->domain .'")');
+		}
+
+		if ($email->name !== '') {
+			throw new Exception('TC-01: name should be empty (got "'. $email->name .'")');
+		}
+
+		if ((string)$email !== 'john@example.com') {
+			throw new Exception('TC-01: __toString wrong (got "'. (string)$email .'")');
+		}
+
+		########################################################################
+		## TC-02: Constructor parses "Name <addr>" form
+		########################################################################
+
+		$email = new type_email('John Doe <john@example.com>');
+
+		if ($email->name !== 'John Doe') {
+			throw new Exception('TC-02: display name not parsed (got "'. $email->name .'")');
+		}
+
+		if ($email->address !== 'john@example.com') {
+			throw new Exception('TC-02: address not parsed (got "'. $email->address .'")');
+		}
+
+		########################################################################
+		## TC-03: Quoted display name with special chars round-trips
+		########################################################################
+
+		$email = new type_email('"John, Jr." <john@example.com>');
+
+		if ($email->name !== 'John, Jr.') {
+			throw new Exception('TC-03: quoted name not parsed (got "'. $email->name .'")');
+		}
+
+		if ((string)$email !== '"John, Jr." <john@example.com>') {
+			throw new Exception('TC-03: quoted name round-trip failed (got "'. (string)$email .'")');
+		}
+
+		########################################################################
+		## TC-04: Bracketed-only form ("<addr>") drops the brackets
+		########################################################################
+
+		$email = new type_email('<just@addr.com>');
+
+		if ($email->name !== '' || $email->address !== 'just@addr.com') {
+			throw new Exception('TC-04: bracketed-only form not parsed correctly');
+		}
+
+		########################################################################
+		## TC-05: Surrounding whitespace is trimmed
+		########################################################################
+
+		$email = new type_email('  spaced@example.com  ');
+
+		if ($email->local !== 'spaced' || $email->domain !== 'example.com') {
+			throw new Exception('TC-05: whitespace not trimmed');
+		}
+
+		########################################################################
+		## TC-06: Domain is normalised to lowercase, local preserves case
+		########################################################################
+
+		$email = new type_email('Mixed@CASE.com');
+
+		if ($email->local !== 'Mixed') {
+			throw new Exception('TC-06: local case should be preserved (got "'. $email->local .'")');
+		}
+
+		if ($email->domain !== 'case.com') {
+			throw new Exception('TC-06: domain should be lowercase (got "'. $email->domain .'")');
+		}
+
+		########################################################################
+		## TC-07: Array constructor for drop-in compatibility with ent_email
+		########################################################################
+
+		$email = new type_email(['email' => 'a@b.c', 'name' => 'X']);
+
+		if ($email->address !== 'a@b.c' || $email->name !== 'X') {
+			throw new Exception('TC-07: array constructor failed');
+		}
+
+		########################################################################
+		## TC-08: type_email constructor argument copies all components
+		########################################################################
+
+		$original = new type_email('Alice <alice@example.com>');
+		$copy = new type_email($original);
+
+		if ($copy->address !== 'alice@example.com' || $copy->name !== 'Alice') {
+			throw new Exception('TC-08: type_email copy constructor failed');
+		}
+
+		########################################################################
+		## TC-09: jsonSerialize returns ent_email-compatible shape
+		########################################################################
+
+		$email = new type_email('John <john@x.com>');
+		$serialized = $email->jsonSerialize();
+
+		if (!is_array($serialized) || ($serialized['email'] ?? null) !== 'john@x.com' || ($serialized['name'] ?? null) !== 'John') {
+			throw new Exception('TC-09: jsonSerialize shape mismatch (got '. json_encode($serialized) .')');
+		}
+
+		########################################################################
+		## TC-10: Setting address re-splits local/domain
+		########################################################################
+
+		$email = new type_email('old@old.com');
+		$email->address = 'new@new.com';
+
+		if ($email->local !== 'new' || $email->domain !== 'new.com') {
+			throw new Exception('TC-10: address setter did not re-split');
+		}
+
+		########################################################################
+		## TC-11: Setting local or domain alone updates the composed address
+		########################################################################
+
+		$email = new type_email('john@example.com');
+		$email->local = 'jane';
+
+		if ($email->address !== 'jane@example.com') {
+			throw new Exception('TC-11a: local setter did not update address (got "'. $email->address .'")');
+		}
+
+		$email->domain = 'OTHER.com';
+
+		if ($email->address !== 'jane@other.com') {
+			throw new Exception('TC-11b: domain setter should normalise to lowercase (got "'. $email->address .'")');
+		}
+
+		########################################################################
+		## TC-12: is_valid reflects the standard validate_email regex
+		########################################################################
+
+		if (!(new type_email('test@example.com'))->is_valid) {
+			throw new Exception('TC-12a: well-formed address should be valid');
+		}
+
+		if ((new type_email('not-an-email'))->is_valid) {
+			throw new Exception('TC-12b: malformed input should not be valid');
+		}
+
+		if ((new type_email(''))->is_valid) {
+			throw new Exception('TC-12c: empty input should not be valid');
+		}
+
+		########################################################################
+		## TC-13: Name setter strips CRLF / tabs (header-injection guard)
+		########################################################################
+
+		$email = new type_email('john@example.com');
+		$email->name = "Evil\r\nBcc: leaked@attacker.com";
+
+		if (preg_match('#[\r\n\t]#', $email->name)) {
+			throw new Exception('TC-13: name setter must strip CRLF/tabs (got '. json_encode($email->name) .')');
+		}
+
+		########################################################################
+		## TC-14: Empty input stays empty (no defaults injected)
+		########################################################################
+
+		$email = new type_email('');
+
+		if ($email->address !== '' || $email->name !== '' || (string)$email !== '') {
+			throw new Exception('TC-14: empty constructor should yield empty components');
+		}
+
+		########################################################################
+		## TC-15: Unknown component access triggers a warning (defense)
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_WARNING);
+
+		try {
+			$email = new type_email('john@example.com');
+			$_ = $email->unknown_property;
+			throw new Exception('TC-15: expected E_USER_WARNING on unknown component');
+		} catch (ErrorException $ex) {
+			if (!str_contains($ex->getMessage(), 'Unknown email component')) {
+				throw new Exception('TC-15: wrong warning message: '. $ex->getMessage());
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Third datatype on the heels of `type_url` (`064c6b169`) and `type_array` (`ab12d4f36`) — mirrors the same shape, lands on a use case where the boilerplate is already obvious: `ent_email` carries four near-identical helpers (`set_sender`, `add_recipient`, `add_cc`, `add_bcc`) that each parse `"Name <addr>"`, trim, strip CRLF, validate, and sanitize before storing the result as `['email' => …, 'name' => …]`.

## Shape

```php
$email = new type_email('"John Doe" <john@example.com>');
$email->local;            // 'john'
$email->domain;           // 'example.com'
$email->name;             // 'John Doe'
$email->address;          // 'john@example.com'
$email->is_valid;         // true
echo $email;              // 'John Doe <john@example.com>'
$email->jsonSerialize();  // ['email' => 'john@example.com', 'name' => 'John Doe']
```

Constructor accepts `string`, `array`, or another `type_email` (analog `type_url`). Magic setters keep components consistent — assigning `local` recomposes `address`, assigning `domain` also normalises to lowercase. Name setter strips CRLF/tabs as a header-injection guard so the value is safe to drop straight into mail headers.

`is_valid` reuses the `f::validate_email()` regex so the validation contract matches the rest of the platform.

## Drop-in compatibility

`jsonSerialize()` returns the exact `['email' => …, 'name' => …]` shape `ent_email` already persists in JSON columns. The follow-up entity refactor (separate PR) becomes:

```php
$this->data['sender'] = ($input instanceof type_email)
    ? $input->jsonSerialize()
    : (new type_email($input, $name))->jsonSerialize();
```

No schema change, no migration, just collapsed boilerplate (~120 lines across the four ent_email methods).

## Test plan

`tests/type_email.php` — 15 TCs, all green locally on PHP 8.5:

- [ ] TC-01 to TC-06: parser variants (bare, quoted, bracketed, whitespace, case)
- [ ] TC-07 to TC-08: array + type_email copy constructors
- [ ] TC-09: `jsonSerialize()` shape matches the ent_email JSON column format
- [ ] TC-10 to TC-11: setter round-trips (`address`, `local`, `domain` independently)
- [ ] TC-12: `is_valid` regex parity with `f::validate_email`
- [ ] TC-13: CRLF / tab stripping on `name` setter (header-injection guard)
- [ ] TC-14: empty input stays empty (no defaults injected)
- [ ] TC-15: unknown component access triggers `E_USER_WARNING`
- [ ] CI runs `tests/type_email.php` via the platform-tests harness

Out of scope here: migrating `ent_email`'s setters to accept `type_email`. Once this lands I'll send a small follow-up that adds the optional `type_email` overload and leaves the existing string/two-arg call shape working for compatibility.

Closes #526.
