### PR TITLE
[v3] Fix installer FS_DIR_STORAGE broken on first-time install (#535)

### DIFF
--- a/public_html/install/includes/init.inc.php
+++ b/public_html/install/includes/init.inc.php
@@ -37,7 +37,9 @@
 	}
 
 	if (!defined('FS_DIR_STORAGE')) {
-		define('FS_DIR_STORAGE', str_replace('\\', '/', realpath(__DIR__ . '/../storage/')));
+		// No realpath() — storage/ may not exist yet on a first-time install,
+		// in which case realpath() would return false and break the path.
+		define('FS_DIR_STORAGE', FS_DIR_APP . 'storage/');
 	}
 
 	if (!defined('WS_DIR_APP') && defined('DOCUMENT_ROOT')) {


### PR DESCRIPTION
Was investigating why CI's Platform Tests were silently red under `continue-on-error: true`. Turns out the installer has been aborting halfway through on every first-time CI run since `38b890f8`. The platform-tests crash downstream is just the symptom — this is the root cause.

Closes #535.

## What's wrong

`install/includes/init.inc.php:40` (before):

```php
define('FS_DIR_STORAGE', str_replace('\', '/', realpath(__DIR__ . '/../storage/')));
```

`realpath()` returns `false` for non-existent paths. On a first-time install, `storage/` doesn't yet exist (that's what the installer needs to create), so:

| Step | Result |
|------|--------|
| `realpath(__DIR__ . '/../storage/')` | `false` |
| `str_replace('\', '/', false)` | `''` |
| `define('FS_DIR_STORAGE', '')` | `FS_DIR_STORAGE = ''` |
| `mkdir(FS_DIR_STORAGE, 0777)` at `install.php:286` | "No such file or directory" |
| Installer | Throws `[Error]`, page outputs `[ABORTED]`, PHP exits 0 |

The PHP-exits-0 is what makes this so quiet — GitHub Actions sees a passing step, and the platform-tests job downstream takes the hit instead, where `Call to undefined function redirect()` in `app_header.inc.php:10` is the visible failure.

Tail of the relevant CI log on the last `dev-major` push:

```
PHP Warning: mkdir(): No such file or directory in storage:///.../install/install.php on line 286
[ABORTED] [Error]
…
test -f public_html/storage/config.inc.php && echo "config.inc.php exists"
(silent — set -e doesn't trip in `cmd && echo` chains)
tables 0
…
PHP Fatal error: Call to undefined function redirect() in app_header.inc.php:10
##[error]Process completed with exit code 255.
```

## Where it came from

Commit `38b890f8` ("Mixed adjustments", May 15) wrapped the storage path in `realpath()`, presumably to normalise Windows backslashes:

```diff
- define('FS_DIR_STORAGE', __DIR__ . '/../storage/');
+ define('FS_DIR_STORAGE', str_replace('\', '/', realpath(__DIR__ . '/../storage/')));
```

Worked for existing installs. First-time installs (the entire point of the installer) silently broke.

## The fix

```php
if (!defined('FS_DIR_STORAGE')) {
  // No realpath() — storage/ may not exist yet on a first-time install,
  // in which case realpath() would return false and break the path.
  define('FS_DIR_STORAGE', FS_DIR_APP . 'storage/');
}
```

`FS_DIR_APP` is already realpath-normalised one line above (because `public_html/` *does* exist on disk), so simple string concat preserves the Windows-backslash-safe behaviour the original `realpath()` was aiming for. `upgrade.php:87` already uses this exact pattern.

## What this unmasks

Once the installer actually completes in CI, the `Run platform tests` step will start running for real — and surface whatever per-test fails are hiding under it. That's expected and fine; those preexisting fails were already tracked (memory says `nod_database`, `nod_settings`, `func_catalog`, `checkout`, `order`), they just weren't reachable because of the bootstrap crash. Address those in follow-up PRs, then drop `continue-on-error: true` once everything's green.

E2E (Playwright) is a separate orthogonal failure (`@playwright/test` not found in the `bunx` cache). Not touched here.

## Test plan

- [x] `php -l` clean on `init.inc.php`
- [x] Empirically verified `realpath()` of a non-existent path returns `false`, `str_replace` then yields `''`
- [ ] CI: Platform Tests step runs to completion (was crashing at app_header before)
- [ ] CI: `Verify installation` now actually reports `config.inc.php exists` + non-zero tables