### PR TITLE
[v3] Fix CI: install + platform-tests need build job in needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
   install:
     name: Install Application
     runs-on: ubuntu-latest
-    needs: [check]
+    needs: [check, build]
     strategy:
       fail-fast: false
       matrix:
@@ -149,7 +149,7 @@ jobs:
   platform-tests:
     name: Platform Tests
     runs-on: ubuntu-latest
-    needs: [check, install]
+    needs: [check, build, install]
 
     services:
       mariadb:


### PR DESCRIPTION
Both `install` and `platform-tests` use `actions/download-artifact@v8 name: built-assets`, but neither declares `build` in `needs:`. They've been getting away with it because `build` usually finishes first — until now. On #542 the `install` matrix started before `build` published the artifact, the download step failed, `Run installer via CLI` was skipped (taking the whole job to red), and `platform-tests` then skipped because `install` didn't succeed.

`e2e-tests` already has the correct `needs: [check, build, install]` — this brings `install` and `platform-tests` in line.

## What changes

| Job | Was | Now |
|-----|-----|-----|
| `install` | `needs: [check]` | `needs: [check, build]` |
| `platform-tests` | `needs: [check, install]` | `needs: [check, build, install]` |

## Test plan

- [x] Diff inspected against existing `e2e-tests` declaration (consistent)
- [ ] CI of this PR: install + platform-tests now wait on build, no more skipped artifact downloads
- [ ] PR #542 re-runs green once this lands