### PR TITLE
[v3] Migrate form_input_money to accept type_money (#533)

### DIFF
--- a/public_html/includes/functions/func_form.inc.php
+++ b/public_html/includes/functions/func_form.inc.php
@@ -520,9 +520,9 @@
 
 	function form_input_money($name, $currency_code=null, $input=true, $attributes=[]) {
 
-		if (preg_match('#^[A-Z]{3}$#', $name) && !preg_match('#^[A-Z]{3}$#', $currency_code)) {
-			trigger_error('Passing currency code as 1st parameter in form_input_money() is deprecated. Instead, use form_input_money($name, $currency_code, $input, $attributes)', E_USER_DEPRECATED);
-			[$name, $currency_code] = [$currency_code, $name];
+		if ($input instanceof type_money) {
+			$currency_code = $currency_code ?: $input->currency_code;
+			$input = $input->in($currency_code);
 		}
 
 		if ($input === true) {

--- a/tests/form_input_money.php
+++ b/tests/form_input_money.php
@@ -1,0 +1,163 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$store_currency = (string)settings::get('store_currency_code');
+
+		########################################################################
+		## TC-01: Bare float still works (backwards compatibility)
+		########################################################################
+
+		$html = f::form_input_money('price', $store_currency, 99.99);
+
+		if (!is_string($html) || $html === '') {
+			throw new Exception('TC-01: expected non-empty HTML string');
+		}
+
+		if (strpos($html, 'name="price"') === false) {
+			throw new Exception('TC-01: rendered input must carry the form field name');
+		}
+
+		if (strpos($html, '99.99') === false) {
+			throw new Exception('TC-01: rendered output must contain the bare-float value (got: '. $html .')');
+		}
+
+		if (strpos($html, $store_currency) === false) {
+			throw new Exception('TC-01: rendered output must contain the currency code');
+		}
+
+		########################################################################
+		## TC-02: type_money instance accepted as the value
+		########################################################################
+
+		$price = new type_money(99.99, $store_currency);
+		$html = f::form_input_money('price', $store_currency, $price);
+
+		if (strpos($html, '99.99') === false) {
+			throw new Exception('TC-02: type_money value must be rendered as a numeric amount (got: '. $html .')');
+		}
+
+		if (strpos($html, 'name="price"') === false) {
+			throw new Exception('TC-02: form field name must be preserved when type_money is passed');
+		}
+
+		########################################################################
+		## TC-03: type_money + null currency_code derives currency from the instance
+		########################################################################
+
+		$price = new type_money(42.50, $store_currency);
+		$html = f::form_input_money('price', null, $price);
+
+		if (strpos($html, $store_currency) === false) {
+			throw new Exception('TC-03: currency_code should be derived from type_money when null is passed (got: '. $html .')');
+		}
+
+		if (strpos($html, '42.50') === false) {
+			throw new Exception('TC-03: type_money value must render with null currency_code (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-04: Empty string as $input still renders an empty value (template stub usage)
+		########################################################################
+
+		$html = f::form_input_money('products[__index__][price]['. $store_currency .']', $store_currency, '', 'style="width: 125px;"');
+
+		if (!is_string($html) || $html === '') {
+			throw new Exception('TC-04: template-stub call with empty $input must still render');
+		}
+
+		if (strpos($html, 'value=""') === false) {
+			throw new Exception('TC-04: empty $input must render value="" (got: '. $html .')');
+		}
+
+		if (strpos($html, 'style="width: 125px;"') === false) {
+			throw new Exception('TC-04: legacy string-attribute syntax must still be honoured');
+		}
+
+		########################################################################
+		## TC-05: No E_USER_DEPRECATED warning on normal call patterns
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			$html = f::form_input_money('price', $store_currency, 99.99);
+			$html = f::form_input_money('price', $store_currency, new type_money(99.99, $store_currency));
+			$html = f::form_input_money('price', null, new type_money(99.99, $store_currency));
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-05: unexpected E_USER_DEPRECATED on normal call: '. $ex->getMessage());
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-06: Legacy swap-hack signature no longer reorders args
+		########################################################################
+		##
+		## Before the refactor: form_input_money('USD', 'price', $v) triggered the
+		## regex-sniff swap and emitted E_USER_DEPRECATED. After the refactor: no
+		## swap, $name is treated literally as 'USD' (a valid form field name).
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			$html = f::form_input_money('USD', 'price', 99.99);
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-06: deprecation-swap hack must be removed (got: '. $ex->getMessage() .')');
+		} finally {
+			restore_error_handler();
+		}
+
+		if (strpos($html, 'name="USD"') === false) {
+			throw new Exception('TC-06: $name must be honoured verbatim post-refactor (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-07: Currency-specific decimals applied to type_money value
+		########################################################################
+
+		if (!empty(currency::$currencies[$store_currency]['decimals'])) {
+
+			$decimals = (int)currency::$currencies[$store_currency]['decimals'];
+			$price = new type_money(100, $store_currency);
+			$html = f::form_input_money('price', $store_currency, $price);
+
+			$expected = number_format(100, $decimals, '.', '');
+
+			if (strpos($html, $expected) === false) {
+				throw new Exception('TC-07: type_money amount must be formatted to currency decimals (expected "'. $expected .'", got: '. $html .')');
+			}
+		}
+
+		########################################################################
+		## TC-08: Array-style attributes still work alongside type_money
+		########################################################################
+
+		$price = new type_money(50, $store_currency);
+		$html = f::form_input_money('price', $store_currency, $price, ['data-test' => 'ok', 'readonly' => 'readonly']);
+
+		if (strpos($html, 'data-test="ok"') === false) {
+			throw new Exception('TC-08: array attributes must merge through (got: '. $html .')');
+		}
+
+		if (strpos($html, 'readonly') === false) {
+			throw new Exception('TC-08: readonly attribute must merge through');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Took the slot you left open in #520 — value-objects landed, so the deprecation-swap hacks they were going to retire can start coming out. First one up: `form_input_money`.

Closes #533.

## What changes

| Aspect | Before | After |
|--------|--------|-------|
| Value parameter (`$input`) | bool / float / string | bool / float / string / `type_money` |
| Deprecation swap on `$name` ↔ `$currency_code` | Active | Removed |
| `trigger_error('…is deprecated', E_USER_DEPRECATED)` | Emitted on legacy shape | Removed |
| When `$input` is `type_money` and `$currency_code` is `null` | n/a | derived from `$input->currency_code` |

The swap-hack wasn't earning its keep — `rg "form_input_money\(['\"][A-Z]{3}['\"]"` shows zero matches in v3, so no production call site was relying on it. Removing it costs nothing.

## How it works

```php
function form_input_money($name, $currency_code=null, $input=true, $attributes=[]) {

  if ($input instanceof type_money) {
    $currency_code = $currency_code ?: $input->currency_code;
    $input = $input->in($currency_code);
  }
  …
}
```

Single `instanceof` branch — unambiguous (a `type_money` can't be confused with a float/bool/string), smallest diff, no new signatures to remember. Considered an explicit 5th `$money` slot but it'd just be more typing at call sites for the same outcome.

## Out of scope (next PRs)

- `form_regional_*` family (separate sub-issue tracking `type_translation` adoption)
- `form_select_zone` / `form_toggle` / `form_function` swap hacks — no value-object tie-in yet, left alone
- Touching the four `''`-as-`$input` template-stub call sites in `edit_campaign.inc.php` / `edit_product.inc.php` — they don't trigger the removed hack and there's no natural `type_money` to put there (the value starts empty by design). Happy to handle in a follow-up if you'd rather see them converted

## Test plan

- [x] `php -l` clean on both touched files
- [x] `npx gulp phplint` green (~1.5 min)
- [ ] CI green
- [x] `tests/form_input_money.php` covers:
  - TC-01: bare float still renders (backwards compat)
  - TC-02: `type_money` instance accepted as `$input`
  - TC-03: `$currency_code` derived from `type_money` when null
  - TC-04: empty-string `$input` still renders empty (template-stub usage unchanged)
  - TC-05: no `E_USER_DEPRECATED` on the normal call paths
  - TC-06: legacy swap-hack signature no longer reorders args
  - TC-07: currency-specific decimals applied to `type_money` value
  - TC-08: array attributes merge through alongside `type_money`