### PR TITLE
[v3] Add type_taxable_amount datatype (#541)

### DIFF
--- a/public_html/includes/types/type_taxable_amount.inc.php
+++ b/public_html/includes/types/type_taxable_amount.inc.php
@@ -1,0 +1,97 @@
+<?php
+
+	/*
+		Represents a monetary amount that knows its tax class. Composes naturally
+		with type_money — inherits dual-mode money handling and JSON serialization,
+		adds net/gross/tax accessors that delegate to the tax:: node.
+
+		    $amount = new type_taxable_amount(100, 'USD', $tax_class_id);
+		    echo $amount->net;        // 100
+		    echo $amount->gross;      // 100 + tax via tax::get_price()
+		    echo $amount->tax;        // tax via tax::get_tax()
+		    echo $amount->tax_rate;   // average rate (sum / count)
+		    echo $amount;             // formatted in $amount->currency_code
+
+		Customer context defaults to the active customer (tax::get_rates() 'customer'
+		preset). For region-aware resolution pass a customer array via gross_for()
+		/ tax_for().
+
+		Drop-in for entity layers that store (amount, tax_class_id, currency)
+		triplets — jsonSerialize() preserves tax_class_id alongside the money payload.
+	*/
+
+	class type_taxable_amount extends type_money {
+
+		private $_tax_class_id;
+
+		public function __construct($input = 0, ?string $currency_code = null, $tax_class_id = null) {
+
+			// Copy from a sibling instance — must come before parent's type_money
+			// check so the tax_class_id carries over.
+			if ($input instanceof type_taxable_amount) {
+				parent::__construct($input);
+				$this->_tax_class_id = $input->_tax_class_id;
+				return;
+			}
+
+			// jsonSerialize() round-trip — peel tax_class_id and let the parent
+			// constructor handle the rest of the array shape.
+			if (is_array($input) && array_key_exists('tax_class_id', $input)) {
+				$this->_tax_class_id = $input['tax_class_id'];
+				unset($input['tax_class_id']);
+				parent::__construct($input, $currency_code);
+				return;
+			}
+
+			parent::__construct($input, $currency_code);
+			$this->_tax_class_id = $tax_class_id;
+		}
+
+		public function __get($name) {
+
+			switch ($name) {
+
+				case 'net':
+					return $this->in($this->currency_code);
+
+				case 'gross':
+					return (float)tax::get_price($this->net, $this->_tax_class_id, true);
+
+				case 'tax':
+					return (float)tax::get_tax($this->net, $this->_tax_class_id);
+
+				case 'tax_rate':
+					$rates = tax::get_rates($this->_tax_class_id);
+					if (empty($rates)) return 0.0;
+					$sum = 0;
+					foreach ($rates as $rate) {
+						$sum += (float)($rate['rate'] ?? 0);
+					}
+					return $sum / count($rates);
+
+				case 'tax_class_id':
+					return $this->_tax_class_id;
+			}
+
+			return parent::__get($name);
+		}
+
+		/*
+			Region-aware variants — accept a customer array (or preset string)
+			and resolve tax against that context instead of the default.
+		*/
+		public function gross_for($customer): float {
+			return (float)tax::get_price($this->net, $this->_tax_class_id, true, $customer);
+		}
+
+		public function tax_for($customer): float {
+			return (float)tax::get_tax($this->net, $this->_tax_class_id, $customer);
+		}
+
+		#[\ReturnTypeWillChange] // Fix PHP 8.1
+		public function jsonSerialize() {
+			return array_merge((array)parent::jsonSerialize(), [
+				'tax_class_id' => $this->_tax_class_id,
+			]);
+		}
+	}

--- a/tests/type_taxable_amount.php
+++ b/tests/type_taxable_amount.php
@@ -1,0 +1,206 @@
+<?php
+
+	include_once __DIR__.'/../public_html/includes/app_header.inc.php';
+
+	try {
+
+		$store_currency = (string)settings::get('store_currency_code');
+
+		########################################################################
+		## TC-01: Basic construction with tax_class_id
+		########################################################################
+
+		$amount = new type_taxable_amount(100, $store_currency, 1);
+
+		if ($amount->tax_class_id !== 1) {
+			throw new Exception('TC-01: tax_class_id not stored (got '. var_export($amount->tax_class_id, true) .')');
+		}
+
+		if ($amount->currency !== $store_currency) {
+			throw new Exception('TC-01: currency not stored (got "'. $amount->currency .'")');
+		}
+
+		if (abs($amount->net - 100) > 0.001) {
+			throw new Exception('TC-01: net amount wrong (got '. $amount->net .')');
+		}
+
+		########################################################################
+		## TC-02: tax_class_id = null behaves like a plain type_money
+		########################################################################
+
+		$amount = new type_taxable_amount(100, $store_currency, null);
+
+		if ($amount->tax_class_id !== null) {
+			throw new Exception('TC-02: tax_class_id should be null');
+		}
+
+		// With no tax_class_id, gross must equal net and tax must be 0.
+		if (abs($amount->gross - $amount->net) > 0.001) {
+			throw new Exception('TC-02: gross should equal net when tax_class_id is null (net='. $amount->net .', gross='. $amount->gross .')');
+		}
+
+		if ($amount->tax !== 0.0) {
+			throw new Exception('TC-02: tax should be 0 when tax_class_id is null (got '. $amount->tax .')');
+		}
+
+		if ($amount->tax_rate !== 0.0) {
+			throw new Exception('TC-02: tax_rate should be 0 when tax_class_id is null (got '. $amount->tax_rate .')');
+		}
+
+		########################################################################
+		## TC-03: jsonSerialize includes tax_class_id alongside money payload
+		########################################################################
+
+		$amount = new type_taxable_amount(100, $store_currency, 42);
+		$serialized = $amount->jsonSerialize();
+
+		if (!is_array($serialized)) {
+			throw new Exception('TC-03: jsonSerialize should return an array');
+		}
+
+		if (!array_key_exists('tax_class_id', $serialized)) {
+			throw new Exception('TC-03: serialized payload missing tax_class_id key');
+		}
+
+		if ($serialized['tax_class_id'] !== 42) {
+			throw new Exception('TC-03: tax_class_id not preserved in serialization (got '. var_export($serialized['tax_class_id'], true) .')');
+		}
+
+		// Money payload still present from parent::jsonSerialize().
+		foreach (['amounts', 'mode', 'origin_currency'] as $key) {
+			if (!array_key_exists($key, $serialized)) {
+				throw new Exception('TC-03: serialized payload missing parent key "'. $key .'"');
+			}
+		}
+
+		########################################################################
+		## TC-04: JSON round-trip preserves tax_class_id and money
+		########################################################################
+
+		$original = new type_taxable_amount(100, $store_currency, 7);
+		$json = json_encode($original);
+		$decoded = json_decode($json, true);
+		$rebuilt = new type_taxable_amount($decoded);
+
+		if ($rebuilt->tax_class_id !== 7) {
+			throw new Exception('TC-04: tax_class_id lost across json round-trip (got '. var_export($rebuilt->tax_class_id, true) .')');
+		}
+
+		if (abs($rebuilt->net - 100) > 0.001) {
+			throw new Exception('TC-04: net amount lost across json round-trip (got '. $rebuilt->net .')');
+		}
+
+		########################################################################
+		## TC-05: Copy constructor preserves tax_class_id
+		########################################################################
+
+		$original = new type_taxable_amount(50, $store_currency, 3);
+		$copy = new type_taxable_amount($original);
+
+		if ($copy->tax_class_id !== 3) {
+			throw new Exception('TC-05: tax_class_id not cloned (got '. var_export($copy->tax_class_id, true) .')');
+		}
+
+		if (abs($copy->net - 50) > 0.001) {
+			throw new Exception('TC-05: net amount not cloned (got '. $copy->net .')');
+		}
+
+		########################################################################
+		## TC-06: Construction from type_money (without tax_class) keeps null
+		########################################################################
+
+		$money = new type_money(75, $store_currency);
+		$amount = new type_taxable_amount($money);
+
+		if ($amount->tax_class_id !== null) {
+			throw new Exception('TC-06: tax_class_id should default to null when constructed from type_money (got '. var_export($amount->tax_class_id, true) .')');
+		}
+
+		if (abs($amount->net - 75) > 0.001) {
+			throw new Exception('TC-06: net amount not carried from type_money (got '. $amount->net .')');
+		}
+
+		########################################################################
+		## TC-07: Customer-aware variants exist and accept a customer arg
+		########################################################################
+
+		$amount = new type_taxable_amount(100, $store_currency, null);
+
+		// With tax_class_id null these must still return floats (not error).
+		$gross_for = $amount->gross_for('store');
+		$tax_for = $amount->tax_for('store');
+
+		if (!is_float($gross_for) || abs($gross_for - 100) > 0.001) {
+			throw new Exception('TC-07: gross_for() should return net when tax_class_id is null (got '. var_export($gross_for, true) .')');
+		}
+
+		if (!is_float($tax_for) || $tax_for !== 0.0) {
+			throw new Exception('TC-07: tax_for() should return 0.0 when tax_class_id is null (got '. var_export($tax_for, true) .')');
+		}
+
+		########################################################################
+		## TC-08: Unknown component still triggers warning via parent::__get
+		########################################################################
+
+		set_error_handler(function($severity, $message) {
+			throw new ErrorException($message, 0, $severity);
+		}, E_USER_WARNING);
+
+		try {
+			$amount = new type_taxable_amount(100, $store_currency, 1);
+			$_ = $amount->unknown_component;
+			throw new Exception('TC-08: expected E_USER_WARNING on unknown component');
+		} catch (ErrorException $ex) {
+			if (!str_contains($ex->getMessage(), 'Unknown money component')) {
+				throw new Exception('TC-08: wrong warning message: '. $ex->getMessage());
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		########################################################################
+		## TC-09: __toString() falls through to type_money's format()
+		########################################################################
+
+		$amount = new type_taxable_amount(100, $store_currency, 1);
+		$rendered = (string)$amount;
+
+		if ($rendered === '') {
+			throw new Exception('TC-09: __toString() should not yield empty string');
+		}
+
+		if (strpos($rendered, '100') === false && strpos($rendered, '100.00') === false) {
+			throw new Exception('TC-09: __toString() should reflect the net amount (got "'. $rendered .'")');
+		}
+
+		########################################################################
+		## TC-10: Fixed-amounts-per-currency mode round-trips with tax_class_id
+		########################################################################
+
+		$amount = new type_taxable_amount([$store_currency => 100, 'EUR' => 92], null, 5);
+
+		if ($amount->tax_class_id !== 5) {
+			throw new Exception('TC-10: tax_class_id not preserved in fixed-map mode');
+		}
+
+		if ($amount->in('EUR') !== 92.0) {
+			throw new Exception('TC-10: fixed EUR amount lost (got '. $amount->in('EUR') .')');
+		}
+
+		$serialized = json_encode($amount);
+		$rebuilt = new type_taxable_amount(json_decode($serialized, true));
+
+		if ($rebuilt->tax_class_id !== 5 || $rebuilt->in('EUR') !== 92.0) {
+			throw new Exception('TC-10: round-trip lost data in fixed-map mode');
+		}
+
+		return true;
+
+	} catch (Exception $e) {
+
+		echo ' [Failed]'. PHP_EOL . 'Error: '. $e->getMessage();
+		return false;
+
+	} finally {
+		// No DB writes — no rollback needed
+	}


### PR DESCRIPTION
Closes #541.

The third value-object @timint sketched out in #520 — `taxable_amount(100, $tax_class_id, $currency)`. Composes naturally on top of `type_money` so the dual-mode money handling, JSON serialization and immutability come for free; this class just adds `net`/`gross`/`tax`/`tax_rate`/`tax_class_id` accessors that delegate to the existing `tax::` node.

## How it looks

```php
$amount = new type_taxable_amount(100, 'USD', $tax_class_id);

$amount->net;       // 100
$amount->gross;     // 100 + tax via tax::get_price()
$amount->tax;       // tax via tax::get_tax()
$amount->tax_rate;  // average of tax::get_rates()
echo $amount;       // formatted in $amount->currency_code
```

Customer context defaults to the active customer (the `'customer'` preset in `tax::get_rates()`). For region-specific resolution there are `gross_for($customer)` and `tax_for($customer)` variants that take a customer array (or preset string).

## Shape

| Aspect | Behaviour |
|--------|-----------|
| Inherits from `type_money` | dual-mode (single-amount + currency vs. fixed-amounts-per-currency map) |
| Constructor signature | `($input, ?string $currency_code = null, $tax_class_id = null)` |
| `$input` accepts | `type_taxable_amount` (copy), `type_money` (lift), array (jsonSerialize round-trip), float, int, string |
| `jsonSerialize()` | merges parent's `{amounts, mode, origin_currency}` with `tax_class_id` |
| `tax_class_id === null` | behaves like a plain `type_money` — gross == net, tax = 0 |

## Tests

`tests/type_taxable_amount.php` — 10 TCs covering construction shapes, null-tax-class fast-path, JSON round-trip, copy constructor, type_money lift, customer-aware variants, unknown-component warning passthrough, `__toString` inheritance, fixed-map mode preservation.

## Out of scope (separate PRs)

- Migrating call sites in `ent_order`, `ent_cart`, `ent_product` to use `type_taxable_amount`. Today the codebase carries `(price, tax, tax_rate, tax_class_id)` quartets by hand in entity arrays — one or two of those is the natural next step but doesn't belong in this landing.
- Form helper adoption (`form_input_taxable_amount`?) — separate question.

## Test plan

- [x] `php -l` clean on both touched files
- [ ] CI green
- [x] All 10 TCs in `tests/type_taxable_amount.php` exercise the constructor matrix + jsonSerialize round-trip + null-tax-class behaviour