### PR TITLE
[v2] Fix Docker container fail — mysqli readiness probe with timeout (closes #539)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install -j$(nproc) \
         gd \
         mysqli \
-        pdo_mysql \
         zip \
         intl \
         curl \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,9 +6,18 @@ CONFIG_FILE="/var/www/html/public_html/includes/config.inc.php"
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "No config found — running LiteCart installer..."
 
-  # Wait for MySQL to accept connections
-  until php -r "new PDO('mysql:host=${DB_SERVER:-mysql};port=3306', '${DB_USERNAME:-litecart}', '${DB_PASSWORD:-litecart}');" 2>/dev/null; do
-    echo "Waiting for MySQL..."
+  # Wait for MySQL to accept connections (mysqli — matches the rest of v2; PDO is no longer used)
+  MAX_ATTEMPTS=30
+  ATTEMPT=0
+  until php -r "mysqli_report(MYSQLI_REPORT_OFF); @mysqli_connect('${DB_SERVER:-mysql}', '${DB_USERNAME:-litecart}', '${DB_PASSWORD:-litecart}') ?: exit(1);" 2>/dev/null; do
+    ATTEMPT=$((ATTEMPT + 1))
+    if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+      echo "ERROR: Could not connect to MySQL at '${DB_SERVER:-mysql}' after $((MAX_ATTEMPTS * 2))s." >&2
+      echo "       If you started the container with plain 'docker run', the 'mysql' hostname doesn't resolve" >&2
+      echo "       — use 'docker compose up' (which creates the shared network) or set DB_SERVER to a reachable host." >&2
+      exit 1
+    fi
+    echo "Waiting for MySQL... (${ATTEMPT}/${MAX_ATTEMPTS})"
     sleep 2
   done
 


### PR DESCRIPTION
Used the moment to grep the rest of v2 for stray PDO bits — turned out it really had only slipped into the Docker setup. (`rg "new PDO|pdo_mysql|PDO::"`)

Closes #539.

## What changes

| File | Change |
|------|--------|
| `docker-entrypoint.sh` | PDO readiness probe → `mysqli_connect` with `MYSQLI_REPORT_OFF` to silence the PHP 8.1+ exception default. 60s timeout (30 × 2s) replaces the unbounded loop. On timeout, prints a hint pointing at the common `docker run` (vs. `docker compose up`) confusion. |
| `Dockerfile` | Drop `pdo_mysql` from `docker-php-ext-install` — no callers anywhere in v2. |

## Issue todo items

- "Use mysqli instead of PDO" — done.
- "Troubleshoot networking setup" — the `getaddrinfo for mysql failed` fatal triggers when the container is started outside the compose network (plain `docker run` vs. `docker compose up`). The DNS lookup itself can't be fixed from inside the container, but the failure mode is now "bounded wait, clear hint about the missing network" instead of "endless loop spamming PHP fatals".

## Test plan

- [x] `bash -n docker-entrypoint.sh` clean
- [ ] `docker compose up --build` from a clean checkout — container starts, installer runs, admin reachable on `:9080`
- [ ] `docker run --rm -e DB_SERVER=mysql litecart` without a compose network — exits after ~60s with the actionable error instead of looping forever
- [ ] No PHP warnings about missing `pdo_mysql`