### PR TITLE
[v3] Migrate form_regional_* family to accept type_translation (#537)

### DIFF
--- a/public_html/includes/functions/func_form.inc.php
+++ b/public_html/includes/functions/func_form.inc.php
@@ -822,13 +822,12 @@
 
 	function form_regional($name, $language_code='', $input=true, $type='text', $attributes=[]) {
 
-		if (preg_match('#^[a-z]{2}$#', $name)) {
-			trigger_error('Passing $language code as 1st parameter in form_regional_text() is deprecated. Instead, use form_regional_text($name, $language_code, $input, $attributes)', E_USER_DEPRECATED);
-			[$name, $language_code] = [$language_code, $name];
-		}
-
 		if (!$language_code) {
 			$language_code = settings::get('store_language_code');
+		}
+
+		if ($input instanceof type_translation) {
+			$input = $input->in($language_code);
 		}
 
 		if ($input === true) {
@@ -851,6 +850,10 @@
 			$language_code = settings::get('store_language_code');
 		}
 
+		if ($input instanceof type_translation) {
+			$input = $input->in($language_code);
+		}
+
 		return implode(PHP_EOL, [
 			'<div class="input-group">',
 			'  <span class="input-group-text" style="font-family: monospace;" title="'. f::escape_attr(language::$languages[$language_code]['name']) .'">'. f::escape_html($language_code) .'</span>',
@@ -861,13 +864,12 @@
 
 	function form_regional_textarea($name, $language_code='', $input=true, $attributes=[]) {
 
-		if (preg_match('#^[a-z]{2}$#', $name)) {
-			trigger_error('Passing language code as 1st parameter in form_regional_textarea() is deprecated. Instead, use form_regional_textarea($name, $language_code, $input, $attributes)', E_USER_DEPRECATED);
-			[$name, $language_code] = [$language_code, $name];
-		}
-
 		if (!$language_code) {
 			$language_code = settings::get('store_language_code');
+		}
+
+		if ($input instanceof type_translation) {
+			$input = $input->in($language_code);
 		}
 
 		return implode(PHP_EOL, [
@@ -880,13 +882,12 @@
 
 	function form_regional_wysiwyg($name, $language_code='', $input=true, $attributes=[]) {
 
-		if (preg_match('#^[a-z]{2}$#', $name)) {
-			trigger_error('Passing language code as 1st parameter in form_regional_wysiwyg() is deprecated. Instead, use form_regional_wysiwyg($name, $language_code, $input, $attributes)', E_USER_DEPRECATED);
-			[$name, $language_code] = [$language_code, $name];
-		}
-
 		if (!$language_code) {
 			$language_code = settings::get('store_language_code');
+		}
+
+		if ($input instanceof type_translation) {
+			$input = $input->in($language_code);
 		}
 
 		return implode(PHP_EOL, [

--- a/tests/form_regional.php
+++ b/tests/form_regional.php
@@ -1,0 +1,192 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$store_locale = (string)settings::get('store_language_code');
+
+		// Reusable translation map with the store locale + one more for cross-locale checks.
+		$translation = new type_translation([
+			$store_locale => 'Hello',
+			'de'          => 'Hallo',
+		]);
+
+		########################################################################
+		## TC-01: form_regional_text — bare string still works
+		########################################################################
+
+		$html = f::form_regional_text('title['. $store_locale .']', $store_locale, 'Hello');
+
+		if (strpos($html, 'value="Hello"') === false) {
+			throw new Exception('TC-01: bare string must render as input value (got: '. $html .')');
+		}
+
+		if (strpos($html, $store_locale) === false) {
+			throw new Exception('TC-01: language code badge must appear in rendered output');
+		}
+
+		########################################################################
+		## TC-02: form_regional_text — type_translation instance accepted
+		########################################################################
+
+		$html = f::form_regional_text('title['. $store_locale .']', $store_locale, $translation);
+
+		if (strpos($html, 'value="Hello"') === false) {
+			throw new Exception('TC-02: type_translation must render the value for $language_code (got: '. $html .')');
+		}
+
+		$html_de = f::form_regional_text('title[de]', 'de', $translation);
+
+		if (strpos($html_de, 'value="Hallo"') === false) {
+			throw new Exception('TC-02: type_translation must pick the de value when language_code=de (got: '. $html_de .')');
+		}
+
+		########################################################################
+		## TC-03: form_regional_textarea — type_translation instance accepted
+		########################################################################
+
+		$html = f::form_regional_textarea('body[de]', 'de', $translation);
+
+		if (strpos($html, 'Hallo') === false) {
+			throw new Exception('TC-03: form_regional_textarea must render the localised value (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-04: form_regional_wysiwyg — type_translation instance accepted
+		########################################################################
+
+		$html = f::form_regional_wysiwyg('content[de]', 'de', $translation);
+
+		if (strpos($html, 'Hallo') === false) {
+			throw new Exception('TC-04: form_regional_wysiwyg must render the localised value (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-05: form_regional (the master with $type param) — type_translation accepted
+		########################################################################
+
+		$html = f::form_regional('h1[de]', 'de', $translation, 'text');
+
+		if (strpos($html, 'value="Hallo"') === false) {
+			throw new Exception('TC-05: form_regional must render the localised value (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-06: Empty $language_code falls back to store_language_code
+		########################################################################
+
+		$html = f::form_regional_text('title', '', 'Hi');
+
+		if (strpos($html, $store_locale) === false) {
+			throw new Exception('TC-06: empty $language_code must fall back to store_language_code (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-07: type_translation locale fallback chain when locale not in map
+		########################################################################
+		##
+		## type_translation::in() falls through to store locale and then 'en'.
+		## Form helper should hand off to in() and accept whatever it returns.
+		########################################################################
+
+		$partial = new type_translation(['en' => 'Fallback']);
+		$html = f::form_regional_text('title[xx]', 'xx', $partial);
+
+		// in('xx') falls back through store + 'en' — we accept either, but value
+		// must not be empty and must reflect a fallback hit.
+		if (strpos($html, 'value=""') !== false) {
+			throw new Exception('TC-07: type_translation fallback must yield a non-empty value (got: '. $html .')');
+		}
+
+		########################################################################
+		## TC-08: No E_USER_DEPRECATED on normal call patterns
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			f::form_regional_text('name['. $store_locale .']', $store_locale, true);
+			f::form_regional_textarea('body['. $store_locale .']', $store_locale, true);
+			f::form_regional_wysiwyg('content['. $store_locale .']', $store_locale, true);
+			f::form_regional('h1['. $store_locale .']', $store_locale, true, 'text');
+			f::form_regional_text('name['. $store_locale .']', $store_locale, $translation);
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-08: unexpected E_USER_DEPRECATED on normal call: '. $ex->getMessage());
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-09: Legacy swap-hack signature no longer reorders args
+		########################################################################
+		##
+		## Before: f::form_regional_textarea('de', 'body', $v) triggered the
+		## ^[a-z]{2}$ swap and emitted E_USER_DEPRECATED. After: no swap, the
+		## name is treated literally as 'de'. Verify silent + literal $name.
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			$html = f::form_regional_textarea('de', 'body', 'X');
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-09: deprecation-swap hack must be removed for form_regional_textarea (got: '. $ex->getMessage() .')');
+		} finally {
+			restore_error_handler();
+		}
+
+		if (strpos($html, 'name="de"') === false) {
+			throw new Exception('TC-09: $name must be honoured verbatim post-refactor (got: '. $html .')');
+		}
+
+		// Same check for form_regional_wysiwyg
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			$html = f::form_regional_wysiwyg('de', 'content', 'X');
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-09: deprecation-swap hack must be removed for form_regional_wysiwyg (got: '. $ex->getMessage() .')');
+		} finally {
+			restore_error_handler();
+		}
+
+		// Same check for form_regional itself
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_DEPRECATED);
+
+		try {
+			$html = f::form_regional('de', 'title', 'X', 'text');
+		} catch (ErrorException $ex) {
+			throw new Exception('TC-09: deprecation-swap hack must be removed for form_regional (got: '. $ex->getMessage() .')');
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-10: Array attributes still work alongside type_translation
+		########################################################################
+
+		$html = f::form_regional_text('title[de]', 'de', $translation, ['data-test' => 'ok']);
+
+		if (strpos($html, 'data-test="ok"') === false) {
+			throw new Exception('TC-10: array attributes must merge through (got: '. $html .')');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Second value-object adoption after [#534](https://github.com/litecart/litecart/pull/534). Same shape — drop the regex-sniff swap-hacks, accept the value-object as `\$input`, leave the call sites alone for now. `type_translation` landed in [#531](https://github.com/litecart/litecart/pull/531) so this is the natural follow-up.

Closes #537.

## What changes

| Helper | Was | Now |
|--------|-----|-----|
| `form_regional` | swap-hack + `trigger_error('…deprecated')` | `type_translation` via `instanceof` |
| `form_regional_text` | already clean | `type_translation` via `instanceof` |
| `form_regional_textarea` | swap-hack + `trigger_error('…deprecated')` | `type_translation` via `instanceof` |
| `form_regional_wysiwyg` | swap-hack + `trigger_error('…deprecated')` | `type_translation` via `instanceof` |

All four helpers now do the same thing internally:

```php
if (!\$language_code) {
  \$language_code = settings::get('store_language_code');
}

if (\$input instanceof type_translation) {
  \$input = \$input->in(\$language_code);
}
```

`type_translation::in()` already returns a guaranteed string with the documented fallback chain, so no extra coalescing at the call site.

## Risk

`rg "form_regional[a-z_]*\(['\"][a-z]{2}['\"]"` returns zero matches — no current call site passes a bare two-letter language code as `\$name`, so the swap-hacks never fired. 44 existing call sites across 12 backend `edit_*.inc.php` files all pass `true` for reinsert; they keep their behaviour verbatim. Tiny verify-only sweep.

There's also a small free pre-existing fixup tucked in: `form_regional`'s deprecation message used to say \"form_regional_text\" (wrong function name). Vanishes for free when the trigger_error block goes.

## Out of scope

- Migrating call sites to pass `type_translation` instances. None of them have one handy today — the JSON columns on `ent_*` entities are still raw arrays. When/if entities expose those as `type_translation` directly (separate, larger refactor), call sites can opt in incrementally.
- `form_select_zone` / `form_toggle` / `form_function` / `form_select_attribute_value` — same orphan-status as before, no value-object tie-in yet.

## Test plan

- [x] `php -l` clean on both touched files
- [ ] CI green (Platform Tests + Lint)
- [x] `tests/form_regional.php` covers:
  - TC-01: bare string still renders (backwards compat)
  - TC-02: `type_translation` instance accepted, cross-locale dispatch via `\$language_code`
  - TC-03: `form_regional_textarea` with `type_translation`
  - TC-04: `form_regional_wysiwyg` with `type_translation`
  - TC-05: `form_regional` (the master with `\$type` param) with `type_translation`
  - TC-06: empty `\$language_code` falls back to `store_language_code`
  - TC-07: `type_translation` fallback chain yields a non-empty value for unknown locale
  - TC-08: no `E_USER_DEPRECATED` on normal call patterns (all four helpers)
  - TC-09: legacy swap-hack signature no longer reorders args (all three helpers that had it)
  - TC-10: array attributes still merge through alongside `type_translation`