### PR TITLE
[v3] + Fix #548 - Tolerate missing settings table on installer connect (Option A)

### DIFF
--- a/public_html/includes/nodes/nod_database.inc.php
+++ b/public_html/includes/nodes/nod_database.inc.php
@@ -76,17 +76,26 @@
 			// Set default storage engine
 			self::query("SET SESSION default_storage_engine = InnoDB;", $link);
 
-			// Set time zone for current session
+			// Set time zone for current session. The settings table may not
+			// exist yet (installer runs connect() before step 080 creates
+			// tables); silently fall through in that case so install/upgrade
+			// can proceed and reach the schema build step.
 			if (defined('DB_TABLE_PREFIX')) {
-				$timezone = database::query(
-					"SELECT `value` FROM ". DB_TABLE_PREFIX ."settings
-					WHERE `key` = 'store_timezone'
-					LIMIT 1;", 'default'
-				)->fetch('value');
+				try {
+					$timezone = database::query(
+						"SELECT `value` FROM ". DB_TABLE_PREFIX ."settings
+						WHERE `key` = 'store_timezone'
+						LIMIT 1;", 'default'
+					)->fetch('value');
 
-				if ($timezone) {
-					$datetime = new \DateTime('now', new \DateTimezone($timezone));
-					self::query("SET time_zone = '". database::input($datetime->format('P')) ."';", $link);
+					if ($timezone) {
+						$datetime = new \DateTime('now', new \DateTimezone($timezone));
+						self::query("SET time_zone = '". database::input($datetime->format('P')) ."';", $link);
+					}
+				} catch (\Throwable $t) {
+					if (mysqli_errno(self::$links[$link]) !== 1146) {
+						throw $t;
+					}
 				}
 			}
 

--- a/public_html/install/install.php
+++ b/public_html/install/install.php
@@ -182,6 +182,10 @@
 			'[ABORTED] ' . $t->getMessage(),
 			'',
 		]);
+		// Surface the failure to the caller (CI, shell) so silent aborts
+		// stop being mistaken for success. The shutdown handler still
+		// runs and flushes the captured buffer before the process ends.
+		exit(1);
 	}
 
 	if (!empty($_REQUEST['redirect'])) {

--- a/public_html/install/upgrade.php
+++ b/public_html/install/upgrade.php
@@ -904,6 +904,12 @@
 				'<p>Error: '. htmlspecialchars($t->getMessage()) .'</p>',
 				'',
 			]);
+
+			// Surface the failure to the caller (CI, shell) so silent
+			// aborts stop being mistaken for success. ob_get_clean() runs
+			// the buffer callback (strip_tags for CLI) before we exit.
+			echo ob_get_clean();
+			exit(1);
 		}
 
 		echo ob_get_clean();


### PR DESCRIPTION
Draft. Putting Option A from #548 up so you can see the actual diff; not pushing for merge until you've picked the variant you want.

## What

`nod_database::connect()` runs a `SELECT` against `lc_settings` to read `store_timezone`. During install, step 060 (check-database) calls `connect()` long before step 080 has created any tables — the query throws `1146 Table doesn't exist`, the outer try/catch in `install.php` prints `[ABORTED]`, and the process exits 0. CI thinks the install succeeded; `e2e-tests` then runs against an empty DB and `/admin/` redirects forever. Full root-cause walk-through in #548.

## Changes

| File | Change |
|---|---|
| `public_html/includes/nodes/nod_database.inc.php` | Wrap the `store_timezone` lookup in `try/catch`. Only `mysqli_errno() === 1146` is swallowed (table doesn't exist yet); every other error rethrows. |
| `public_html/install/install.php` | `exit(1)` from the abort catch so silent failures stop being mistaken for success. |
| `public_html/install/upgrade.php` | Same `exit(1)` in the upgrade's abort branch — symmetric pattern, prevents the same silent-fail trap there. |

## Variant notes (in case you prefer B or C)

- **B** (INFORMATION_SCHEMA probe before the query): straightforward to swap in — replace the try/catch with a `SELECT 1 FROM information_schema.tables ...` guard. Costs one extra query per `connect()`.
- **C** (move the `store_timezone` lookup out of `connect()` into `nod_settings` init or a one-time call): bigger surface, better separation of concerns. Happy to redo as a separate PR if you'd rather.

Your call — I'll convert this from draft once you've picked.

## Test plan

- [ ] `php public_html/install/install.php --db_server=... --db_database=... ...` against a fresh, empty DB → completes through step 140, writes `install.lock`, exits 0
- [ ] Re-run installer on an existing install → still hits `install_reject_locked()` (no behavior change)
- [ ] Inject a forced 1064 error inside the connect-time query → propagates, exit 1 (proves we're only swallowing 1146)
- [ ] CI `e2e-tests` job → installer step actually completes, `/admin/` reachable
- [ ] CI install step → if the installer aborts now, exit code is 1 (no more green-on-fail)