### PR TITLE
Fix path to config directory in write-config script

### DIFF
--- a/public_html/install/includes/steps/070-write-config.inc.php
+++ b/public_html/install/includes/steps/070-write-config.inc.php
@@ -6,7 +6,7 @@
 
 	// AC-3, AC-4: values are serialised through var_export() via
 	// install_render_config(), which also validates client_ip.
-	$config = install_render_config(__DIR__ . '/config', [
+	$config = install_render_config(dirname(__DIR__, 2) . '/config', [
 		'STORAGE_FOLDER'        => 'storage',
 		'ADMIN_FOLDER'          => BACKEND_ALIAS,
 		'DB_SERVER'             => DB_SERVER,


### PR DESCRIPTION
This caused installation to fail:

⚠️ Warning:  file_get_contents(steps/config): Failed to open stream: No such file or directory  in app://install/includes/config_writer.inc.php on line 56