### PR TITLE
[v3] + Fix #544 - Detect truncated POST and show actionable warning

### DIFF
--- a/public_html/includes/app_header.inc.php
+++ b/public_html/includes/app_header.inc.php
@@ -84,6 +84,15 @@
 		}
 	}
 
+	// Detect truncated POST (PHP max_input_vars exceeded)
+	if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
+		$max_input_vars = (int)ini_get('max_input_vars');
+		$received_vars = count($_POST, COUNT_RECURSIVE) + count($_FILES, COUNT_RECURSIVE);
+		if ($max_input_vars > 0 && $received_vars >= $max_input_vars) {
+			notices::add('errors', strtr(t('error_post_truncated', 'The submitted form has too many fields for the server (received :received fields, server limit :limit). Some data was not saved. Ask your hoster to increase the PHP setting max_input_vars in php.ini, .htaccess (Apache), or .user.ini.'), [':received' => $received_vars, ':limit' => $max_input_vars]));
+		}
+	}
+
 	// Run operations before capture
 	event::fire('before_capture');
 


### PR DESCRIPTION
v3 counterpart to #545. Root cause and approach discussion in #544.

## Summary

| Before | After |
|---|---|
| `Warning: Undefined array key "en" in admin-catalog.app-edit_product.inc.php` | `The submitted form has too many fields for the server (received 1000 fields, server limit 1000). Some data was not saved. Ask your hoster to increase the PHP setting max_input_vars in php.ini, .htaccess (Apache), or .user.ini.` |

## Detection

```
count($_POST, COUNT_RECURSIVE) + count($_FILES, COUNT_RECURSIVE)  >=  ini_get('max_input_vars')
```

Reaching the limit means the parser has stopped — at the boundary the user is at best one field away from data loss, so warning there too is the right call. For multipart forms (product, account, etc.) this is the only reliable detection — `php://input` is consumed.

## Placement

Right before `event::fire('before_capture')` in `app_header.inc.php`. Autoloader is up by then, so `notices` and `t()` are both safe to use. CLI guard added.

## Test plan

- [ ] Set `max_input_vars = 100` in php.ini, restart Apache / PHP-FPM
- [ ] Edit any product, save → notice shown with received/limit counts, no PHP warning
- [ ] GET request → no notice (guard works)
- [ ] Small POST below the limit → no notice (no false positive)
- [ ] CLI script → no notice (REQUEST_METHOD guard works)