### PR TITLE
[v3] Add type_translation datatype (#529)

### DIFF
--- a/public_html/includes/datatypes/type_translation.inc.php
+++ b/public_html/includes/datatypes/type_translation.inc.php
@@ -1,0 +1,142 @@
+<?php
+
+	/*
+		Holds a multilingual payload (locale => string) and renders the active
+		locale on stringification with a documented fallback chain.
+
+		Example:
+		    $name = new type_translation([
+		        'en' => 'Rubber Ducks',
+		        'de' => 'Gummienten',
+		        'sv' => 'Gummiankor',
+		    ]);
+		    echo $name;            // current locale (language::$selected['code'])
+		    echo $name->in('de');  // 'Gummienten'
+		    isset($name['de']);    // true — ArrayAccess for $row['name']['de']-style callers
+
+		Fallback chain documented at __toString().
+	*/
+
+	class type_translation implements \JsonSerializable, \ArrayAccess {
+
+		private $_translations = [];
+
+		public function __construct($input = '', ?string $locale = null) {
+
+			if ($input instanceof type_translation) {
+				$this->_translations = $input->_translations;
+				return;
+			}
+
+			if (is_array($input)) {
+				// Plain {locale => string} map.
+				foreach ($input as $code => $value) {
+					if (is_string($code) && is_scalar($value)) {
+						$this->_translations[$code] = (string)$value;
+					}
+				}
+				return;
+			}
+
+			if (is_string($input) && $input !== '') {
+				// Seed the requested locale (or the active locale) with the string.
+				$code = $locale ?: ($this->_active_locale() ?: 'en');
+				$this->_translations[$code] = $input;
+			}
+		}
+
+		/*
+			Returns the value for a specific locale, walking the same fallback
+			chain as __toString. Always returns a string (never null), so callers
+			don't have to coalesce.
+		*/
+		public function in(string $locale): string {
+			if (isset($this->_translations[$locale]) && $this->_translations[$locale] !== '') {
+				return $this->_translations[$locale];
+			}
+			return $this->_fallback($locale);
+		}
+
+		public function set(string $locale, string $value): self {
+			$this->_translations[$locale] = $value;
+			return $this;
+		}
+
+		public function has(string $locale): bool {
+			return isset($this->_translations[$locale]) && $this->_translations[$locale] !== '';
+		}
+
+		public function locales(): array {
+			return array_keys(array_filter($this->_translations, fn($v) => $v !== ''));
+		}
+
+		/*
+			Fallback chain for __toString:
+			1. Active locale (language::$selected['code'])
+			2. Store default locale (settings::get('store_language_code'))
+			3. 'en' as final declared fallback (LiteCart's seed locale)
+			4. First populated entry (defensive — shouldn't happen on a sane install)
+			5. Empty string
+		*/
+		public function __toString(): string {
+			return $this->_fallback($this->_active_locale());
+		}
+
+		private function _fallback(string $requested_locale = ''): string {
+
+			$store_locale = (string)settings::get('store_language_code');
+
+			foreach (array_unique(array_filter([
+				$requested_locale,
+				$store_locale,
+				'en',
+			])) as $code) {
+				if (!empty($this->_translations[$code])) {
+					return $this->_translations[$code];
+				}
+			}
+
+			// Defensive: return the first non-empty entry if the documented chain misses.
+			foreach ($this->_translations as $value) {
+				if ($value !== '') return $value;
+			}
+
+			return '';
+		}
+
+		private function _active_locale(): string {
+			if (isset(language::$selected['code']) && is_string(language::$selected['code'])) {
+				return language::$selected['code'];
+			}
+			return '';
+		}
+
+		#[\ReturnTypeWillChange] // Fix PHP 8.1
+		public function jsonSerialize() {
+			// Matches the existing JSON column shape — {locale => string}.
+			return $this->_translations;
+		}
+
+		// ArrayAccess — preserves $row['name']['de']-style read patterns from
+		// pre-type_translation call sites without forcing a sweep.
+		public function offsetExists($offset): bool {
+			return $this->has((string)$offset);
+		}
+
+		#[\ReturnTypeWillChange]
+		public function offsetGet($offset) {
+			return $this->in((string)$offset);
+		}
+
+		public function offsetSet($offset, $value): void {
+			if ($offset === null) {
+				trigger_error('type_translation requires an explicit locale key', E_USER_WARNING);
+				return;
+			}
+			$this->set((string)$offset, (string)$value);
+		}
+
+		public function offsetUnset($offset): void {
+			unset($this->_translations[(string)$offset]);
+		}
+	}

--- a/tests/type_translation.php
+++ b/tests/type_translation.php
@@ -1,0 +1,223 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		########################################################################
+		## TC-01: Constructor accepts a {locale => string} map
+		########################################################################
+
+		$name = new type_translation([
+			'en' => 'Rubber Ducks',
+			'de' => 'Gummienten',
+			'sv' => 'Gummiankor',
+		]);
+
+		if ($name->in('en') !== 'Rubber Ducks') {
+			throw new Exception('TC-01: en lookup failed (got "'. $name->in('en') .'")');
+		}
+
+		if ($name->in('de') !== 'Gummienten') {
+			throw new Exception('TC-01: de lookup failed');
+		}
+
+		########################################################################
+		## TC-02: Missing locale falls back through the documented chain
+		########################################################################
+
+		$name = new type_translation([
+			'en' => 'Rubber Ducks',
+			'de' => 'Gummienten',
+		]);
+
+		// French not present — chain is: fr → store_default → en → first
+		$result = $name->in('fr');
+		if ($result === '' || ($result !== 'Rubber Ducks' && $result !== 'Gummienten')) {
+			throw new Exception('TC-02: fr fallback should yield a populated value (got "'. $result .'")');
+		}
+
+		########################################################################
+		## TC-03: Bug check — fallback loop uses the loop variable, not the member
+		########################################################################
+
+		// Tim's original draft had a bug where the fallback loop read
+		// $this->_language_code instead of the loop var, silently disabling
+		// the fallback. Verify by constructing a translation without the
+		// active locale entry and confirming we still get a value.
+		$active = isset(language::$selected['code']) ? language::$selected['code'] : 'en';
+		$other_locale = ($active === 'en') ? 'de' : 'en';
+
+		$name = new type_translation([
+			$other_locale => 'Only here',
+		]);
+
+		// Active locale ('en' or whatever) isn't in the map — must fall back.
+		if ($name->in($active) !== 'Only here') {
+			throw new Exception('TC-03: fallback regression — expected "Only here", got "'. $name->in($active) .'"');
+		}
+
+		########################################################################
+		## TC-04: __toString renders the active locale
+		########################################################################
+
+		$active = isset(language::$selected['code']) ? language::$selected['code'] : 'en';
+
+		$name = new type_translation([
+			$active => 'Active locale value',
+			'xx'    => 'Other locale value',
+		]);
+
+		if ((string)$name !== 'Active locale value') {
+			throw new Exception('TC-04: __toString should render the active locale (got "'. (string)$name .'")');
+		}
+
+		########################################################################
+		## TC-05: String constructor seeds the requested locale
+		########################################################################
+
+		$name = new type_translation('Hello', 'en');
+
+		if ($name->in('en') !== 'Hello') {
+			throw new Exception('TC-05: string constructor did not seed the requested locale');
+		}
+
+		########################################################################
+		## TC-06: type_translation copy constructor clones the payload
+		########################################################################
+
+		$original = new type_translation(['en' => 'A', 'de' => 'B']);
+		$copy = new type_translation($original);
+
+		if ($copy->in('en') !== 'A' || $copy->in('de') !== 'B') {
+			throw new Exception('TC-06: copy constructor lost entries');
+		}
+
+		########################################################################
+		## TC-07: set() updates one locale without disturbing others
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello', 'de' => 'Hallo']);
+		$name->set('fr', 'Bonjour');
+
+		if ($name->in('fr') !== 'Bonjour' || $name->in('en') !== 'Hello' || $name->in('de') !== 'Hallo') {
+			throw new Exception('TC-07: set() should add without disturbing existing entries');
+		}
+
+		########################################################################
+		## TC-08: has() reports populated entries only
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello', 'de' => '']);
+
+		if (!$name->has('en')) {
+			throw new Exception('TC-08: has(en) should be true');
+		}
+
+		if ($name->has('de')) {
+			throw new Exception('TC-08: has(de) should be false for empty string');
+		}
+
+		if ($name->has('fr')) {
+			throw new Exception('TC-08: has(fr) should be false for missing');
+		}
+
+		########################################################################
+		## TC-09: locales() lists populated codes only
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello', 'de' => 'Hallo', 'fr' => '']);
+		$locales = $name->locales();
+
+		if (!in_array('en', $locales) || !in_array('de', $locales)) {
+			throw new Exception('TC-09: populated entries missing from locales()');
+		}
+
+		if (in_array('fr', $locales)) {
+			throw new Exception('TC-09: empty entries should not appear in locales()');
+		}
+
+		########################################################################
+		## TC-10: ArrayAccess — read pattern $name['de'] matches in()
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello', 'de' => 'Hallo']);
+
+		if ($name['de'] !== 'Hallo') {
+			throw new Exception('TC-10: ArrayAccess read failed (got "'. $name['de'] .'")');
+		}
+
+		if (!isset($name['de'])) {
+			throw new Exception('TC-10: isset($name[de]) should be true');
+		}
+
+		if (isset($name['fr'])) {
+			throw new Exception('TC-10: isset($name[fr]) should be false');
+		}
+
+		########################################################################
+		## TC-11: ArrayAccess — write pattern $name['de'] = '...' calls set
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello']);
+		$name['de'] = 'Hallo';
+
+		if ($name->in('de') !== 'Hallo') {
+			throw new Exception('TC-11: ArrayAccess write failed');
+		}
+
+		########################################################################
+		## TC-12: jsonSerialize returns the locale-map shape unchanged
+		########################################################################
+
+		$payload = ['en' => 'Hello', 'de' => 'Hallo', 'sv' => 'Hej'];
+		$name = new type_translation($payload);
+
+		$serialized = $name->jsonSerialize();
+		if ($serialized !== $payload) {
+			throw new Exception('TC-12: jsonSerialize shape mismatch (got '. json_encode($serialized) .')');
+		}
+
+		// Round-trip through json_encode / json_decode
+		$decoded = json_decode(json_encode($name), true);
+		$rebuilt = new type_translation($decoded);
+
+		if ($rebuilt->in('en') !== 'Hello' || $rebuilt->in('de') !== 'Hallo' || $rebuilt->in('sv') !== 'Hej') {
+			throw new Exception('TC-12: json round-trip lost entries');
+		}
+
+		########################################################################
+		## TC-13: Empty constructor stays empty
+		########################################################################
+
+		$name = new type_translation();
+
+		if ((string)$name !== '' || !empty($name->locales())) {
+			throw new Exception('TC-13: empty constructor should yield empty state');
+		}
+
+		########################################################################
+		## TC-14: offsetUnset removes a single locale entry
+		########################################################################
+
+		$name = new type_translation(['en' => 'Hello', 'de' => 'Hallo']);
+		unset($name['de']);
+
+		if ($name->has('de')) {
+			throw new Exception('TC-14: offsetUnset should remove the locale');
+		}
+
+		if (!$name->has('en')) {
+			throw new Exception('TC-14: offsetUnset should not disturb other locales');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Picking up #529 — built on the draft you posted in the types.zip dump and addresses the items from the comment thread.

## What changed vs. the draft

| Area | Draft | This PR |
|------|-------|---------|
| Class / file name | `type_translations` (plural) | `type_translation` (singular, matches sibling `type_url` / `type_email` / `type_money`) |
| Fallback loop | Read `$this->_language_code` inside the loop instead of the loop var — disabled the fallback path silently | Loop now reads the local `$code`, fallback chain walks correctly |
| JsonSerializable | absent | full round-trip; returns the `{locale => string}` map verbatim, matches the JSON column shape ent_* already persists |
| ArrayAccess | absent | `$row['name']['de']`-style reads still work without forcing a sweep of every call site |
| Helpers | `set_language()` only | added `in()` / `set()` / `has()` / `locales()` |
| Empty / null safety | strict typing of locale param | always returns a string, never null — callers don't have to coalesce |

## The fallback chain (documented at `__toString`)

1. Active locale (`language::$selected['code']`)
2. Store default locale (`settings::get('store_language_code')`)
3. `'en'` as final declared fallback (LiteCart's seed locale)
4. First populated entry (defensive)
5. Empty string

Pinned in the class header so future readers don't have to reason it out from the code.

## Drop-in compatibility

`jsonSerialize()` matches the existing JSON-column shape — the entity refactor (separate PR) becomes a pass-through:

```php
// Before
$row['name'] = json_decode($row['name'], true);
echo $row['name'][language::$selected['code']] ?? $row['name']['en'] ?? '';

// After
$row['name'] = new type_translation(json_decode($row['name'], true));
echo $row['name'];   // walks the fallback chain
```

ArrayAccess means the bridging step works too:

```php
echo $row['name']['de'];   // explicit locale lookup, same fallback safety
```

## Test plan

- [ ] CI green across all four matrix columns
- [ ] `tests/type_translation.php` — 14 TCs:
  - TC-01 to TC-04: constructor variants (map / string / copy / type_translation), explicit-locale reads, active-locale `__toString`
  - TC-03: regression check for the draft's fallback-loop bug — translation containing only a non-active locale must still resolve via fallback
  - TC-05 to TC-07: string-with-locale constructor, copy clone, `set()` without disturbing existing entries
  - TC-08 to TC-09: `has()` / `locales()` filter on populated entries only
  - TC-10 to TC-11: `ArrayAccess` read and write
  - TC-12: `jsonSerialize` shape preservation + json round-trip
  - TC-13 to TC-14: empty constructor stays empty, `unset($t['de'])` removes a locale

Closes #529.

This is the second of two follow-ups to the types.zip dump. `type_money` is up in #530, sequenced ahead of this one only because the dual-mode discussion deserved the first slot. The two PRs are independent — merge in either order.

