### PR TITLE
Fix FS_DIR_ADMIN path by adding missing slash

### DIFF
--- a/public_html/install/config
+++ b/public_html/install/config
@@ -10,7 +10,7 @@
 	define('DOCUMENT_ROOT',      rtrim(str_replace('\\', '/', realpath(!empty($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : __DIR__.'/..')), '/'));
 
 	define('FS_DIR_APP',         rtrim(str_replace('\\', '/', realpath(__DIR__.'/..')), '/') . '/');
-	define('FS_DIR_ADMIN',       FS_DIR_APP . 'backend/');
+	define('FS_DIR_ADMIN',       FS_DIR_APP . 'backend' . '/');
 	define('FS_DIR_STORAGE',     FS_DIR_APP . '{STORAGE_FOLDER}' . '/');
 
 	// Web System


### PR DESCRIPTION
To make FS_DIR_ADMIN path consistent with the others.