### PR TITLE
[v3] Add type_money datatype with dual construction modes (#528)

### DIFF
--- a/public_html/includes/datatypes/type_money.inc.php
+++ b/public_html/includes/datatypes/type_money.inc.php
@@ -1,0 +1,181 @@
+<?php
+
+	/*
+		Represents a monetary amount with currency awareness. Two construction modes:
+
+		1) Single amount + currency — internally normalised to the store currency
+		   and converted on demand. Use this for calculated values (totals, taxes).
+
+		    $price = new type_money(99.99, 'USD');
+		    echo $price->in('EUR');             // float, converted from USD
+		    echo $price;                        // 'USD 99.99' formatted
+		    $price->convert('EUR')->format();   // chainable — returns new type_money
+
+		2) Fixed amounts per currency — explicit merchant-set prices that should
+		   NOT drift with FX-rate refreshes. Use this for catalog prices.
+
+		    $price = new type_money(['USD' => 99.99, 'EUR' => 92.00, 'SEK' => 1050]);
+		    echo $price->in('EUR');             // 92.00 — verbatim, no conversion
+		    echo $price->in('GBP');             // converts from store-currency entry
+
+		Drop-in for entity JSON columns that already store per-currency maps —
+		jsonSerialize() returns ['amounts' => [...], 'mode' => 'fixed'|'converted'].
+	*/
+
+	class type_money implements \JsonSerializable {
+
+		const MODE_CONVERTED = 'converted';
+		const MODE_FIXED     = 'fixed';
+
+		private $_amounts = [];
+		private $_mode;
+		private $_origin_currency;
+
+		public function __construct($input = 0, ?string $currency_code = null) {
+
+			if ($input instanceof type_money) {
+				$this->_amounts         = $input->_amounts;
+				$this->_mode            = $input->_mode;
+				$this->_origin_currency = $input->_origin_currency;
+				return;
+			}
+
+			$store_currency = (string)settings::get('store_currency_code');
+
+			if (is_array($input)) {
+
+				// Fixed-amounts-per-currency mode — explicit merchant prices, no conversion.
+				if (isset($input['amounts']) && is_array($input['amounts'])) {
+					// jsonSerialize round-trip — accept the serialised shape verbatim.
+					$this->_amounts         = array_map('floatval', $input['amounts']);
+					$this->_mode            = ($input['mode'] ?? self::MODE_FIXED) === self::MODE_CONVERTED ? self::MODE_CONVERTED : self::MODE_FIXED;
+					$this->_origin_currency = $input['origin_currency'] ?? $store_currency;
+					return;
+				}
+
+				// Plain map of currency_code => amount.
+				$this->_amounts         = array_map('floatval', $input);
+				$this->_mode            = self::MODE_FIXED;
+				$this->_origin_currency = array_key_first($this->_amounts) ?: $store_currency;
+				return;
+			}
+
+			// Single amount mode — normalise to store currency for consistent math.
+			$amount   = (float)$input;
+			$currency = $currency_code ?: $store_currency;
+			$this->_origin_currency = $currency;
+			$this->_mode            = self::MODE_CONVERTED;
+			$this->_amounts         = [
+				$store_currency => $currency === $store_currency ? $amount : (float)currency::convert($amount, $currency, $store_currency),
+			];
+		}
+
+		public function __get($name) {
+
+			switch ($name) {
+
+				case 'amount':
+					// Default to the origin currency in single-amount mode, or to the
+					// store-currency entry in fixed-map mode if present, else first.
+					return $this->in($this->_origin_currency);
+
+				case 'currency':
+				case 'currency_code':
+					return $this->_origin_currency;
+
+				case 'mode':
+					return $this->_mode;
+
+				case 'is_fixed':
+					return $this->_mode === self::MODE_FIXED;
+
+				case 'currencies':
+					return array_keys($this->_amounts);
+			}
+
+			trigger_error("Unknown money component ($name)", E_USER_WARNING);
+			return null;
+		}
+
+		public function __set($name, $value) {
+			trigger_error("type_money is immutable — use convert() / with_amount() for derived values", E_USER_WARNING);
+			return $this;
+		}
+
+		/*
+			Returns the amount as a float in the requested currency.
+			Fixed-mode: returns the verbatim merchant-set amount if present,
+			otherwise falls back to converting from the store-currency entry.
+			Converted-mode: always converts from the store-currency reference.
+		*/
+		public function in(?string $currency_code = null): float {
+
+			$currency = $currency_code ?: $this->_origin_currency;
+
+			if ($this->_mode === self::MODE_FIXED && isset($this->_amounts[$currency])) {
+				return $this->_amounts[$currency];
+			}
+
+			$store_currency = (string)settings::get('store_currency_code');
+			$base_currency  = isset($this->_amounts[$store_currency]) ? $store_currency : array_key_first($this->_amounts);
+			$base_amount    = $this->_amounts[$base_currency] ?? 0.0;
+
+			if ($base_currency === $currency) {
+				return $base_amount;
+			}
+
+			return (float)currency::convert($base_amount, $base_currency, $currency);
+		}
+
+		/*
+			Returns a new type_money in the requested currency (chainable).
+			Single-amount mode preserves the converted value. Fixed-mode
+			preserves all entries but changes the default currency.
+		*/
+		public function convert(string $currency_code): type_money {
+
+			if ($this->_mode === self::MODE_FIXED) {
+				$copy = new type_money($this);
+				$copy->_origin_currency = $currency_code;
+				return $copy;
+			}
+
+			return new type_money($this->in($currency_code), $currency_code);
+		}
+
+		/*
+			Returns a new type_money with a different amount in the same currency.
+			Useful for tax math and discount applications.
+		*/
+		public function with_amount(float $amount, ?string $currency_code = null): type_money {
+			return new type_money($amount, $currency_code ?: $this->_origin_currency);
+		}
+
+		public function format(?string $currency_code = null, $auto_decimals = true): string {
+			$currency = $currency_code ?: $this->_origin_currency;
+			return currency::format($this->in($currency), $auto_decimals, $currency);
+		}
+
+		public function format_html(?string $currency_code = null, $auto_decimals = true): string {
+			$currency = $currency_code ?: $this->_origin_currency;
+			return currency::format_html($this->in($currency), $auto_decimals, $currency);
+		}
+
+		public function format_raw(?string $currency_code = null): string {
+			$currency = $currency_code ?: $this->_origin_currency;
+			return currency::format_raw($this->in($currency), $currency);
+		}
+
+		public function __toString(): string {
+			return $this->format();
+		}
+
+		#[\ReturnTypeWillChange] // Fix PHP 8.1
+		public function jsonSerialize() {
+			return [
+				'amounts'         => $this->_amounts,
+				'mode'            => $this->_mode,
+				'origin_currency' => $this->_origin_currency,
+			];
+		}
+	}

--- a/tests/type_money.php
+++ b/tests/type_money.php
@@ -1,0 +1,217 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$store_currency = (string)settings::get('store_currency_code');
+
+		########################################################################
+		## TC-01: Single-amount constructor stores normalised to store currency
+		########################################################################
+
+		$price = new type_money(100, $store_currency);
+
+		if ($price->currency !== $store_currency) {
+			throw new Exception('TC-01: currency not stored (got "'. $price->currency .'")');
+		}
+
+		if (abs($price->in($store_currency) - 100) > 0.001) {
+			throw new Exception('TC-01: amount mismatch in store currency (got '. $price->in($store_currency) .')');
+		}
+
+		if ($price->mode !== type_money::MODE_CONVERTED) {
+			throw new Exception('TC-01: expected mode=converted, got "'. $price->mode .'"');
+		}
+
+		########################################################################
+		## TC-02: Fixed-amounts-per-currency constructor stores verbatim
+		########################################################################
+
+		$price = new type_money([$store_currency => 100, 'EUR' => 92, 'SEK' => 1050]);
+
+		if ($price->mode !== type_money::MODE_FIXED) {
+			throw new Exception('TC-02: expected mode=fixed, got "'. $price->mode .'"');
+		}
+
+		if (!$price->is_fixed) {
+			throw new Exception('TC-02: is_fixed should be true');
+		}
+
+		if ($price->in('EUR') !== 92.0) {
+			throw new Exception('TC-02: fixed EUR amount should be 92.0 verbatim (got '. $price->in('EUR') .')');
+		}
+
+		if ($price->in('SEK') !== 1050.0) {
+			throw new Exception('TC-02: fixed SEK amount should be 1050.0 verbatim (got '. $price->in('SEK') .')');
+		}
+
+		########################################################################
+		## TC-03: Fixed-mode falls back to conversion for unlisted currencies
+		########################################################################
+
+		$price = new type_money([$store_currency => 100, 'EUR' => 92]);
+		$gbp_amount = $price->in('GBP'); // not in the map — must convert from store entry
+
+		// We can't assert an exact rate, but the result must be a positive float
+		if (!is_float($gbp_amount) || $gbp_amount <= 0) {
+			throw new Exception('TC-03: GBP fallback conversion should yield a positive float (got '. var_export($gbp_amount, true) .')');
+		}
+
+		########################################################################
+		## TC-04: convert() returns a NEW type_money (immutable, chainable)
+		########################################################################
+
+		$usd = new type_money(100, $store_currency);
+		$eur = $usd->convert('EUR');
+
+		if (!($eur instanceof type_money)) {
+			throw new Exception('TC-04: convert() must return a type_money instance');
+		}
+
+		if ($eur === $usd) {
+			throw new Exception('TC-04: convert() must return a new object, not the same reference');
+		}
+
+		if ($eur->currency !== 'EUR') {
+			throw new Exception('TC-04: converted instance should be in EUR (got "'. $eur->currency .'")');
+		}
+
+		// Chainable through format()
+		if (!is_string($usd->convert('EUR')->format())) {
+			throw new Exception('TC-04: chain convert()->format() must yield a string');
+		}
+
+		########################################################################
+		## TC-05: with_amount() returns a new type_money in the same currency
+		########################################################################
+
+		$price = new type_money(100, $store_currency);
+		$doubled = $price->with_amount(200);
+
+		if ($doubled === $price || abs($doubled->in($store_currency) - 200) > 0.001) {
+			throw new Exception('TC-05: with_amount() must produce a fresh, updated instance');
+		}
+
+		if ($doubled->currency !== $store_currency) {
+			throw new Exception('TC-05: with_amount() should preserve the currency');
+		}
+
+		########################################################################
+		## TC-06: type_money copy constructor clones all components
+		########################################################################
+
+		$original = new type_money([$store_currency => 100, 'EUR' => 92]);
+		$copy = new type_money($original);
+
+		if ($copy->mode !== $original->mode || $copy->currencies !== $original->currencies) {
+			throw new Exception('TC-06: copy constructor must clone mode + currencies');
+		}
+
+		########################################################################
+		## TC-07: jsonSerialize round-trips through json_encode / json_decode
+		########################################################################
+
+		$original = new type_money([$store_currency => 100, 'EUR' => 92, 'SEK' => 1050]);
+		$serialized = json_encode($original);
+		$decoded = json_decode($serialized, true);
+		$rebuilt = new type_money($decoded);
+
+		if ($rebuilt->mode !== $original->mode) {
+			throw new Exception('TC-07: mode lost across json round-trip');
+		}
+
+		if ($rebuilt->in('EUR') !== 92.0 || $rebuilt->in('SEK') !== 1050.0) {
+			throw new Exception('TC-07: fixed amounts lost across json round-trip');
+		}
+
+		########################################################################
+		## TC-08: Magic setters reject mutation (immutable contract)
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_WARNING);
+
+		try {
+			$price = new type_money(100, $store_currency);
+			$price->amount = 200;
+			throw new Exception('TC-08: expected E_USER_WARNING on direct property mutation');
+		} catch (ErrorException $ex) {
+			if (!str_contains($ex->getMessage(), 'immutable')) {
+				throw new Exception('TC-08: wrong warning message: '. $ex->getMessage());
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-09: __toString() defaults to format() in origin currency
+		########################################################################
+
+		$price = new type_money(100, $store_currency);
+		$rendered = (string)$price;
+
+		if ($rendered === '') {
+			throw new Exception('TC-09: __toString() should not yield empty string');
+		}
+
+		// Expect the rendered string to contain the formatted amount somewhere
+		if (strpos($rendered, '100') === false && strpos($rendered, '100.00') === false) {
+			throw new Exception('TC-09: __toString() output should reflect the amount (got "'. $rendered .'")');
+		}
+
+		########################################################################
+		## TC-10: Unknown component access triggers warning
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_WARNING);
+
+		try {
+			$price = new type_money(100, $store_currency);
+			$_ = $price->unknown_property;
+			throw new Exception('TC-10: expected E_USER_WARNING on unknown component');
+		} catch (ErrorException $ex) {
+			if (!str_contains($ex->getMessage(), 'Unknown money component')) {
+				throw new Exception('TC-10: wrong warning message: '. $ex->getMessage());
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-11: currencies getter returns the list of stored currency codes
+		########################################################################
+
+		$price = new type_money([$store_currency => 100, 'EUR' => 92, 'SEK' => 1050]);
+
+		if (!in_array($store_currency, $price->currencies) || !in_array('EUR', $price->currencies)) {
+			throw new Exception('TC-11: currencies list missing entries');
+		}
+
+		########################################################################
+		## TC-12: Zero amount handled gracefully
+		########################################################################
+
+		$zero = new type_money(0, $store_currency);
+
+		if ($zero->in($store_currency) !== 0.0) {
+			throw new Exception('TC-12: zero amount not preserved');
+		}
+
+		if ((string)$zero === '') {
+			throw new Exception('TC-12: zero should still format to a non-empty string');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Picking up #528 — builds on the draft you posted in the types.zip dump and extends it along the lines we discussed in the comment thread.

## What changed vs. the draft

| Area | Draft | This PR |
|------|-------|---------|
| Construction | `(float, currency_code)` only | Same **plus** `(array $currency_map)` for fixed-amounts-per-currency mode |
| `convert()` return | `float` | `type_money` — the chain pattern you said you liked works now (`$price->convert('EUR')->format()`) |
| Internal storage key | `settings::get('site_currency_code')` (doesn't exist in v3) | `store_currency_code` |
| Immutability | implicit (public properties allowed mutation) | enforced — magic setter rejects with `E_USER_WARNING`, derived values come from `convert()` / `with_amount()` |
| JsonSerializable | absent | full round-trip — `mode` + `origin_currency` + `amounts` |

## The two modes

```php
// Mode A: single amount + currency, auto-converts to store currency internally.
// Use for calculated values (totals, taxes, discounts).
$total = new type_money(99.99, 'USD');
$total->in('EUR');             // float, converted on demand
$total->convert('EUR')         // new type_money in EUR
      ->format();              // 'EUR 92.05' (or whatever the rate yields)

// Mode B: fixed amounts per currency, verbatim merchant prices.
// Use for catalog prices that should NOT drift with FX-rate refreshes.
$price = new type_money([
    'USD' => 99.99,
    'EUR' => 92.00,
    'SEK' => 1050,
]);
$price->in('EUR');             // 92.00 — exact merchant price, no conversion
$price->in('GBP');             // falls back to converting from the store-currency entry
```

Detection lives in the constructor — `is_array($input)` → fixed mode, scalar → converted mode. The two modes coexist on the same type without a separate class, which keeps `type_taxable_amount` (#528 sibling) able to compose either flavour.

## Why immutable

`type_url` is mutable (you can set `$url->host = 'x'` directly), but money flows through many more code paths — totals, taxes, discounts, conversions — and a mutable instance there means spooky-action-at-a-distance when a `format()` call somewhere accidentally rewrites the price. Locking mutation to `convert()` / `with_amount()` keeps the chain explicit. Happy to discuss if you'd rather match `type_url`'s mutability, but the divergence felt worth keeping.

## Catalog-price drift, for context

The fixed mode addresses an old pain — today multi-currency catalog prices drift every time the FX cache refreshes, because each render re-runs the conversion. With `type_money` knowing it's holding a fixed merchant price, that path stops re-computing.

## Test plan

- [ ] CI green across all four matrix columns
- [ ] `tests/type_money.php` — 12 TCs:
  - TC-01 to TC-03: both construction modes + fallback conversion when a currency isn't in the fixed map
  - TC-04 to TC-05: `convert()` and `with_amount()` return fresh instances (chainable)
  - TC-06: copy constructor clones all components
  - TC-07: `jsonSerialize` round-trips through `json_encode` / `json_decode`
  - TC-08: magic setter rejects mutation with `E_USER_WARNING`
  - TC-09: `__toString` defaults to `format()` and yields a non-empty rendered string
  - TC-10: unknown component access triggers `E_USER_WARNING`
  - TC-11: `currencies` getter exposes the stored currency list
  - TC-12: zero amount is preserved and formats to a non-empty string
- [ ] Manual smoke: round-tripping a fixed-map through `ent_campaign`-style JSON storage preserves the explicit per-currency values

Closes #528.

`type_translation` (#529) comes next as a separate PR — keeping that one independent so the loop-bug fix doesn't tangle with the dual-mode discussion here.

