### PR TITLE
[v3] + Color installer CLI output with ANSI escapes

### DIFF
--- a/public_html/install/includes/functions.inc.php
+++ b/public_html/install/includes/functions.inc.php
@@ -22,6 +22,28 @@
 		csp_send_headers();
 	}
 
+	/*
+		Format installer HTML output for CLI consumption. Status spans
+		(<span class="ok|warning|error">) are converted to ANSI color
+		escapes when STDOUT is a terminal; remaining tags are stripped.
+		Non-TTY destinations (pipes, file redirects, CI logs without
+		color support) get plain stripped text so log files stay clean.
+	*/
+	function install_cli_format($html) {
+		static $is_tty = null;
+		if ($is_tty === null) {
+			$is_tty = function_exists('stream_isatty') && defined('STDOUT') && @stream_isatty(STDOUT);
+		}
+
+		if ($is_tty) {
+			$html = preg_replace('#<span class="ok">([^<]*)</span>#', "\033[32m$1\033[0m", $html);
+			$html = preg_replace('#<span class="warning">([^<]*)</span>#', "\033[33m$1\033[0m", $html);
+			$html = preg_replace('#<span class="error">([^<]*)</span>#', "\033[31m$1\033[0m", $html);
+		}
+
+		return strip_tags($html);
+	}
+
 	function csp_send_headers() {
 
 		header('Content-Security-Policy: ' . implode('; ', [

--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -138,7 +138,7 @@
 
 		register_shutdown_function(function(){
 			$buffer = ob_get_clean();
-			echo ($_SERVER['SERVER_SOFTWARE'] == 'CLI') ? strip_tags($buffer) : $buffer;
+			echo install_is_cli() ? install_cli_format($buffer) : $buffer;
 		});
 
 		echo '<h1>LiteCart Installer</h1>' . PHP_EOL . PHP_EOL;

--- a/public_html/install/upgrade.php
+++ b/public_html/install/upgrade.php
@@ -179,8 +179,8 @@
 
 		ob_start(function($buffer) {
 
-			if ($_SERVER['SERVER_SOFTWARE'] == 'CLI') {
-				$buffer = strip_tags($buffer);
+			if (install_is_cli()) {
+				$buffer = install_cli_format($buffer);
 			}
 
 			return $buffer;


### PR DESCRIPTION
First piece of the CLI polish you sketched in #524 — small enough to land on its own. Picking up the ANSI side of things; the progress bar from `draw_progress_bar()` is the natural next step but kept separate so this one stays trivial to review.

## Summary

| Before | After |
|---|---|
| `PHP version 8.4 [OK] (no color)` | `PHP version 8.4 ` + `[OK]` in green |
| `Migration [Skipped]` | `Migration ` + `[Skipped]` in yellow |
| `[Failed] Could not write config` | `[Failed]` in red + ` Could not write config` |

## How

New helper `install_cli_format($html)` in `install/includes/functions.inc.php`:

```php
function install_cli_format($html) {
    static $is_tty = null;
    if ($is_tty === null) {
        $is_tty = function_exists('stream_isatty') && defined('STDOUT') && @stream_isatty(STDOUT);
    }

    if ($is_tty) {
        $html = preg_replace('#<span class="ok">([^<]*)</span>#', "\033[32m$1\033[0m", $html);
        $html = preg_replace('#<span class="warning">([^<]*)</span>#', "\033[33m$1\033[0m", $html);
        $html = preg_replace('#<span class="error">([^<]*)</span>#', "\033[31m$1\033[0m", $html);
    }

    return strip_tags($html);
}
```

`install.php` shutdown handler and `upgrade.php` output buffer now call this instead of raw `strip_tags()`. The TTY guard is static-cached, so the check runs once per request.

## Behavior matrix

| Context | Output |
|---|---|
| Interactive terminal | colored `[OK]` / `[Warning]` / `[Error]` |
| Pipe / file redirect (`> install.log`) | plain stripped text — no escape soup in logs |
| CI runner without TTY | plain stripped text |
| Web (browser) | unchanged — `install_is_cli()` guard skips formatter |

## Test plan

- [ ] `php install/install.php --db_server=... --username=admin ...` in a real terminal → status tags rendered with color
- [ ] `php install/install.php ... > install.log` → log file contains only plain text, no `\e[32m` sequences
- [ ] CI install job (no TTY) → output unchanged from before
- [ ] Web installer → output unchanged (no `install_cli_format` reached)
- [ ] `upgrade.php` CLI run → same color treatment

## Out of scope (follow-up)

- Progress bar via `draw_progress_bar()` in 080-write-database (table iteration) and 100-copy-regional-data (CSV import)
- Step headers in CLI output ("═══ Step 030: Check PHP ═══")
- Dead-code block at `install.php:110-114` (`'cli'` lowercase guard with stray `exit;`) — separate tidy-up if you want it