### PR TITLE
Add paths for litecore CSS and SCSS files

### DIFF
--- a/public_html/install/includes/steps/120-development-type.inc.php
+++ b/public_html/install/includes/steps/120-development-type.inc.php
@@ -30,6 +30,9 @@
 				FS_DIR_APP . 'frontend/templates/*/css/*.min.css',
 				FS_DIR_APP . 'frontend/templates/*/css/*.min.css.map',
 				FS_DIR_APP . 'frontend/templates/*/scss/',
+				FS_DIR_APP . 'assets/litecore/css/*.min.css',
+				FS_DIR_APP . 'assets/litecore/css/*.min.css.map',
+				FS_DIR_APP . 'assets/litecore/scss/',
 			]);
 
 			perform_action('modify', [


### PR DESCRIPTION
Nice to see this addition!

Why is there a litecore directory here?  Aren't those files already in LiteCart?